### PR TITLE
Feature/dm disable free run

### DIFF
--- a/PepperDashEssentials/Bridges/DmTxControllerBridge.cs
+++ b/PepperDashEssentials/Bridges/DmTxControllerBridge.cs
@@ -57,7 +57,7 @@ namespace PepperDash.Essentials.Bridges
 
                 trilist.UShortInput[joinMap.HdcpSupportCapability].UShortValue = (ushort)tx.HdcpSupportCapability;
 
-                if(txR.InputPorts[DmPortName.HdmiIn] != null)
+                if (txR.InputPorts[DmPortName.HdmiIn] != null)
                 {
                     var inputPort = txR.InputPorts[DmPortName.HdmiIn];
 
@@ -71,7 +71,7 @@ namespace PepperDash.Essentials.Bridges
                         SetHdcpCapabilityAction(hdcpTypeSimple, port, joinMap.Port1HdcpState, trilist);
                     }
                 }
-                
+
                 if (txR.InputPorts[DmPortName.HdmiIn1] != null)
                 {
                     var inputPort = txR.InputPorts[DmPortName.HdmiIn1];
@@ -102,6 +102,22 @@ namespace PepperDash.Essentials.Bridges
                     }
                 }
 
+            }
+
+            var txFreeRun = tx as IHasFreeRun;
+            if (txFreeRun != null)
+            {
+                txFreeRun.FreeRunEnabledFeedback.LinkInputSig(trilist.BooleanInput[joinMap.FreeRunEnabled]);
+                trilist.SetBoolSigAction(joinMap.FreeRunEnabled, new Action<bool>(b => txFreeRun.SetFreeRunEnabled(b)));
+            }
+
+            var txVga = tx as IVgaBrightnessContrastControls;
+            {
+                txVga.VgaBrightnessFeedback.LinkInputSig(trilist.UShortInput[joinMap.VgaBrightness]);
+                txVga.VgaContrastFeedback.LinkInputSig(trilist.UShortInput[joinMap.VgaContrast]);
+
+                trilist.SetUShortSigAction(joinMap.VgaBrightness, new Action<ushort>(u => txVga.SetVgaBrightness(u)));
+                trilist.SetUShortSigAction(joinMap.VgaContrast, new Action<ushort>(u => txVga.SetVgaContrast(u)));
             }
         }
 

--- a/PepperDashEssentials/Bridges/JoinMaps/DmTxControllerJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/DmTxControllerJoinMap.cs
@@ -18,6 +18,10 @@ namespace PepperDash.Essentials.Bridges
         /// High when video sync is detected
         /// </summary>
         public uint VideoSyncStatus { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public uint FreeRunEnabled { get; set; }
         #endregion
 
         #region Analogs
@@ -41,6 +45,16 @@ namespace PepperDash.Essentials.Bridges
         /// Sets and reports the current HDCP state for the corresponding input port
         /// </summary>
         public uint Port2HdcpState { get; set; }
+
+        /// <summary>
+        /// Sets and reports the current VGA Brightness level
+        /// </summary>
+        public uint VgaBrightness { get; set; }
+
+        /// <summary>
+        /// Sets and reports the current VGA Contrast level
+        /// </summary>
+        public uint VgaContrast { get; set; }
         #endregion
 
         #region Serials
@@ -56,6 +70,7 @@ namespace PepperDash.Essentials.Bridges
             // Digital
             IsOnline = 1;
             VideoSyncStatus = 2;
+            FreeRunEnabled = 3;
             // Serial
             CurrentInputResolution = 1;
             // Analog
@@ -64,6 +79,8 @@ namespace PepperDash.Essentials.Bridges
             HdcpSupportCapability = 3;
             Port1HdcpState = 4;
             Port2HdcpState = 5;
+            VgaBrightness = 6;
+            VgaContrast = 7;
         }
 
         public override void OffsetJoinNumbers(uint joinStart)
@@ -72,12 +89,15 @@ namespace PepperDash.Essentials.Bridges
 
             IsOnline = IsOnline + joinOffset;
             VideoSyncStatus = VideoSyncStatus + joinOffset;
+            FreeRunEnabled = FreeRunEnabled + joinOffset;
             CurrentInputResolution = CurrentInputResolution + joinOffset;
             VideoInput = VideoInput + joinOffset;
             AudioInput = AudioInput + joinOffset;
             HdcpSupportCapability = HdcpSupportCapability + joinOffset;
             Port1HdcpState = Port1HdcpState + joinOffset;
             Port2HdcpState = Port2HdcpState + joinOffset;
+            VgaBrightness = VgaBrightness + joinOffset;
+            VgaContrast = VgaContrast + joinOffset;
         }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Timers/CountdownTimer.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Timers/CountdownTimer.cs
@@ -23,6 +23,10 @@ namespace PepperDash.Essentials.Core
         public StringFeedback TimeRemainingFeedback { get; private set; }
 
         public bool CountsDown { get; set; }
+
+        /// <summary>
+        /// The number of seconds to countdown
+        /// </summary>
         public int SecondsToCount { get; set; }
         
         public DateTime StartTime { get; private set; }
@@ -31,7 +35,7 @@ namespace PepperDash.Essentials.Core
         CTimer SecondTimer;
 
         /// <summary>
-        /// 
+        /// Constructor
         /// </summary>
         /// <param name="key"></param>
         public SecondsCountdownTimer(string key)
@@ -61,7 +65,7 @@ namespace PepperDash.Essentials.Core
         }
 
         /// <summary>
-        /// 
+        /// Starts the Timer
         /// </summary>
         public void Start()
         {
@@ -82,7 +86,7 @@ namespace PepperDash.Essentials.Core
         }
 
         /// <summary>
-        /// 
+        /// Restarts the timer
         /// </summary>
         public void Reset()
         {
@@ -91,7 +95,7 @@ namespace PepperDash.Essentials.Core
         }
 
         /// <summary>
-        /// 
+        /// Cancels the timer (without triggering it to finish)
         /// </summary>
         public void Cancel()
         {

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
@@ -19,7 +19,7 @@ namespace PepperDash.Essentials.DM
     /// <summary>
     /// Controller class for all DM-TX-201C/S/F transmitters
     /// </summary>
-    public class DmTx201XController : DmTxControllerBase, ITxRouting, IHasFeedback, IHasFreeRun
+    public class DmTx201XController : DmTxControllerBase, ITxRouting, IHasFeedback, IHasFreeRun, IVgaBrightnessContrastControls
 	{
 		public DmTx201S Tx { get; private set; } // uses the 201S class as it is the base class for the 201C
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
@@ -234,11 +234,19 @@ namespace PepperDash.Essentials.DM
             }
         }
 
+        /// <summary>
+        /// Sets the VGA brightness level
+        /// </summary>
+        /// <param name="level"></param>
         public void SetVgaBrightness(ushort level)
         {
             Tx.VgaInput.VideoControls.Brightness.UShortValue = level;
         }
 
+        /// <summary>
+        /// Sets the VGA contrast level
+        /// </summary>
+        /// <param name="level"></param>
         public void SetVgaContrast(ushort level)
         {
             Tx.VgaInput.VideoControls.Contrast.UShortValue = level;

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/IFreeRunEnabled.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/IFreeRunEnabled.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crestron.SimplSharp;
+
+using PepperDash.Essentials.Core;
+
+namespace PepperDash.Essentials.DM
+{
+    /// <summary>
+    /// Defines a device capable of setting the Free Run state of a VGA input and reporting feedback
+    /// </summary>
+    public interface IHasFreeRun
+    {
+        BoolFeedback FreeRunEnabledFeedback { get; }
+
+        void SetFreeRunEnabled(bool enable);
+    }
+}

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/TxInterfaces.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/TxInterfaces.cs
@@ -17,4 +17,16 @@ namespace PepperDash.Essentials.DM
 
         void SetFreeRunEnabled(bool enable);
     }
+
+    /// <summary>
+    /// Defines a device capable of adjusting VGA settings
+    /// </summary>
+    public interface IVgaBrightnessContrastControls
+    {
+        IntFeedback VgaBrightnessFeedback { get; }
+        IntFeedback VgaContrastFeedback { get; }
+
+        void SetVgaBrightness(ushort level);
+        void SetVgaContrast(ushort level);
+    }
 }

--- a/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
+++ b/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Chassis\DmpsInternalVirtualDmTxController.cs" />
     <Compile Include="Chassis\DmpsRoutingController.cs" />
     <Compile Include="Chassis\HdMdNxM4kEController.cs" />
+    <Compile Include="Endpoints\Transmitters\IFreeRunEnabled.cs" />
     <Compile Include="IDmSwitch.cs" />
     <Compile Include="Config\DmpsRoutingConfig.cs" />
     <Compile Include="Config\DmRmcConfig.cs" />

--- a/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
+++ b/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
@@ -96,7 +96,7 @@
     <Compile Include="Chassis\DmpsInternalVirtualDmTxController.cs" />
     <Compile Include="Chassis\DmpsRoutingController.cs" />
     <Compile Include="Chassis\HdMdNxM4kEController.cs" />
-    <Compile Include="Endpoints\Transmitters\IFreeRunEnabled.cs" />
+    <Compile Include="Endpoints\Transmitters\TxInterfaces.cs" />
     <Compile Include="IDmSwitch.cs" />
     <Compile Include="Config\DmpsRoutingConfig.cs" />
     <Compile Include="Config\DmRmcConfig.cs" />


### PR DESCRIPTION
Closes #34 
Closes #35

Adds support for enabling/disabling Free Run as well as setting brightness/contrast on VGA inputs of DM-TX-201-C and adds necessary interfaces to define TX devices that are compatible.  

Adds updates to generic DmTxControllerBridge and associated join map as well.

Once tested on DM-TX-201-C the interfaces can be implemented on all other affected Tx classes.