### PR TITLE
Feature/update systemmonitorcontroller

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,8 +147,8 @@ jobs:
       # Copy Contents of output folder to root directory
       - name: Copy Files to root & delete output directory
         run: |
-          Remove-Item -Path .\ -Include @("*.cpz", "*.dll", "*.cplz", "*.clz", "*.xml", "*.md")
-          Get-ChildItem -Path .\output\*.* | Copy-Item -DestinationPath .\
+          Remove-Item -Path .\* -Include @("*.cpz","*.md","*.cplz","*.json","*.dll","*.clz")
+          Get-ChildItem -Path .\output\* | Copy-Item -DestinationPath .\
           Remove-Item -Path .\output -Recurse
       # Commits the build output to the branch and tags it with the version
       - name: Commit build output and tag the commit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,7 +147,7 @@ jobs:
       # Copy Contents of output folder to root directory
       - name: Copy Files to root & delete output directory
         run: |
-          Remove-Item -Path .\*.*
+          Remove-Item -Path .\ -Include @("*.cpz", "*.dll", "*.cplz", "*.clz", "*.xml", "*.md")
           Get-ChildItem -Path .\output\*.* | Copy-Item -DestinationPath .\
           Remove-Item -Path .\output -Recurse
       # Commits the build output to the branch and tags it with the version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,8 +147,8 @@ jobs:
       # Copy Contents of output folder to root directory
       - name: Copy Files to root & delete output directory
         run: |
-          Remove-Item -Path .\* -Include @("*.cpz","*.md","*.cplz","*.json","*.dll","*.clz")
-          Get-ChildItem -Path .\output\* | Copy-Item -DestinationPath .\
+          Remove-Item -Path .\* -Include @("*.cpz","*.md","*.cplz","*.json","*.dll","*.clz")  
+          Get-ChildItem -Path .\output\* | Copy-Item -Destination .\
           Remove-Item -Path .\output -Recurse
       # Commits the build output to the branch and tags it with the version
       - name: Commit build output and tag the commit

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -144,6 +144,12 @@ jobs:
           Remove-Item -Path .\*.zip
       - name: Check directory again
         run: Get-ChildItem ./
+      # Copy Contents of output folder to root directory
+      - name: Copy Files to root & delete output directory
+        run: |
+          Remove-Item -Path .\*.*
+          Get-ChildItem -Path .\output\*.* | Copy-Item -DestinationPath .\
+          Remove-Item -Path .\output -Recurse
       # Commits the build output to the branch and tags it with the version
       - name: Commit build output and tag the commit
         shell: powershell

--- a/PepperDashEssentials/AppServer/Messengers/SystemMonitorMessenger.cs
+++ b/PepperDashEssentials/AppServer/Messengers/SystemMonitorMessenger.cs
@@ -1,11 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Crestron.SimplSharp;
-
-using Newtonsoft.Json;
-
 using PepperDash.Core;
 using PepperDash.Essentials.Core.Monitoring;
 
@@ -23,11 +17,11 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
             SysMon = sysMon;
 
-            SysMon.SystemMonitorPropertiesChanged += new EventHandler<EventArgs>(SysMon_SystemMonitorPropertiesChanged);
+            SysMon.SystemMonitorPropertiesChanged += SysMon_SystemMonitorPropertiesChanged;
 
             foreach (var p in SysMon.ProgramStatusFeedbackCollection)
             {
-                p.Value.ProgramInfoChanged += new EventHandler<ProgramInfoEventArgs>(ProgramInfoChanged);
+                p.Value.ProgramInfoChanged += ProgramInfoChanged;
             }
 
             CrestronConsole.AddNewConsoleCommand(s => SendFullStatusMessage(), "SendFullSysMonStatus", "Sends the full System Monitor Status", ConsoleAccessLevelEnum.AccessOperator);
@@ -72,18 +66,15 @@ namespace PepperDash.Essentials.AppServer.Messengers
             Debug.Console(1, "Posting System Monitor Status Message.");
 
             // This takes a while, launch a new thread
-            CrestronInvoke.BeginInvoke((o) =>
+            CrestronInvoke.BeginInvoke(o => PostStatusMessage(new
             {
-                PostStatusMessage(new
-                {
-                    timeZone = SysMon.TimeZoneFeedback.IntValue,
-                    timeZoneName = SysMon.TimeZoneTextFeedback.StringValue,
-                    ioControllerVersion = SysMon.IOControllerVersionFeedback.StringValue,
-                    snmpVersion = SysMon.SnmpVersionFeedback.StringValue,
-                    bacnetVersion = SysMon.BACnetAppVersionFeedback.StringValue,
-                    controllerVersion = SysMon.ControllerVersionFeedback.StringValue
-                });
-            });
+                timeZone = SysMon.TimeZoneFeedback.IntValue,
+                timeZoneName = SysMon.TimeZoneTextFeedback.StringValue,
+                ioControllerVersion = SysMon.IoControllerVersionFeedback.StringValue,
+                snmpVersion = SysMon.SnmpVersionFeedback.StringValue,
+                bacnetVersion = SysMon.BaCnetAppVersionFeedback.StringValue,
+                controllerVersion = SysMon.ControllerVersionFeedback.StringValue
+            }));
         }
 
         protected override void CustomRegisterWithAppServer(MobileControlSystemController appServerController)

--- a/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Crestron.SimplSharp;
-using PepperDash.Essentials.Core;
+﻿using PepperDash.Essentials.Core;
 
 namespace PepperDash.Essentials.Bridges
 {

--- a/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
@@ -144,6 +144,16 @@ namespace PepperDash.Essentials.Bridges
         /// Reports the DHCP Status of the corresponding interface
         /// </summary>
         public uint DhcpStatus { get; set; }
+
+        /// <summary>
+        /// Reports the current uptime. Updated in 5 minute intervals.
+        /// </summary>
+        public uint Uptime { get; set; }
+
+        /// <summary>
+        /// Reports the date of the last boot
+        /// </summary>
+        public uint LastBoot { get; set; }
         #endregion
 
         public SystemMonitorJoinMap()
@@ -157,6 +167,8 @@ namespace PepperDash.Essentials.Bridges
             ControllerVersion = 5;
             SerialNumber = 6;
             Model = 7;
+            Uptime = 8;
+            LastBoot = 9;
 
 
             ProgramStartJoin = 10;
@@ -179,6 +191,7 @@ namespace PepperDash.Essentials.Bridges
 
             EthernetOffsetJoin = 15;
 
+            // Offset in groups of 15
             HostName = 1;
             CurrentIpAddress = 2;
             CurrentSubnetMask = 3;

--- a/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
@@ -187,7 +187,7 @@ namespace PepperDash.Essentials.Bridges
             ProgramEnvironmentVersion = 4;
             AggregatedProgramInfo = 5;
 
-            EthernetStartJoin = 60;
+            EthernetStartJoin = 75;
 
             EthernetOffsetJoin = 15;
 

--- a/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/SystemMonitorJoinMap.cs
@@ -10,9 +10,19 @@ namespace PepperDash.Essentials.Bridges
         public uint ProgramStartJoin { get; set; }
 
         /// <summary>
+        /// Offset to indicate where the range of iterated Ethernet joins will start
+        /// </summary>
+        public uint EthernetStartJoin { get; set; }
+
+        /// <summary>
         /// Offset between each program join set
         /// </summary>
         public uint ProgramOffsetJoin { get; set; }
+
+        /// <summary>
+        /// Offset between each Ethernet Interface join set
+        /// </summary>
+        public uint EthernetOffsetJoin { get; set; }
 
         #region Digitals
         /// <summary>
@@ -82,6 +92,58 @@ namespace PepperDash.Essentials.Bridges
         /// Serialized JSON output that aggregates the program info of the corresponding program
         /// </summary>
         public uint AggregatedProgramInfo { get; set; }
+        /// <summary>
+        /// Reports the controller serial number
+        /// </summary>
+        public uint SerialNumber { get; set; }
+        /// <summary>
+        /// Reports the controller model
+        /// </summary>
+        public uint Model { get; set; }
+        /// <summary>
+        /// Reports the Host name set on the corresponding interface
+        /// </summary>
+        public uint HostName { get; set; }
+        /// <summary>
+        /// Reports the Current IP address set on the corresponding interface. If DHCP is enabled, this will be the DHCP assigned address.
+        /// </summary>
+        public uint CurrentIpAddress { get; set; }
+        /// <summary>
+        /// Reporst the Current Default Gateway set on the corresponding interface. If DHCP is enabled, this will be the DHCP assigned gateway
+        /// </summary>
+        public uint CurrentDefaultGateway { get; set; }
+        /// <summary>
+        /// Reports the Current Subnet Mask set on the corresponding interface. If DHCP is enabled, this will be the DHCP assigned subnet mask
+        /// </summary>
+        public uint CurrentSubnetMask { get; set; }
+        /// <summary>
+        /// Reports the Static IP address set on the corresponding interface. If DHCP is disabled, this will match the Current IP address
+        /// </summary>
+        public uint StaticIpAddress { get; set; }
+        /// <summary>
+        /// Reporst the Static Default Gateway set on the corresponding interface. If DHCP is disabled, this will match the Current gateway
+        /// </summary>
+        public uint StaticDefaultGateway { get; set; }
+        /// <summary>
+        /// Reports the Current Subnet Mask set on the corresponding interface. If DHCP is enabled, this will be the DHCP assigned subnet mask
+        /// </summary>
+        public uint StaticSubnetMask { get; set; }
+        /// <summary>
+        /// Reports the current DomainFeedback on the corresponding interface
+        /// </summary>
+        public uint Domain { get; set; }
+        /// <summary>
+        /// Reports the current DNS Servers on the corresponding interface
+        /// </summary>
+        public uint DnsServer { get; set; }
+        /// <summary>
+        /// Reports the MAC Address of the corresponding interface
+        /// </summary>
+        public uint MacAddress { get; set; }
+        /// <summary>
+        /// Reports the DHCP Status of the corresponding interface
+        /// </summary>
+        public uint DhcpStatus { get; set; }
         #endregion
 
         public SystemMonitorJoinMap()
@@ -93,6 +155,8 @@ namespace PepperDash.Essentials.Bridges
             SnmpAppVersion = 3;
             BACnetAppVersion = 4;
             ControllerVersion = 5;
+            SerialNumber = 6;
+            Model = 7;
 
 
             ProgramStartJoin = 10;
@@ -110,6 +174,22 @@ namespace PepperDash.Essentials.Bridges
             ProgramCrestronDatabaseVersion = 3;
             ProgramEnvironmentVersion = 4;
             AggregatedProgramInfo = 5;
+
+            EthernetStartJoin = 60;
+
+            EthernetOffsetJoin = 15;
+
+            HostName = 1;
+            CurrentIpAddress = 2;
+            CurrentSubnetMask = 3;
+            CurrentDefaultGateway = 4;
+            StaticIpAddress = 5;
+            StaticSubnetMask = 6;
+            StaticDefaultGateway = 7;
+            Domain = 8;
+            DnsServer = 9;
+            MacAddress = 10;
+            DhcpStatus = 11;
         }
 
         public override void OffsetJoinNumbers(uint joinStart)
@@ -126,6 +206,7 @@ namespace PepperDash.Essentials.Bridges
 
             // Sets the initial join value where the iterated program joins will begin
             ProgramStartJoin = ProgramStartJoin + joinOffset;
+            EthernetStartJoin = EthernetStartJoin + joinOffset;
         }
     }
 }

--- a/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
+++ b/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Crestron.SimplSharp;
-using Crestron.SimplSharpPro.DeviceSupport;
+﻿using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.Diagnostics;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
@@ -17,7 +12,7 @@ namespace PepperDash.Essentials.Bridges
     {
         public static void LinkToApi(this SystemMonitorController systemMonitorController, BasicTriList trilist, uint joinStart, string joinMapKey)
         {
-            SystemMonitorJoinMap joinMap = new SystemMonitorJoinMap();
+            var joinMap = new SystemMonitorJoinMap();
 
             var joinMapSerialized = JoinMapHelper.GetJoinMapForDevice(joinMapKey);
 
@@ -30,12 +25,11 @@ namespace PepperDash.Essentials.Bridges
             Debug.Console(2, systemMonitorController, "Linking API starting at join: {0}", joinStart);
 
             systemMonitorController.TimeZoneFeedback.LinkInputSig(trilist.UShortInput[joinMap.TimeZone]);
-            //trilist.SetUShortSigAction(joinMap.TimeZone, new Action<ushort>(u => systemMonitorController.SetTimeZone(u)));
             systemMonitorController.TimeZoneTextFeedback.LinkInputSig(trilist.StringInput[joinMap.TimeZoneName]);
 
-            systemMonitorController.IOControllerVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.IOControllerVersion]);
+            systemMonitorController.IoControllerVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.IOControllerVersion]);
             systemMonitorController.SnmpVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.SnmpAppVersion]);
-            systemMonitorController.BACnetAppVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.BACnetAppVersion]);
+            systemMonitorController.BaCnetAppVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.BACnetAppVersion]);
             systemMonitorController.ControllerVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.ControllerVersion]);
 
             // iterate the program status feedback collection and map all the joins
@@ -45,20 +39,16 @@ namespace PepperDash.Essentials.Bridges
             {
                 var programNumber = p.Value.Program.Number;
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStart, new Action<bool>
-                    (b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Start));
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStart, b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Start);
                 p.Value.ProgramStartedFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramStart]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStop, new Action<bool>
-                    (b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Stop));
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStop, b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Stop);
                 p.Value.ProgramStoppedFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramStop]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramRegister, new Action<bool>
-                    (b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Register));
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramRegister, b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Register);
                 p.Value.ProgramRegisteredFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramRegister]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramUnregister, new Action<bool>
-                    (b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Unregister));
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramUnregister, b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Unregister);
                 p.Value.ProgramUnregisteredFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramUnregister]);
 
                 p.Value.ProgramNameFeedback.LinkInputSig(trilist.StringInput[programSlotJoinStart + joinMap.ProgramName]);

--- a/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
+++ b/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
@@ -59,6 +59,8 @@ namespace PepperDash.Essentials.Bridges
                 fb.Value.DomainFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.Domain]);
                 fb.Value.DnsServerFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.DnsServer]);
                 fb.Value.DhcpStatusFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.DhcpStatus]);
+
+                ethernetSlotJoinStart += joinMap.EthernetOffsetJoin;
             }
         }
 

--- a/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
+++ b/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
@@ -33,6 +33,8 @@ namespace PepperDash.Essentials.Bridges
             systemMonitorController.ControllerVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.ControllerVersion]);
             systemMonitorController.SerialNumberFeedback.LinkInputSig(trilist.StringInput[joinMap.SerialNumber]);
             systemMonitorController.ModelFeedback.LinkInputSig(trilist.StringInput[joinMap.Model]);
+            systemMonitorController.UptimeFeedback.LinkInputSig(trilist.StringInput[joinMap.Uptime]);
+            systemMonitorController.LastStartFeedback.LinkInputSig(trilist.StringInput[joinMap.LastBoot]);
 
             // iterate the program status feedback collection and map all the joins
             LinkProgramInfoJoins(systemMonitorController, trilist, joinMap);

--- a/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
+++ b/PepperDashEssentials/Bridges/SystemMonitorBridge.cs
@@ -31,25 +31,61 @@ namespace PepperDash.Essentials.Bridges
             systemMonitorController.SnmpVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.SnmpAppVersion]);
             systemMonitorController.BaCnetAppVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.BACnetAppVersion]);
             systemMonitorController.ControllerVersionFeedback.LinkInputSig(trilist.StringInput[joinMap.ControllerVersion]);
+            systemMonitorController.SerialNumberFeedback.LinkInputSig(trilist.StringInput[joinMap.SerialNumber]);
+            systemMonitorController.ModelFeedback.LinkInputSig(trilist.StringInput[joinMap.Model]);
 
             // iterate the program status feedback collection and map all the joins
+            LinkProgramInfoJoins(systemMonitorController, trilist, joinMap);
+
+            LinkEthernetInfoJoins(systemMonitorController, trilist, joinMap);
+        }
+
+        private static void LinkEthernetInfoJoins(SystemMonitorController systemMonitorController, BasicTriList trilist, SystemMonitorJoinMap joinMap)
+        {
+            var ethernetSlotJoinStart = joinMap.EthernetStartJoin;
+
+            foreach (var fb in systemMonitorController.EthernetStatusFeedbackCollection)
+            {
+                fb.Value.CurrentIpAddressFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.CurrentIpAddress]);
+                fb.Value.CurrentSubnetMaskFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.CurrentSubnetMask]);
+                fb.Value.CurrentDefaultGatewayFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.CurrentDefaultGateway]);
+                fb.Value.StaticIpAddressFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.StaticIpAddress]);
+                fb.Value.StaticSubnetMaskFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.StaticSubnetMask]);
+                fb.Value.StaticDefaultGatewayFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.StaticDefaultGateway]);
+                fb.Value.HostNameFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.HostName]);
+                fb.Value.MacAddressFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.MacAddress]);
+                fb.Value.DomainFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.Domain]);
+                fb.Value.DnsServerFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.DnsServer]);
+                fb.Value.DhcpStatusFeedback.LinkInputSig(trilist.StringInput[ethernetSlotJoinStart + joinMap.DhcpStatus]);
+            }
+        }
+
+        private static void LinkProgramInfoJoins(SystemMonitorController systemMonitorController, BasicTriList trilist,
+            SystemMonitorJoinMap joinMap)
+        {
             var programSlotJoinStart = joinMap.ProgramStartJoin;
 
             foreach (var p in systemMonitorController.ProgramStatusFeedbackCollection)
             {
                 var programNumber = p.Value.Program.Number;
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStart, b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Start);
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStart,
+                    b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Start);
                 p.Value.ProgramStartedFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramStart]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStop, b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Stop);
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramStop,
+                    b => SystemMonitor.ProgramCollection[programNumber].OperatingState = eProgramOperatingState.Stop);
                 p.Value.ProgramStoppedFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramStop]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramRegister, b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Register);
-                p.Value.ProgramRegisteredFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramRegister]);
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramRegister,
+                    b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Register);
+                p.Value.ProgramRegisteredFeedback.LinkInputSig(
+                    trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramRegister]);
 
-                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramUnregister, b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Unregister);
-                p.Value.ProgramUnregisteredFeedback.LinkInputSig(trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramUnregister]);
+                trilist.SetBoolSigAction(programSlotJoinStart + joinMap.ProgramUnregister,
+                    b => SystemMonitor.ProgramCollection[programNumber].RegistrationState = eProgramRegistrationState.Unregister);
+                p.Value.ProgramUnregisteredFeedback.LinkInputSig(
+                    trilist.BooleanInput[programSlotJoinStart + joinMap.ProgramUnregister]);
 
                 p.Value.ProgramNameFeedback.LinkInputSig(trilist.StringInput[programSlotJoinStart + joinMap.ProgramName]);
                 p.Value.ProgramCompileTimeFeedback.LinkInputSig(

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
@@ -38,7 +38,7 @@ namespace PepperDash.Essentials.Core
         /// Creates the feedback with the Func as described.
         /// </summary>
         /// <remarks>
-        /// While the sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
         /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
         /// </remarks>
         /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
@@ -51,7 +51,7 @@ namespace PepperDash.Essentials.Core
         /// Creates the feedback with the Func as described.
         /// </summary>
         /// <remarks>
-        /// While the sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
         /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
         /// </remarks>
         /// <param name="key">Key to find this Feedback</param>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
@@ -34,17 +34,33 @@ namespace PepperDash.Essentials.Core
 
         List<Crestron.SimplSharpPro.DeviceSupport.Feedback> LinkedCrestronFeedbacks = new List<Crestron.SimplSharpPro.DeviceSupport.Feedback>();
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public BoolFeedback(Func<bool> valueFunc)
             : this(null, valueFunc)
         {
         }
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="key">Key to find this Feedback</param>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public BoolFeedback(string key, Func<bool> valueFunc)
             : base(key)
         {
             ValueFunc = valueFunc;
         }
-
 
         public override void FireUpdate()
         {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/IntFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/IntFeedback.cs
@@ -23,11 +23,28 @@ namespace PepperDash.Essentials.Core
         Func<int> ValueFunc;
         List<UShortInputSig> LinkedInputSigs = new List<UShortInputSig>();
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public IntFeedback(Func<int> valueFunc)
             : this(null, valueFunc)
         {
         }
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="key">Key to find this Feedback</param>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public IntFeedback(string key, Func<int> valueFunc)
             : base(key)
         {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
@@ -7,6 +7,7 @@ using Crestron.SimplSharpPro;
 
 namespace PepperDash.Essentials.Core
 {
+
     public class StringFeedback : Feedback
     {
         public override string StringValue { get { return _StringValue; } } // ValueFunc.Invoke(); } }
@@ -18,7 +19,7 @@ namespace PepperDash.Essentials.Core
         public string TestValue { get; private set; }
 
         /// <summary>
-        /// Evalutated on FireUpdate
+        /// Evaluated on FireUpdate
         /// </summary>
         public Func<string> ValueFunc { get; private set; }
         List<StringInputSig> LinkedInputSigs = new List<StringInputSig>();

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
@@ -24,11 +24,28 @@ namespace PepperDash.Essentials.Core
         public Func<string> ValueFunc { get; private set; }
         List<StringInputSig> LinkedInputSigs = new List<StringInputSig>();
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public StringFeedback(Func<string> valueFunc)
             : this(null, valueFunc)
         {
         }
 
+        /// <summary>
+        /// Creates the feedback with the Func as described.
+        /// </summary>
+        /// <remarks>
+        /// While the linked sig value will be updated with the current value stored when it is linked to a EISC Bridge,
+        /// it will NOT reflect an actual value from a device until <seealso cref="FireUpdate"/> has been called
+        /// </remarks>
+        /// <param name="key">Key to find this Feedback</param>
+        /// <param name="valueFunc">Delegate to invoke when this feedback needs to be updated</param>
         public StringFeedback(string key, Func<string> valueFunc)
             : base(key)
         {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Crestron.SimplSharp;
 using Crestron.SimplSharpPro.Diagnostics;
-
 using PepperDash.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -26,15 +25,13 @@ namespace PepperDash.Essentials.Core.Monitoring
         public StringFeedback SnmpVersionFeedback { get; set; }
         public StringFeedback BaCnetAppVersionFeedback { get; set; }
         public StringFeedback ControllerVersionFeedback { get; set; }
-        
+
         public SystemMonitorController(string key)
             : base(key)
         {
             Debug.Console(2, this, "Adding SystemMonitorController.");
 
             SystemMonitor.ProgramInitialization.ProgramInitializationUnderUserControl = true;
-
-            //CrestronConsole.AddNewConsoleCommand(RefreshSystemMonitorData, "RefreshSystemMonitor", "Refreshes System Monitor Feedbacks", ConsoleAccessLevelEnum.AccessOperator);
 
             TimeZoneFeedback = new IntFeedback(() => SystemMonitor.TimeZoneInformation.TimeZoneNumber);
             TimeZoneTextFeedback = new StringFeedback(() => SystemMonitor.TimeZoneInformation.TimeZoneName);
@@ -43,12 +40,6 @@ namespace PepperDash.Essentials.Core.Monitoring
             SnmpVersionFeedback = new StringFeedback(() => SystemMonitor.VersionInformation.SNMPVersion);
             BaCnetAppVersionFeedback = new StringFeedback(() => SystemMonitor.VersionInformation.BACNetVersion);
             ControllerVersionFeedback = new StringFeedback(() => SystemMonitor.VersionInformation.ControlSystemVersion);
-
-            //var status = string.Format("System Monitor Status: \r TimeZone: {0}\rTimeZoneText: {1}\rIOControllerVersion: {2}\rSnmpAppVersionFeedback: {3}\rBACnetAppVersionFeedback: {4}\rControllerVersionFeedback: {5}",
-            //    SystemMonitor.TimeZoneInformation.TimeZoneNumber, SystemMonitor.TimeZoneInformation.TimeZoneName, SystemMonitor.VersionInformation.IOPVersion, SystemMonitor.VersionInformation.SNMPVersion,
-            //    SystemMonitor.VersionInformation.BACNetVersion, SystemMonitor.VersionInformation.ControlSystemVersion);
-                
-            //Debug.Console(1, this, status);
 
             ProgramStatusFeedbackCollection = new Dictionary<uint, ProgramStatusFeedbacks>();
 
@@ -88,7 +79,7 @@ namespace PepperDash.Essentials.Core.Monitoring
             var handler = SystemMonitorPropertiesChanged;
             if (handler != null)
             {
-                handler(this, new EventArgs());   
+                handler(this, new EventArgs());
             }
         }
 
@@ -124,15 +115,15 @@ namespace PepperDash.Essentials.Core.Monitoring
 
                 program.ProgramInfo.OperatingState = args.OperatingState;
 
-				//program.GetProgramInfo();
+                //program.GetProgramInfo();
 
-				if (args.OperatingState == eProgramOperatingState.Start)
-					program.GetProgramInfo();
-				else
-				{
-					program.AggregatedProgramInfoFeedback.FireUpdate();
-					program.OnProgramInfoChanged();
-				}
+                if (args.OperatingState == eProgramOperatingState.Start)
+                    program.GetProgramInfo();
+                else
+                {
+                    program.AggregatedProgramInfoFeedback.FireUpdate();
+                    program.OnProgramInfoChanged();
+                }
             }
             else if (args.EventType == eProgramChangeEventType.RegistrationState)
             {
@@ -142,7 +133,7 @@ namespace PepperDash.Essentials.Core.Monitoring
                 program.ProgramInfo.RegistrationState = args.RegistrationState;
 
                 program.GetProgramInfo();
-            }         
+            }
         }
 
         /// <summary>
@@ -190,8 +181,10 @@ namespace PepperDash.Essentials.Core.Monitoring
 
                 ProgramStartedFeedback = new BoolFeedback(() => Program.OperatingState == eProgramOperatingState.Start);
                 ProgramStoppedFeedback = new BoolFeedback(() => Program.OperatingState == eProgramOperatingState.Stop);
-                ProgramRegisteredFeedback = new BoolFeedback(() => Program.RegistrationState == eProgramRegistrationState.Register);
-                ProgramUnregisteredFeedback = new BoolFeedback(() => Program.RegistrationState == eProgramRegistrationState.Unregister);
+                ProgramRegisteredFeedback =
+                    new BoolFeedback(() => Program.RegistrationState == eProgramRegistrationState.Register);
+                ProgramUnregisteredFeedback =
+                    new BoolFeedback(() => Program.RegistrationState == eProgramRegistrationState.Unregister);
 
                 ProgramNameFeedback = new StringFeedback(() => ProgramInfo.ProgramFile);
                 ProgramCompileTimeFeedback = new StringFeedback(() => ProgramInfo.CompileTime);
@@ -211,13 +204,14 @@ namespace PepperDash.Essentials.Core.Monitoring
                 CrestronInvoke.BeginInvoke(GetProgramInfo);
             }
 
-            private void GetProgramInfo(object o)   
+            private void GetProgramInfo(object o)
             {
                 Debug.Console(2, "Attempting to get program info for slot: {0}", Program.Number);
 
                 string response = null;
 
-                var success = CrestronConsole.SendControlSystemCommand(string.Format("progcomments:{0}", Program.Number), ref response);
+                var success = CrestronConsole.SendControlSystemCommand(
+                    string.Format("progcomments:{0}", Program.Number), ref response);
 
                 if (success)
                 {
@@ -238,7 +232,8 @@ namespace PepperDash.Essentials.Core.Monitoring
                             ProgramInfo.FriendlyName = ParseConsoleData(response, "Friendly Name", ": ", "\n");
                             ProgramInfo.ApplicationName = ParseConsoleData(response, "Application Name", ": ", "\n");
                             ProgramInfo.ProgramTool = ParseConsoleData(response, "Program Tool", ": ", "\n");
-                            ProgramInfo.MinFirmwareVersion = ParseConsoleData(response, "Min Firmware Version", ": ", "\n");
+                            ProgramInfo.MinFirmwareVersion = ParseConsoleData(response, "Min Firmware Version", ": ",
+                                "\n");
                             ProgramInfo.PlugInVersion = ParseConsoleData(response, "PlugInVersion", ": ", "\n");
                         }
                         else if (ProgramInfo.ProgramFile.Contains(".smw"))
@@ -254,7 +249,9 @@ namespace PepperDash.Essentials.Core.Monitoring
                     }
                     else
                     {
-                        Debug.Console(2, "Bad or incomplete console command response.  Initializing ProgramInfo for slot: {0}", Program.Number);
+                        Debug.Console(2,
+                            "Bad or incomplete console command response.  Initializing ProgramInfo for slot: {0}",
+                            Program.Number);
 
                         // Assume no valid program info.  Constructing a new object will wipe all properties
                         ProgramInfo = new ProgramInfo(Program.Number)
@@ -297,10 +294,10 @@ namespace PepperDash.Essentials.Core.Monitoring
 
                 try
                 {
-
                     //Debug.Console(2, "ParseConsoleData Data: {0}, Line {1}, startStirng {2}, endString {3}", data, line, startString, endString);
                     var linePosition = data.IndexOf(line, StringComparison.Ordinal);
-                    var startPosition = data.IndexOf(startString, linePosition, StringComparison.Ordinal) + startString.Length;
+                    var startPosition = data.IndexOf(startString, linePosition, StringComparison.Ordinal) +
+                                        startString.Length;
                     var endPosition = data.IndexOf(endString, startPosition, StringComparison.Ordinal);
                     outputData = data.Substring(startPosition, endPosition - startPosition).Trim();
                     //Debug.Console(2, "ParseConsoleData Return: {0}", outputData);
@@ -313,7 +310,6 @@ namespace PepperDash.Essentials.Core.Monitoring
                 return outputData;
             }
         }
-
     }
 
     /// <summary>
@@ -326,32 +322,39 @@ namespace PepperDash.Essentials.Core.Monitoring
         [JsonProperty("programNumber")]
         public uint ProgramNumber { get; private set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof (StringEnumConverter))]
         [JsonProperty("operatingState")]
         public eProgramOperatingState OperatingState { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof (StringEnumConverter))]
         [JsonProperty("registrationState")]
         public eProgramRegistrationState RegistrationState { get; set; }
 
         [JsonProperty("programFile")]
         public string ProgramFile { get; set; }
+
         [JsonProperty("friendlyName")]
         public string FriendlyName { get; set; }
+
         [JsonProperty("compilerRevision")]
         public string CompilerRevision { get; set; }
+
         [JsonProperty("compileTime")]
         public string CompileTime { get; set; }
+
         [JsonProperty("include4Dat")]
         public string Include4Dat { get; set; }
 
         // SIMPL Windows properties
         [JsonProperty("systemName")]
         public string SystemName { get; set; }
+
         [JsonProperty("crestronDb")]
         public string CrestronDb { get; set; }
+
         [JsonProperty("environment")]
         public string Environment { get; set; }
+
         [JsonProperty("programmer")]
         public string Programmer { get; set; }
 
@@ -359,10 +362,13 @@ namespace PepperDash.Essentials.Core.Monitoring
         // SSP Properties
         [JsonProperty("applicationName")]
         public string ApplicationName { get; set; }
+
         [JsonProperty("programTool")]
         public string ProgramTool { get; set; }
+
         [JsonProperty("minFirmwareVersion")]
         public string MinFirmwareVersion { get; set; }
+
         [JsonProperty("plugInVersion")]
         public string PlugInVersion { get; set; }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -30,15 +30,13 @@ namespace PepperDash.Essentials.Core.Monitoring
         public StringFeedback ControllerVersionFeedback { get; protected set; }
 
         //new feedbacks. Issue #50
-        public StringFeedback FirmwareVersion { get; protected set; }
         public StringFeedback HostName { get; protected set; }
         public StringFeedback SerialNumber { get; protected set; }
         public StringFeedback Model { get; set; }
         public StringFeedback LanIpAddress { get; protected set; }
         public StringFeedback DefaultGateway { get; protected set; }
         public StringFeedback Domain { get; protected set; }
-        public StringFeedback DnsServer01 { get; protected set; }
-        public StringFeedback DnsServer02 { get; protected set; }
+        public StringFeedback DnsServer { get; protected set; }
         public StringFeedback LanMacAddress { get; protected set; }
         public StringFeedback LanSubnetMask { get; protected set; }
      
@@ -78,19 +76,55 @@ namespace PepperDash.Essentials.Core.Monitoring
         private void CreateControllerFeedbacks()
         {
             //assuming 0 = LAN, 1 = CS for devices that have CS
-            FirmwareVersion = new StringFeedback(() => InitialParametersClass.FirmwareVersion);
-            HostName = new StringFeedback(() => CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_HOSTNAME, LanAdapterIndex) );
+            HostName =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_HOSTNAME, LanAdapterIndex));
             SerialNumber = new StringFeedback(() => CrestronEnvironment.SystemInfo.SerialNumber);
             Model = new StringFeedback(() => InitialParametersClass.ControllerPromptName);
-            LanIpAddress = new StringFeedback(() => CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, LanAdapterIndex));
-            DefaultGateway = new StringFeedback(() => String.Empty);
-            Domain = new StringFeedback(() => String.Empty);
-            DnsServer01 = new StringFeedback(() => String.Empty);
-            DnsServer02 = new StringFeedback(() => String.Empty);
-            LanMacAddress = new StringFeedback(() => String.Empty);
-            LanSubnetMask = new StringFeedback(() => String.Empty);
-            CsIpAddress = new StringFeedback(() => String.Empty);
-            CsSubnetMask = new StringFeedback(() => String.Empty);
+            LanIpAddress =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, LanAdapterIndex));
+            DefaultGateway =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_ROUTER, LanAdapterIndex));
+            Domain =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_DOMAIN_NAME, LanAdapterIndex));
+            DnsServer =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_DNS_SERVER, LanAdapterIndex));
+            LanMacAddress =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_MAC_ADDRESS, LanAdapterIndex));
+            LanSubnetMask =
+                new StringFeedback(
+                    () =>
+                        CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_STATIC_IPMASK, LanAdapterIndex));
+
+            CsIpAddress =
+                new StringFeedback(
+                    () =>
+                        InitialParametersClass.NumberOfEthernetInterfaces > 1
+                            ? CrestronEthernetHelper.GetEthernetParameter(
+                                CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, CsAdapterIndex)
+                            : String.Empty);
+            CsSubnetMask = new StringFeedback(() => InitialParametersClass.NumberOfEthernetInterfaces > 1
+                            ? CrestronEthernetHelper.GetEthernetParameter(
+                                CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_MASK, CsAdapterIndex)
+                            : String.Empty);
         }
 
         /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -14,6 +14,9 @@ namespace PepperDash.Essentials.Core.Monitoring
     /// </summary>
     public class SystemMonitorController : Device
     {
+        protected const short LanAdapterIndex = 0;
+        protected const short CsAdapterIndex = 1;
+        
         public event EventHandler<EventArgs> SystemMonitorPropertiesChanged;
 
         public Dictionary<uint, ProgramStatusFeedbacks> ProgramStatusFeedbackCollection;
@@ -74,11 +77,12 @@ namespace PepperDash.Essentials.Core.Monitoring
 
         private void CreateControllerFeedbacks()
         {
+            //assuming 0 = LAN, 1 = CS for devices that have CS
             FirmwareVersion = new StringFeedback(() => InitialParametersClass.FirmwareVersion);
-            HostName = new StringFeedback(() => String.Empty );
-            SerialNumber = new StringFeedback(()=> String.Empty);
+            HostName = new StringFeedback(() => CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_HOSTNAME, LanAdapterIndex) );
+            SerialNumber = new StringFeedback(() => CrestronEnvironment.SystemInfo.SerialNumber);
             Model = new StringFeedback(() => InitialParametersClass.ControllerPromptName);
-            LanIpAddress = new StringFeedback(() => String.Empty);
+            LanIpAddress = new StringFeedback(() => CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, LanAdapterIndex));
             DefaultGateway = new StringFeedback(() => String.Empty);
             Domain = new StringFeedback(() => String.Empty);
             DnsServer01 = new StringFeedback(() => String.Empty);

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -131,8 +131,11 @@ namespace PepperDash.Essentials.Core.Monitoring
         {
             EthernetStatusFeedbackCollection = new Dictionary<short, EthernetStatusFeedbacks>();
 
+            Debug.Console(2, "Creating {0} EthernetStatusFeedbacks", InitialParametersClass.NumberOfEthernetInterfaces);
+
             for (short i = 0; i < InitialParametersClass.NumberOfEthernetInterfaces; i++)
             {
+                Debug.Console(2, "Creating EthernetStatusFeedback for Interface {0}", i);
                 var ethernetInterface = new EthernetStatusFeedbacks(i);
                 EthernetStatusFeedbackCollection.Add(i, ethernetInterface);
             }
@@ -267,6 +270,29 @@ namespace PepperDash.Essentials.Core.Monitoring
 
             public EthernetStatusFeedbacks(short adapterIndex)
             {
+                Debug.Console(2, "Ethernet Information for interface {0}", adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Hostname: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_HOSTNAME, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Current IP Address: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Current Subnet Mask: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_MASK, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Current Router: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_ROUTER, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Static IP Address: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_STATIC_IPADDRESS, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Static Subnet Mask: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_STATIC_IPMASK, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Static Router: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_STATIC_ROUTER, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} DNS Servers: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_DNS_SERVER, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} DHCP State: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_DHCP_STATE, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} Domain Name: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_DOMAIN_NAME, adapterIndex), adapterIndex);
+                Debug.Console(2, "Adapter Index: {1} MAC Address: {0}", CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_MAC_ADDRESS, adapterIndex), adapterIndex);
                 HostNameFeedback =
                     new StringFeedback(
                         () =>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -43,6 +43,8 @@ namespace PepperDash.Essentials.Core.Monitoring
         public StringFeedback CsIpAddress { get; protected set; }
         public StringFeedback CsSubnetMask { get; protected set; }
 
+        public BoolFeedback DhcpEnabled { get; protected set; }
+
 
         public SystemMonitorController(string key)
             : base(key)
@@ -125,6 +127,12 @@ namespace PepperDash.Essentials.Core.Monitoring
                             ? CrestronEthernetHelper.GetEthernetParameter(
                                 CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_MASK, CsAdapterIndex)
                             : String.Empty);
+
+            DhcpEnabled = new BoolFeedback(
+                () =>
+                    CrestronEthernetHelper.GetEthernetParameter(
+                        CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_DHCP_STATE, LanAdapterIndex) ==
+                    "Enabled");
         }
 
         /// <summary>

--- a/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
+++ b/essentials-framework/Essentials DM/Essentials_DM/Essentials_DM.csproj
@@ -84,7 +84,7 @@
     </Reference>
     <Reference Include="SimplSharpReflectionInterface, Version=1.0.5583.25238, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Closes #50 
Adds the following informational Serial Joins:

SerialNumber = 6
Model = 7
Uptime = 8
LastBoot = 9

Ethernet Information joins start at 75 and are offset by 15 for each interface the processor has:

HostName = 1;
CurrentIpAddress = 2;
CurrentSubnetMask = 3;
CurrentDefaultGateway = 4;
StaticIpAddress = 5;
StaticSubnetMask = 6;
StaticDefaultGateway = 7;
Domain = 8;
DnsServer = 9;
MacAddress = 10;
DhcpStatus = 11;
