### PR TITLE
Added condition to check for _loadedPluginsDirectoryPath when loading plugins

### DIFF
--- a/PepperDashEssentials/AppServer/MobileControlSystemController.cs
+++ b/PepperDashEssentials/AppServer/MobileControlSystemController.cs
@@ -290,6 +290,10 @@ namespace PepperDash.Essentials
 									SystemUuid);
 							}
 						}
+						else
+						{
+							Debug.Console(0, "Authorization failed, code {0}: {1}", r.Code, r.ContentString);
+						}
 					}
 					else
 						Debug.Console(0, this, "Error {0} in authorizing system", e);

--- a/PepperDashEssentials/PluginLoading/PluginLoading.cs
+++ b/PepperDashEssentials/PluginLoading/PluginLoading.cs
@@ -415,14 +415,15 @@ namespace PepperDash.Essentials
                 // Deal with any .cplz files
                 UnzipAndMoveCplzArchives();
 
-                // Load the assemblies from the loadedPlugins folder into the AppDomain
-                LoadPluginAssemblies();
+				if(Directory.Exists(_loadedPluginsDirectoryPath) {
+					// Load the assemblies from the loadedPlugins folder into the AppDomain
+					LoadPluginAssemblies();
 
-                // Load the types from any custom plugin assemblies
-                LoadCustomPluginTypes();
+					// Load the types from any custom plugin assemblies
+					LoadCustomPluginTypes();
+				}
             }
         }
-
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #80 

Adds a check to make sure that the loadedPlugins folder exists before attempting to load plugins from it.