### PR TITLE
Adds ctor for ComPortController and CecPortController

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/CecPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/CecPortController.cs
@@ -20,6 +20,17 @@ namespace PepperDash.Essentials.Core
 
         ICec Port;
 
+        public CecPortController(string key, Func<EssentialsControlPropertiesConfig, ICec> postActivationFunc,
+            EssentialsControlPropertiesConfig config):base(key)
+        {
+            AddPostActivationAction(() =>
+            {
+                Port = postActivationFunc(config);
+
+                Port.StreamCec.CecChange += StreamCec_CecChange;
+            });            
+        }
+
         public CecPortController(string key, ICec port)
             : base(key)
         {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/ComPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/ComPortController.cs
@@ -21,6 +21,19 @@ namespace PepperDash.Essentials.Core
 		ComPort Port;
 		ComPort.ComPortSpec Spec;
 
+	    public ComPortController(string key, Func<EssentialsControlPropertiesConfig, ComPort> postActivationFunc,
+	        ComPort.ComPortSpec spec, EssentialsControlPropertiesConfig config) : base(key)
+	    {
+	        Spec = spec;
+
+            AddPostActivationAction(() =>
+            {
+                Port = postActivationFunc(config);
+
+                ConfigureComPort();
+            });
+	    }
+
 		public ComPortController(string key, ComPort port, ComPort.ComPortSpec spec)
 			: base(key)
 		{
@@ -45,16 +58,21 @@ namespace PepperDash.Essentials.Core
 					return; // false
 				}
 			}
-			var specResult = Port.SetComPortSpec(Spec);
-			if (specResult != 0)
-			{
-				Debug.Console(0, this, "WARNING: Cannot set comspec");
-				return; // false
-			}
-			Port.SerialDataReceived += new ComPortDataReceivedEvent(Port_SerialDataReceived);
+			ConfigureComPort();
 		}
 
-		~ComPortController()
+	    private void ConfigureComPort()
+	    {
+	        var specResult = Port.SetComPortSpec(Spec);
+	        if (specResult != 0)
+	        {
+	            Debug.Console(0, this, "WARNING: Cannot set comspec");
+	            return;
+	        }
+	        Port.SerialDataReceived += Port_SerialDataReceived;
+	    }
+
+	    ~ComPortController()
 		{
 			Port.SerialDataReceived -= Port_SerialDataReceived;
 		}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/CommFactory.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/CommFactory.cs
@@ -48,10 +48,10 @@ namespace PepperDash.Essentials.Core
 				switch (controlConfig.Method)
 				{
 					case eControlMethod.Com:
-						comm = new ComPortController(deviceConfig.Key + "-com", GetComPort(controlConfig), controlConfig.ComParams);
+						comm = new ComPortController(deviceConfig.Key + "-com", GetComPort, controlConfig.ComParams, controlConfig);
 						break;
                     case eControlMethod.Cec:
-                        comm = new CecPortController(deviceConfig.Key + "-cec", GetCecPort(controlConfig));
+                        comm = new CecPortController(deviceConfig.Key + "-cec", GetCecPort, controlConfig);
                         break;
 					case eControlMethod.IR:
 						break;


### PR DESCRIPTION
Closes #126 by moving linking and configuration of the com port and cec port to a post-activation action by injecting the correct method via the constructor calling it in the action that is passed into the AddPostActivationAction method. This should defer the linking and retrieval of the ComPort and ICec to after all devices have been instantiated.