### PR TITLE
Fix Issues with DisplayBase and CameraBase backwards compatibility

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -114,11 +114,13 @@ namespace PepperDash.Essentials.Core.Bridges
                     //{
                     //    Debug.Console(2, this, "'{0}' is IBridge", device.Key);
                     //}
-                    if (device.GetType().GetCType().IsAssignableFrom(typeof (IBridgeAdvanced)))
+                    if (!typeof (IBridgeAdvanced).IsAssignableFrom(device.GetType().GetCType()))
                     {
-                        var bridge = device as IBridgeAdvanced;
-                        if (bridge != null) bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
+                        continue;
                     }
+
+                    var bridge = device as IBridgeAdvanced;
+                    if (bridge != null) bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
                 }
 
                 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/ComPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/ComPortController.cs
@@ -30,7 +30,7 @@ namespace PepperDash.Essentials.Core
             {
                 Port = postActivationFunc(config);
 
-                ConfigureComPort();
+                RegisterAndConfigureComPort();
             });
 	    }
 
@@ -47,16 +47,13 @@ namespace PepperDash.Essentials.Core
 			Spec = spec;
 			//IsConnected = new BoolFeedback(CommonBoolCue.IsConnected, () => true);
 
-
-			ConfigureComPort();
+			RegisterAndConfigureComPort();
 		}
 
-	    private void ConfigureComPort()
+	    private void RegisterAndConfigureComPort()
 	    {
             if (Port.Parent is CrestronControlSystem)
             {
-
-
                 var result = Port.Register();
                 if (result != eDeviceRegistrationUnRegistrationResponse.Success)
                 {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/BasicIrDisplay.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/BasicIrDisplay.cs
@@ -14,7 +14,7 @@ using PepperDash.Essentials.Core.Routing;
 
 namespace PepperDash.Essentials.Core
 {
-	public class BasicIrDisplay : DisplayBase, IBasicVolumeControls, IPower, IWarmingCooling
+	public class BasicIrDisplay : DisplayBase, IBasicVolumeControls, IBridgeAdvanced
 	{
 		public IrOutputPortController IrPort { get; private set; }
 		public ushort IrPulseTime { get; set; }
@@ -204,7 +204,7 @@ namespace PepperDash.Essentials.Core
 
 		#endregion
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
@@ -18,7 +18,7 @@ namespace PepperDash.Essentials.Core
 	/// <summary>
 	/// 
 	/// </summary>
-	public abstract class DisplayBase : EssentialsBridgeableDevice, IHasFeedback, IRoutingSinkWithSwitching, IPower, IWarmingCooling, IUsageTracking
+	public abstract class DisplayBase : EssentialsDevice, IHasFeedback, IRoutingSinkWithSwitching, IPower, IWarmingCooling, IUsageTracking
 	{
         public event SourceInfoChangeHandler CurrentSourceChange;
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/MockDisplay.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/MockDisplay.cs
@@ -19,7 +19,7 @@ namespace PepperDash.Essentials.Core
 	/// <summary>
 	/// 
 	/// </summary>
-	public class MockDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback
+	public class MockDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, IBridgeAdvanced
 
 	{
 		public RoutingInputPort HdmiIn1 { get; private set; }
@@ -177,7 +177,7 @@ namespace PepperDash.Essentials.Core
 
 		#endregion
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraBase.cs
@@ -25,7 +25,7 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
         Focus = 8
     }
 
-    public abstract class CameraBase : EssentialsBridgeableDevice, IRoutingOutputs
+    public abstract class CameraBase : EssentialsDevice, IRoutingOutputs
 	{
         public eCameraControlMode ControlMode { get; protected set; }
 

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraVisca.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraVisca.cs
@@ -14,7 +14,7 @@ using Crestron.SimplSharp.Reflection;
 
 namespace PepperDash.Essentials.Devices.Common.Cameras
 {
-	public class CameraVisca : CameraBase, IHasCameraPtzControl, ICommunicationMonitor, IHasCameraPresets, IPower
+	public class CameraVisca : CameraBase, IHasCameraPtzControl, ICommunicationMonitor, IHasCameraPresets, IPower, IBridgeAdvanced
 	{
 		public IBasicCommunication Communication { get; private set; }
 		public CommunicationGather PortGather { get; private set; }
@@ -82,7 +82,7 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
 			return true;
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/AvocorVTFDisplay.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/AvocorVTFDisplay.cs
@@ -19,7 +19,7 @@ namespace PepperDash.Essentials.Devices.Displays
 	/// 
 	/// </summary>
     public class AvocorDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor, IInputDisplayPort1,
-        IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4, IInputVga1
+        IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4, IInputVga1, IBridgeAdvanced
 	{
         public IBasicCommunication Communication { get; private set; }
         public CommunicationGather PortGather { get; private set; }
@@ -203,7 +203,7 @@ namespace PepperDash.Essentials.Devices.Displays
 			return true;
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/NECPSXMDisplay.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/NECPSXMDisplay.cs
@@ -17,7 +17,7 @@ namespace PepperDash.Essentials.Devices.Displays
 	/// <summary>
 	/// 
 	/// </summary>
-	public class NecPSXMDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor
+	public class NecPSXMDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor, IBridgeAdvanced
 	{
 		public IBasicCommunication Communication { get; private set; }
 		public CommunicationGather PortGather { get; private set; }
@@ -154,7 +154,7 @@ namespace PepperDash.Essentials.Devices.Displays
 			return true;
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/NecPaSeriesProjector.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/NecPaSeriesProjector.cs
@@ -11,7 +11,7 @@ using PepperDash.Essentials.Core.Bridges;
 
 namespace PepperDash.Essentials.Devices.Displays
 {
-	public class NecPaSeriesProjector : ComTcpDisplayBase
+	public class NecPaSeriesProjector : ComTcpDisplayBase, IBridgeAdvanced
 	{
 		public readonly IntFeedback Lamp1RemainingPercent;
 		int _Lamp1RemainingPercent;
@@ -219,7 +219,7 @@ namespace PepperDash.Essentials.Devices.Displays
 
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/PanasonicThDisplay.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/PanasonicThDisplay.cs
@@ -17,7 +17,7 @@ namespace PepperDash.Essentials.Devices.Displays
 	/// <summary>
 	/// 
 	/// </summary>
-	public class PanasonicThDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor
+	public class PanasonicThDisplay : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor, IBridgeAdvanced
 	{
 		public IBasicCommunication Communication { get; private set; }
 		public CommunicationGather PortGather { get; private set; }
@@ -146,7 +146,7 @@ namespace PepperDash.Essentials.Devices.Displays
 			return true;
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/SamsungMDCDisplay.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/SamsungMDCDisplay.cs
@@ -21,7 +21,7 @@ namespace PepperDash.Essentials.Devices.Displays
 	/// 
 	/// </summary>
     public class SamsungMDC : TwoWayDisplayBase, IBasicVolumeWithFeedback, ICommunicationMonitor, IInputDisplayPort1, IInputDisplayPort2,
-        IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4
+        IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4, IBridgeAdvanced
 	{
 		public IBasicCommunication Communication { get; private set; }
 				
@@ -152,7 +152,7 @@ namespace PepperDash.Essentials.Devices.Displays
 			return true;
 		}
 
-	    public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+	    public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
 	    {
 	        LinkDisplayToApi(this, trilist, joinStart, joinMapKey, bridge);
 	    }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoCamera.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoCamera.cs
@@ -9,7 +9,7 @@ using PepperDash.Essentials.Devices.Common.Cameras;
 
 namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 {
-    public class CiscoFarEndCamera : CameraBase, IHasCameraPtzControl, IAmFarEndCamera
+    public class CiscoFarEndCamera : CameraBase, IHasCameraPtzControl, IAmFarEndCamera, IBridgeAdvanced
     {
         protected CiscoSparkCodec ParentCodec { get; private set; }
 
@@ -100,13 +100,13 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
             ParentCodec.SendText(string.Format("xCommand Call FarEndControl Camera Stop CallId: {0}", CallId)); 
         }
 
-        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
         }
     }
 
-    public class CiscoSparkCamera : CameraBase, IHasCameraPtzControl, IHasCameraFocusControl
+    public class CiscoSparkCamera : CameraBase, IHasCameraPtzControl, IHasCameraFocusControl, IBridgeAdvanced
     {
         /// <summary>
         /// The codec this camera belongs to
@@ -315,7 +315,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
         #endregion
 
-        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
         }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/MockVC/MockVCCamera.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/MockVC/MockVCCamera.cs
@@ -10,7 +10,7 @@ using PepperDash.Essentials.Devices.Common.VideoCodec;
 
 namespace PepperDash.Essentials.Devices.Common.Cameras
 {
-    public class MockVCCamera : CameraBase, IHasCameraPtzControl, IHasCameraFocusControl
+    public class MockVCCamera : CameraBase, IHasCameraPtzControl, IHasCameraFocusControl, IBridgeAdvanced
     {
         protected VideoCodecBase ParentCodec { get; private set; }
 
@@ -113,13 +113,13 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
 
         #endregion
 
-        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
         }
     }
 
-    public class MockFarEndVCCamera : CameraBase, IHasCameraPtzControl, IAmFarEndCamera
+    public class MockFarEndVCCamera : CameraBase, IHasCameraPtzControl, IAmFarEndCamera, IBridgeAdvanced
     {
         protected VideoCodecBase ParentCodec { get; private set; }
 
@@ -198,7 +198,7 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
 
         #endregion
 
-        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
         }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoomCamera.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoomCamera.cs
@@ -30,7 +30,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
     }
 
 
-    public class ZoomRoomCamera : CameraBase, IHasCameraPtzControl
+    public class ZoomRoomCamera : CameraBase, IHasCameraPtzControl, IBridgeAdvanced
     {
         protected ZoomRoom ParentCodec { get; private set; }
 
@@ -200,7 +200,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
         #endregion
 
-        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        public void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             LinkCameraToApi(this, trilist, joinStart, joinMapKey, bridge);
         }


### PR DESCRIPTION
closes #131 

CameraBase & DisplayBase moved back to inherit from EssentialsDevice instead of EssentialsBridgeableDevice. Internal children now implement IBridgeAdvanced instead of relying on a parent to implement it.

CameraBase and DisplayBase both have LinkCamera/DisplayToApi methods that take the respective base class and the appropriate parameters for the IBridgeAdvanced LinkToApi method, and use the existing join maps to link signals to the bridge.