### PR TITLE
Feature/add dm rmc 4 kz scaler c

### DIFF
--- a/PepperDashEssentials/Bridges/JoinMaps/DmRmcControllerJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/DmRmcControllerJoinMap.cs
@@ -40,6 +40,10 @@ namespace PepperDash.Essentials.Bridges
         public uint EdidSerialNumber { get; set; }
         #endregion
 
+        #region Analogs
+        public uint AudioVideoSource { get; set; }
+        #endregion
+
         public DmRmcControllerJoinMap()
         {
             // Digital
@@ -51,6 +55,9 @@ namespace PepperDash.Essentials.Bridges
             EdidName = 3;
             EdidPrefferedTiming = 4;
             EdidSerialNumber = 5;
+
+            //Analog
+            AudioVideoSource = 1;
         }
 
         public override void OffsetJoinNumbers(uint joinStart)
@@ -63,6 +70,7 @@ namespace PepperDash.Essentials.Bridges
             EdidName = EdidName + joinOffset;
             EdidPrefferedTiming = EdidPrefferedTiming + joinOffset;
             EdidSerialNumber = EdidSerialNumber + joinOffset;
+            AudioVideoSource = AudioVideoSource + joinOffset;
         }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmRmcControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmRmcControllerJoinMap.cs
@@ -39,6 +39,10 @@ namespace PepperDash.Essentials.Core.Bridges
         public uint EdidSerialNumber { get; set; }
         #endregion
 
+        #region Analogs
+        public uint AudioVideoSource { get; set; }
+        #endregion
+
         public DmRmcControllerJoinMap()
         {
             // Digital
@@ -50,6 +54,9 @@ namespace PepperDash.Essentials.Core.Bridges
             EdidName = 3;
             EdidPrefferedTiming = 4;
             EdidSerialNumber = 5;
+
+            //Analog
+            AudioVideoSource = 1;
         }
 
         public override void OffsetJoinNumbers(uint joinStart)
@@ -62,6 +69,7 @@ namespace PepperDash.Essentials.Core.Bridges
             EdidName = EdidName + joinOffset;
             EdidPrefferedTiming = EdidPrefferedTiming + joinOffset;
             EdidSerialNumber = EdidSerialNumber + joinOffset;
+            AudioVideoSource = AudioVideoSource + joinOffset;
         }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
@@ -91,11 +91,13 @@ namespace PepperDash.Essentials.Core
         void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type);
     }
 
+    /// <summary>
+    /// Defines a receiver that has internal routing (DM-RMC-4K-Z-SCALER-C)
+    /// </summary>
     public interface IRmcRouting : IRouting
     {
         IntFeedback AudioVideoSourceNumericFeedback { get; }
         void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type);
-
     }
 
 	/// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
@@ -91,6 +91,13 @@ namespace PepperDash.Essentials.Core
         void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type);
     }
 
+    public interface IRmcRouting : IRouting
+    {
+        IntFeedback AudioVideoSourceNumericFeedback { get; }
+        void ExecuteNumericSwitch(ushort input, ushort output, eRoutingSignalType type);
+
+    }
+
 	/// <summary>
 	/// Defines an IRoutingOutputs devices as being a source - the start of the chain
 	/// </summary>

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.DM;
+using Crestron.SimplSharpPro.DM.Endpoints;
+using Crestron.SimplSharpPro.DM.Endpoints.Receivers;
+
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Core;
+
+namespace PepperDash.Essentials.DM
+{
+    public class DmRmc4kZScalerCController : DmRmcControllerBase, IRmcRouting,
+        IIRInputPort, IComPorts, ICec
+    {
+        DmRmc4kzScalerC Rmc { get; private set; }
+
+        public RoutingInputPort DmIn { get; private set; }
+        public RoutingInputPort HdmiIn { get; private set; }
+        public RoutingOutputPort HdmiOut { get; private set; }
+
+        /// <summary>
+        /// The value of the current video source for the HDMI output on the receiver
+        /// </summary>
+        public IntFeedback AudioVideoSourceNumericFeedback { get; private set; }
+
+        public RoutingPortCollection<RoutingInputPort> InputPorts
+        {
+            get { return new RoutingPortCollection<RoutingInputPort> { DmIn, HdmiIn }; }
+        }
+
+        public RoutingPortCollection<RoutingOutputPort> OutputPorts
+        {
+            get { return new RoutingPortCollection<RoutingOutputPort> { HdmiOut }; }
+        }
+
+        public DmRmc4kZScalerCController(string key, string name, DmRmc4kzScalerC rmc)
+            : base(key, name, rmc)
+        {
+            Rmc = rmc;
+            DmIn = new RoutingInputPort(DmPortName.DmIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
+                eRoutingPortConnectionType.DmCat, 0, this);
+            HdmiIn = new RoutingInputPort(DmPortName.HdmiIn, eRoutingSignalType.Audio | eRoutingSignalType.Video,
+                eRoutingPortConnectionType.Hdmi, 0, this);
+            HdmiOut = new RoutingOutputPort(DmPortName.HdmiOut, eRoutingSignalType.Audio | eRoutingSignalType.Video,
+                eRoutingPortConnectionType.Hdmi, null, this);
+
+            EdidManufacturerFeedback = new StringFeedback(() => Rmc.HdmiOutput.ConnectedDevice.Manufacturer.StringValue);
+            EdidNameFeedback = new StringFeedback(() => Rmc.HdmiOutput.ConnectedDevice.Name.StringValue);
+            EdidPreferredTimingFeedback = new StringFeedback(() => Rmc.HdmiOutput.ConnectedDevice.PreferredTiming.StringValue);
+            EdidSerialNumberFeedback = new StringFeedback(() => Rmc.HdmiOutput.ConnectedDevice.SerialNumber.StringValue);
+
+            VideoOutputResolutionFeedback = new StringFeedback(() => Rmc.HdmiOutput.GetVideoResolutionString());
+
+            Rmc.HdmiOutput.OutputStreamChange += HdmiOutput_OutputStreamChange;
+            Rmc.HdmiOutput.ConnectedDevice.DeviceInformationChange += ConnectedDevice_DeviceInformationChange;
+
+            // Set Ports for CEC
+            HdmiOut.Port = Rmc.HdmiOutput;
+
+            AudioVideoSourceNumericFeedback = new IntFeedback(() => (ushort)(Rmc.SelectedSourceFeedback));
+        }
+
+        void HdmiOutput_OutputStreamChange(EndpointOutputStream outputStream, EndpointOutputStreamEventArgs args)
+        {
+            if (args.EventId == EndpointOutputStreamEventIds.HorizontalResolutionFeedbackEventId || args.EventId == EndpointOutputStreamEventIds.VerticalResolutionFeedbackEventId ||
+                args.EventId == EndpointOutputStreamEventIds.FramesPerSecondFeedbackEventId)
+            {
+                VideoOutputResolutionFeedback.FireUpdate();
+            }
+
+            if (args.EventId == EndpointOutputStreamEventIds.SelectedSourceFeedbackEventId)
+            {
+                AudioVideoSourceNumericFeedback.FireUpdate();
+            }
+        }
+
+        void ConnectedDevice_DeviceInformationChange(ConnectedDeviceInformation connectedDevice, ConnectedDeviceEventArgs args)
+        {
+            if (args.EventId == ConnectedDeviceEventIds.ManufacturerEventId)
+            {
+                EdidManufacturerFeedback.FireUpdate();
+            }
+            else if (args.EventId == ConnectedDeviceEventIds.NameEventId)
+            {
+                EdidNameFeedback.FireUpdate();
+            }
+            else if (args.EventId == ConnectedDeviceEventIds.PreferredTimingEventId)
+            {
+                EdidPreferredTimingFeedback.FireUpdate();
+            }
+            else if (args.EventId == ConnectedDeviceEventIds.SerialNumberEventId)
+            {
+                EdidSerialNumberFeedback.FireUpdate();
+            }
+        }
+
+        public override bool CustomActivate()
+        {
+            // Base does register and sets up comm monitoring.
+            return base.CustomActivate();
+        }
+
+        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        {
+            LinkDmRmcToApi(this, trilist, joinStart, joinMapKey, bridge);
+        }
+
+        #region IIROutputPorts Members
+        public CrestronCollection<IROutputPort> IROutputPorts { get { return Rmc.IROutputPorts; } }
+        public int NumberOfIROutputPorts { get { return Rmc.NumberOfIROutputPorts; } }
+        #endregion
+
+        #region IComPorts Members
+        public CrestronCollection<ComPort> ComPorts { get { return Rmc.ComPorts; } }
+        public int NumberOfComPorts { get { return Rmc.NumberOfComPorts; } }
+        #endregion
+
+        #region ICec Members
+        /// <summary>
+        /// Gets the CEC stream directly from the HDMI port.
+        /// </summary>
+        public Cec StreamCec { get { return Rmc.HdmiOutput.StreamCec; } }
+        #endregion
+
+
+        #region IRmcRouting Members
+        public void ExecuteSwitch(object inputSelector, object outputSelector, eRoutingSignalType signalType)
+        {
+            Debug.Console(2, this, "Attempting a route from input {0} to HDMI Output", inputSelector);
+
+            var number = Convert.ToUInt16(inputSelector);
+
+            Rmc.AudioVideoSource = (DmRmc4kzScalerC.eAudioVideoSource)number;
+        }
+
+        public void ExecuteNumericSwitch(uint inputSelector, uint outputSelector, eRoutingSignalType signalType)
+        {
+            Debug.Console(2, this, "Attempting a route from input {0} to HDMI Output", inputSelector);
+
+            Rmc.AudioVideoSource = (DmRmc4kzScalerC.eAudioVideoSource)inputSelector;
+        }
+        #endregion
+
+    }
+}

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
@@ -16,9 +16,9 @@ using PepperDash.Core;
 namespace PepperDash.Essentials.DM
 {
     public class DmRmc4kZScalerCController : DmRmcControllerBase, IRmcRouting,
-        IIRInputPort, IComPorts, ICec
+        IIROutputPorts, IComPorts, ICec
     {
-        DmRmc4kzScalerC Rmc { get; private set; }
+        public DmRmc4kzScalerC Rmc { get; private set; }
 
         public RoutingInputPort DmIn { get; private set; }
         public RoutingInputPort HdmiIn { get; private set; }
@@ -139,7 +139,7 @@ namespace PepperDash.Essentials.DM
             Rmc.AudioVideoSource = (DmRmc4kzScalerC.eAudioVideoSource)number;
         }
 
-        public void ExecuteNumericSwitch(uint inputSelector, uint outputSelector, eRoutingSignalType signalType)
+        public void ExecuteNumericSwitch(ushort inputSelector, ushort outputSelector, eRoutingSignalType signalType)
         {
             Debug.Console(2, this, "Attempting a route from input {0} to HDMI Output", inputSelector);
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -37,8 +37,8 @@ namespace PepperDash.Essentials.DM
             AddToFeedbackList(VideoOutputResolutionFeedback, EdidManufacturerFeedback, EdidSerialNumberFeedback, EdidNameFeedback, EdidPreferredTimingFeedback);
         }
 
-	    protected void LinkDmRmcToApi(DmRmcControllerBase rmc, BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
-	    {
+        protected void LinkDmRmcToApi(DmRmcControllerBase rmc, BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        {
             var joinMap = new DmRmcControllerJoinMap();
 
             var joinMapSerialized = JoinMapHelper.GetSerializedJoinMapForDevice(joinMapKey);
@@ -61,7 +61,18 @@ namespace PepperDash.Essentials.DM
                 rmc.EdidPreferredTimingFeedback.LinkInputSig(trilist.StringInput[joinMap.EdidPrefferedTiming]);
             if (rmc.EdidSerialNumberFeedback != null)
                 rmc.EdidSerialNumberFeedback.LinkInputSig(trilist.StringInput[joinMap.EdidSerialNumber]);
-	    }
+            
+            //If the device is an DM-RMC-4K-Z-SCALER-C
+            var routing = rmc as IRmcRouting;
+
+            if (routing != null) 
+            {
+                if (routing.AudioVideoSourceNumericFeedback != null)
+                    routing.AudioVideoSourceNumericFeedback.LinkInputSig(trilist.UShortInput[joinMap.AudioVideoSource]);
+
+                trilist.SetUShortSigAction(joinMap.AudioVideoSource, (a) => routing.ExecuteNumericSwitch(a, 1, eRoutingSignalType.AudioVideo));
+            }
+        }
 	}
 
     public abstract class DmHdBaseTControllerBase : CrestronGenericBaseDevice
@@ -165,6 +176,8 @@ namespace PepperDash.Essentials.DM
 						return new DmRmc4kScalerCController(key, name, new DmRmc4kScalerC(ipid, Global.ControlSystem));
                     if (typeName.StartsWith("dmrmc4kscalercdsp"))
                         return new DmRmc4kScalerCDspController(key, name, new DmRmc4kScalerCDsp(ipid, Global.ControlSystem));
+                    if (typeName.StartsWith("dmrmc4kzscalerc"))
+                        return new DmRmc4kZScalerCController(key, name, new DmRmc4kzScalerC(ipid, Global.ControlSystem));
 				}
 				catch (Exception e)
 				{
@@ -238,6 +251,8 @@ namespace PepperDash.Essentials.DM
 							return new DmRmc4kScalerCController(key, name, new DmRmc4kScalerC(chassis.Outputs[num]));
 						if (typeName.StartsWith("dmrmc4kscalercdsp"))
 							return new DmRmc4kScalerCDspController(key, name, new DmRmc4kScalerCDsp(chassis.Outputs[num]));
+                        if (typeName.StartsWith("dmrmc4kzscalerc"))
+                            return new DmRmc4kZScalerCController(key, name, new DmRmc4kzScalerC(chassis.Outputs[num]));
 					}
 					else
 					{
@@ -271,6 +286,9 @@ namespace PepperDash.Essentials.DM
 							return new DmRmc4kScalerCController(key, name, new DmRmc4kScalerC(ipid, chassis.Outputs[num]));
 						if (typeName.StartsWith("dmrmc4kscalercdsp"))
 							return new DmRmc4kScalerCDspController(key, name, new DmRmc4kScalerCDsp(ipid, chassis.Outputs[num]));
+                        if (typeName.StartsWith("dmrmc4kzscalerc"))
+                            return new DmRmc4kZScalerCController(key, name, new DmRmc4kzScalerC(chassis.Outputs[num]));
+
 					}
 				}
 				catch (Exception e)
@@ -288,7 +306,8 @@ namespace PepperDash.Essentials.DM
         public DmRmcControllerFactory()
         {
             TypeNames = new List<string>() { "hdbasetrx", "dmrmc4k100c1g", "dmrmc100c", "dmrmc100s", "dmrmc4k100c", "dmrmc150s",
-                "dmrmc200c", "dmrmc200s", "dmrmc200s2", "dmrmcscalerc", "dmrmcscalers", "dmrmcscalers2", "dmrmc4kscalerc", "dmrmc4kscalercdsp" };
+                "dmrmc200c", "dmrmc200s", "dmrmc200s2", "dmrmcscalerc", "dmrmcscalers", "dmrmcscalers2", "dmrmc4kscalerc", "dmrmc4kscalercdsp",
+                "dmrmc4kzscalerc" };
         }
 
         public override EssentialsDevice BuildDevice(DeviceConfig dc)

--- a/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
+++ b/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Chassis\DmpsInternalVirtualDmTxController.cs" />
     <Compile Include="Chassis\DmpsRoutingController.cs" />
     <Compile Include="Chassis\HdMdNxM4kEController.cs" />
+    <Compile Include="Endpoints\Receivers\DmRmc4kZScalerCController.cs" />
     <Compile Include="Endpoints\Transmitters\TxInterfaces.cs" />
     <Compile Include="IDmSwitch.cs" />
     <Compile Include="Config\DmpsRoutingConfig.cs" />


### PR DESCRIPTION
Added a new Interface to support the internal routing for the DM-RMC-4K-Z-Scaler-C and added a device controller for the same, including it as a valid device in the DmRmcHelper class.