### PR TITLE
Fix DM-TX-4KZ-302-C Audio feedback and routing

### DIFF
--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
@@ -109,7 +109,8 @@ namespace PepperDash.Essentials.DM
             });
             AudioSourceNumericFeedback = new IntFeedback(() =>
             {
-                return (int)Tx.AudioSourceFeedback;
+                //Doing this because 4kz302 does not allow for breakaway audio source selection
+                return (int)Tx.VideoSourceFeedback;
             });
 
             HdmiIn1HdcpCapabilityFeedback = new IntFeedback("HdmiIn1HdcpCapability", () =>
@@ -250,7 +251,11 @@ namespace PepperDash.Essentials.DM
             // NOTE:  It's possible that this particular TX model may not like the AudioSource property being set.  
             // The SIMPL definition only shows a single analog for AudioVideo Source
             if ((signalType | eRoutingSignalType.Audio) == eRoutingSignalType.Audio)
-                Tx.AudioSource = (eAst)inputSelector;
+            {
+                //it doesn't...
+                Debug.Console(2, this, "Unable to execute audio-only switch for tx {0}", Key);
+                //Tx.AudioSource = (eAst) inputSelector;
+            }
         }
 
         void InputStreamChangeEvent(EndpointInputStream inputStream, EndpointInputStreamEventArgs args)


### PR DESCRIPTION
closes #155 
Audio Feedback will now reflect the video source always, as the DM-TX-4KZ-302-C does not support breakaway audio routing. Attempting to set the Audio source using the ExecuteSwitch method with a type of Audio will log a debug message at level 2.