### PR TITLE
Update DeviceManager to provide protections for multiple threads or reentrancy

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -26,6 +26,8 @@ namespace PepperDash.Essentials
     {
         HttpLogoServer LogoServer;
 
+        private CTimer _startTimer;
+        private const long StartupTime = 500;
 
         public ControlSystem()
             : base()
@@ -39,6 +41,11 @@ namespace PepperDash.Essentials
         /// Entry point for the program
         /// </summary>
         public override void InitializeSystem()
+        {
+            _startTimer = new CTimer(StartSystem,StartupTime);
+        }
+
+        private void StartSystem(object obj)
         {
             DeterminePlatform();
 
@@ -75,11 +82,11 @@ namespace PepperDash.Essentials
             }, "showconfig", "Shows the current running merged config", ConsoleAccessLevelEnum.AccessOperator);
 
             CrestronConsole.AddNewConsoleCommand(s =>
-                {
-                    CrestronConsole.ConsoleCommandResponse("This system can be found at the following URLs:\r" +
-                        "System URL:   {0}\r" +
-                        "Template URL: {1}", ConfigReader.ConfigObject.SystemUrl, ConfigReader.ConfigObject.TemplateUrl);
-                }, "portalinfo", "Shows portal URLS from configuration", ConsoleAccessLevelEnum.AccessOperator);
+            {
+                CrestronConsole.ConsoleCommandResponse("This system can be found at the following URLs:\r" +
+                    "System URL:   {0}\r" +
+                    "Template URL: {1}", ConfigReader.ConfigObject.SystemUrl, ConfigReader.ConfigObject.TemplateUrl);
+            }, "portalinfo", "Shows portal URLS from configuration", ConsoleAccessLevelEnum.AccessOperator);
 
 
             if (!Debug.DoNotLoadOnNextBoot)


### PR DESCRIPTION
closes #147 

I added protections to prevent classes from attempting to manipulate the IKeyed dictionary as the collection is being iterated and devices are being activated. This includes a CCriticalSection and the associated leave/enter logic when the activation cycle is being run, as well as in the AddDevices method.

There is now a boolean that is set to false when the activation cycle is complete. Attempting to add a device after the activation cycle is no longer allowed. Calling the AddDevice method after the activation cycle will result in a console message and an Error Log entry, and the device will NOT be added.