### PR TITLE
Fix incorrect cast in GenericComm LinkToApi method

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/GenericComm.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Config/Comm and IR/GenericComm.cs
@@ -96,7 +96,7 @@ namespace PepperDash.Essentials.Core
             trilist.SetStringSigAction(joinMap.SetPortConfig.JoinNumber, SetPortConfig);
 
 
-            var sComm = this as ISocketStatus;
+            var sComm = CommPort as ISocketStatus;
             if (sComm == null) return;
             sComm.ConnectionChange += (s, a) =>
             {

--- a/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
+++ b/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
@@ -84,7 +84,7 @@
     </Reference>
     <Reference Include="SimplSharpReflectionInterface, Version=1.0.5583.25238, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpReflectionInterface.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Closes #215 

Changed the `GenericComm` `LinkToApi` method to check that the internal `CommPort` property implements the `ISocketStatus` interface instead of the `GenericComm` device. 