### PR TITLE
Update RemoteOccupancy Info to send data via string

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -107,6 +107,8 @@ namespace PepperDash.Essentials.Core.Fusion
 
         public long PushNotificationTimeout = 5000;
 
+	    private const string RemoteOccupancyXml = "<Occupancy><Type>Local</Type><State>{0}</State></Occupancy>";
+
         protected Dictionary<int, FusionAsset> FusionStaticAssets;
 
         // For use with local occ sensor devices which will relay to Fusion the current occupancy status
@@ -1381,8 +1383,7 @@ namespace PepperDash.Essentials.Core.Fusion
 
         void RoomIsOccupiedFeedback_OutputChange(object sender, FeedbackEventArgs e)
         {
-            _roomOccupancyRemoteString = e.BoolValue ? @"<Occupancy><Type>Local</Type><State>Occupied</State></Occupancy>" 
-                : @"<Occupancy><Type>Local</Type><State>Unoccupied</State></Occupancy>";
+            _roomOccupancyRemoteString = String.Format(RemoteOccupancyXml, e.BoolValue ? "Occupied" : "Unoccupied");
             RoomOccupancyRemoteStringFeedback.FireUpdate();
         }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -117,6 +117,9 @@ namespace PepperDash.Essentials.Core.Fusion
 
         public BoolFeedback RoomIsOccupiedFeedback { get; private set; }
 
+	    private string _roomOccupancyRemoteString;
+        public StringFeedback RoomOccupancyRemoteStringFeedback { get; private set; }
+
         protected Func<bool> RoomIsOccupiedFeedbackFunc
         {
             get
@@ -1366,13 +1369,24 @@ namespace PepperDash.Essentials.Core.Fusion
                 
                 // Tie to method on occupancy object
                 //occSensorShutdownMinutes.OutputSig.UserObject(new Action(ushort)(b => Room.OccupancyObj.SetShutdownMinutes(b));
-                
 
+
+                RoomOccupancyRemoteStringFeedback = new StringFeedback(() => _roomOccupancyRemoteString);
                 Room.RoomOccupancy.RoomIsOccupiedFeedback.LinkInputSig(occSensorAsset.RoomOccupied.InputSig);
+                Room.RoomOccupancy.RoomIsOccupiedFeedback.OutputChange += RoomIsOccupiedFeedback_OutputChange;
+                RoomOccupancyRemoteStringFeedback.LinkInputSig(occSensorAsset.RoomOccupancyInfo.InputSig);
+                
             //}
         }
 
-		/// <summary>
+        void RoomIsOccupiedFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            _roomOccupancyRemoteString = e.BoolValue ? @"<Occupancy><Type>Local</Type><State>Occupied</State></Occupancy>" 
+                : @"<Occupancy><Type>Local</Type><State>Unoccupied</State></Occupancy>";
+            RoomOccupancyRemoteStringFeedback.FireUpdate();
+        }
+
+	    /// <summary>
 		/// Helper to get the number from the end of a device's key string
 		/// </summary>
 		/// <returns>-1 if no number matched</returns>


### PR DESCRIPTION
Added new string tracking for the RemoteOccupancyObject replicating the way it's handled by the Fusion SSI modules.  It's a fairly simple XML, and I think i did this right, but please check my work!