### PR TITLE
Add BasicDmTxControllerBase back

### DIFF
--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
@@ -599,7 +599,7 @@ namespace PepperDash.Essentials.DM {
                 {
                     Debug.Console(2, "Creating Tx Feedbacks {0}", ioSlot);
                     var txKey = TxDictionary[ioSlot];
-                    var basicTxDevice = DeviceManager.GetDeviceForKey(txKey) as DmTxControllerBase;
+                    var basicTxDevice = DeviceManager.GetDeviceForKey(txKey) as BasicDmTxControllerBase;
 
                     var advancedTxDevice = basicTxDevice as DmTxControllerBase;
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -1154,9 +1154,9 @@ namespace PepperDash.Essentials.DM
                 {
                     Debug.Console(2, "Creating Tx Feedbacks {0}", ioSlot);
                     var txKey = TxDictionary[ioSlot];
-                    var basicTxDevice = DeviceManager.GetDeviceForKey(txKey) as DmTxControllerBase;
+                    var basicTxDevice = DeviceManager.GetDeviceForKey(txKey) as BasicDmTxControllerBase;
 
-                    var advancedTxDevice = basicTxDevice;
+                    var advancedTxDevice = basicTxDevice as DmTxControllerBase;
 
                     if (Chassis is DmMd8x8Cpu3 || Chassis is DmMd8x8Cpu3rps
                         || Chassis is DmMd16x16Cpu3 || Chassis is DmMd16x16Cpu3rps

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k100Controller.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k100Controller.cs
@@ -3,6 +3,7 @@
 using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM;
 using Crestron.SimplSharpPro.DM.Endpoints.Transmitters;
+using PepperDash.Core;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Bridges;
 
@@ -11,7 +12,7 @@ namespace PepperDash.Essentials.DM
     using eVst = eX02VideoSourceType;
     using eAst = eX02AudioSourceType;
 
-    public class DmTx4k100Controller : DmTxControllerBase, IRoutingInputsOutputs,
+    public class DmTx4k100Controller : BasicDmTxControllerBase, IRoutingInputsOutputs,
         IIROutputPorts, IComPorts, ICec
     {
         public DmTx4K100C1G Tx { get; private set; }
@@ -72,9 +73,7 @@ namespace PepperDash.Essentials.DM
 
         public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
-            DmTxControllerJoinMap joinMap = GetDmTxJoinMap(joinStart, joinMapKey);
-
-            LinkDmTxToApi(this, trilist, joinMap, bridge);
+            Debug.Console(1, this, "No properties to link. Skipping device {0}", Name);
         }
 
         #region IIROutputPorts Members
@@ -90,7 +89,5 @@ namespace PepperDash.Essentials.DM
         #region ICec Members
         public Cec StreamCec { get { return Tx.StreamCec; } }
         #endregion
-
-        public override StringFeedback ActiveVideoInputFeedback { get; protected set; }
     }
 }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
@@ -27,7 +27,7 @@ namespace PepperDash.Essentials.DM
 		/// <param name="name"></param>
 		/// <param name="props"></param>
 		/// <returns></returns>
-        public static DmTxControllerBase GetDmTxController(string key, string name, string typeName, DmTxPropertiesConfig props)
+        public static BasicDmTxControllerBase GetDmTxController(string key, string name, string typeName, DmTxPropertiesConfig props)
 		{
 			// switch on type name... later...
 
@@ -157,11 +157,20 @@ namespace PepperDash.Essentials.DM
 		}
 	}
 
+    public abstract class BasicDmTxControllerBase : CrestronGenericBridgeableBaseDevice
+    {
+        protected BasicDmTxControllerBase(string key, string name, GenericBase hardware)
+            : base(key, name, hardware)
+        {
+
+        }
+    }
+
 	/// <summary>
 	/// 
 	/// </summary>
     [Description("Wrapper class for all DM-TX variants")]
-	public abstract class DmTxControllerBase : CrestronGenericBridgeableBaseDevice
+	public abstract class DmTxControllerBase : BasicDmTxControllerBase
 	{
         public virtual void SetPortHdcpCapability(eHdcpCapabilityType hdcpMode, uint port) { }
         public virtual eHdcpCapabilityType HdcpSupportCapability { get; protected set; }
@@ -197,13 +206,7 @@ namespace PepperDash.Essentials.DM
 
 	    protected void LinkDmTxToApi(DmTxControllerBase tx, BasicTriList trilist, DmTxControllerJoinMap joinMap, EiscApiAdvanced bridge)
 	    {
-	        if (tx.Hardware is DmHDBasedTEndPoint)
-	        {
-	            Debug.Console(1, tx, "No properties to link. Skipping device {0}", tx.Name);
-	            return;
-	        }
-
-            Debug.Console(1, tx, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
+	        Debug.Console(1, tx, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 
             tx.IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.IsOnline.JoinNumber]);
             tx.AnyVideoInput.VideoStatus.VideoSyncFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoSyncStatus.JoinNumber]);


### PR DESCRIPTION
closes #240 
BasicDmTxControllerBase was removed without checking other places it was used, hence it caused some null reference errors. Adding it back in, and adjusting bridging in DmChassisController and in the 1 class that inherits from BasicDmTxControllerBase