### PR TITLE
Add backwards compatability with `IBridge` to `EiscApiAdvanced`

### DIFF
--- a/PepperDashEssentials/Bridges/IBridge.cs
+++ b/PepperDashEssentials/Bridges/IBridge.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Crestron.SimplSharpPro.DeviceSupport;
 
 namespace PepperDash.Essentials.Bridges
 {
@@ -7,8 +6,7 @@ namespace PepperDash.Essentials.Bridges
     /// Defines a device that uses the legacy JoinMapBase for its join map
     /// </summary>
     [Obsolete("IBridgeAdvanced should be used going forward with JoinMapBaseAdvanced")]
-    public interface IBridge
+    public interface IBridge:Core.Bridges.IBridge
     {
-        void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey);
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -110,15 +110,24 @@ namespace PepperDash.Essentials.Core.Bridges
                     if (device == null) continue;
 
                     Debug.Console(1, this, "Linking Device: '{0}'", device.Key);
-                    //if (device is IBridge)      // Check for this first to allow bridges in plugins to override existing bridges that apply to the same type.
-                    //{
-                    //    Debug.Console(2, this, "'{0}' is IBridge", device.Key);
-                    //}
+
+                    if (typeof (IBridge).IsAssignableFrom(device.GetType().GetCType()))
+                    {
+                        var basicBridge = device as IBridge;
+                        if (basicBridge != null)
+                        {
+                            Debug.Console(0, this, Debug.ErrorLogLevel.Notice,
+                                "Linking EiscApiAdvanced {0} to device {1} using obsolete join map. Please update the device's join map.",
+                                Key, device.Key);
+                            basicBridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey);
+                        }
+                        continue;
+                    }
+
                     if (!typeof (IBridgeAdvanced).IsAssignableFrom(device.GetType().GetCType()))
                     {
                         continue;
                     }
-
                     var bridge = device as IBridgeAdvanced;
                     if (bridge != null) bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
                 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/IBridge.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/IBridge.cs
@@ -1,13 +1,19 @@
 ﻿using System;
 using Crestron.SimplSharpPro.DeviceSupport;
+using PepperDash.Core;
 
 namespace PepperDash.Essentials.Core.Bridges
 {
     /// <summary>
     /// Defines a device that uses JoinMapBaseAdvanced for its join map
     /// </summary>
-    public interface IBridgeAdvanced
+    public interface IBridgeAdvanced:IKeyed
     {
         void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge);
     }
+
+    public interface IBridge:IKeyed
+    {
+        void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey);
+    }   
 }


### PR DESCRIPTION
closes #237 

I created `IBridge` in `PepperDash.Essentials.Core` and modified the version in `PepperDash.Essentials` to inherit from the one in core. Also added logic for linking `IBridge` devices to `EiscApiAdvanced` bridges.