### PR TITLE
Add 3-series Card Support

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3CardControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3CardControllerBase.cs
@@ -1,0 +1,16 @@
+﻿using Crestron.SimplSharpPro;
+using Crestron.SimplSharpProInternal;
+using PepperDash.Essentials.Core;
+
+namespace PepperDash_Essentials_Core.Crestron_IO.Cards
+{
+    public class C3CardControllerBase:CrestronGenericBaseDevice
+    {
+        private C3Card _card;
+
+        public C3CardControllerBase(string key, string name, C3Card hardware) : base(key, name, hardware)
+        {
+            _card = hardware;
+        }
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3CardControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3CardControllerBase.cs
@@ -1,16 +1,24 @@
-﻿using Crestron.SimplSharpPro;
+﻿using System;
 using Crestron.SimplSharpProInternal;
-using PepperDash.Essentials.Core;
 
-namespace PepperDash_Essentials_Core.Crestron_IO.Cards
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
 {
     public class C3CardControllerBase:CrestronGenericBaseDevice
     {
-        private C3Card _card;
+        private readonly C3Card _card;
 
         public C3CardControllerBase(string key, string name, C3Card hardware) : base(key, name, hardware)
         {
             _card = hardware;
         }
+
+        #region Overrides of Object
+
+        public override string ToString()
+        {
+            return String.Format("{0} {1}", Key, _card.ToString());
+        }
+
+        #endregion
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Com3Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Com3Controller.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Crestron.SimplSharp;
-using Crestron.SimplSharpPro;
-using Crestron.SimplSharpPro.DeviceSupport;
+﻿using Crestron.SimplSharpPro;
 using Crestron.SimplSharpPro.ThreeSeriesCards;
-using PepperDash.Essentials.Core;
-using PepperDash.Essentials.Core.Bridges;
 
-namespace PepperDash_Essentials_Core.Crestron_IO.Cards
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
 {
     public class C3Com3Controller:C3CardControllerBase, IComPorts
     {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Com3Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Com3Controller.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+
+namespace PepperDash_Essentials_Core.Crestron_IO.Cards
+{
+    public class C3Com3Controller:C3CardControllerBase, IComPorts
+    {
+        private readonly C3com3 _card;
+
+        public C3Com3Controller(string key, string name, C3com3 hardware) : base(key, name, hardware)
+        {
+            _card = hardware;
+        }
+
+        #region Implementation of IComPorts
+
+        public CrestronCollection<ComPort> ComPorts
+        {
+            get { return _card.ComPorts; }
+        }
+
+        public int NumberOfComPorts
+        {
+            get { return _card.NumberOfComPorts; }
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Io16Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Io16Controller.cs
@@ -1,0 +1,29 @@
+﻿using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    public class C3Io16Controller:C3CardControllerBase,IIOPorts
+    {
+        private readonly C3io16 _card;
+
+        public C3Io16Controller(string key, string name, C3io16 hardware) : base(key, name, hardware)
+        {
+            _card = hardware;
+        }
+
+        #region Implementation of IIOPorts
+
+        public CrestronCollection<Versiport> VersiPorts
+        {
+            get { return _card.VersiPorts; }
+        }
+
+        public int NumberOfVersiPorts
+        {
+            get { return _card.NumberOfVersiPorts; }
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ir8Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ir8Controller.cs
@@ -1,0 +1,29 @@
+﻿using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    public class C3Ir8Controller:C3CardControllerBase, IIROutputPorts
+    {
+        private readonly C3ir8 _card;
+
+        public C3Ir8Controller(string key, string name, C3ir8 hardware) : base(key, name, hardware)
+        {
+            _card = hardware;
+        }
+
+        #region Implementation of IIROutputPorts
+
+        public CrestronCollection<IROutputPort> IROutputPorts
+        {
+            get { return _card.IROutputPorts; }
+        }
+
+        public int NumberOfIROutputPorts
+        {
+            get { return _card.NumberOfIROutputPorts; }
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry16Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry16Controller.cs
@@ -1,0 +1,29 @@
+﻿using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    public class C3Ry16Controller:C3CardControllerBase, IRelayPorts
+    {
+        private readonly C3ry16 _card;
+
+        public C3Ry16Controller(string key, string name, C3ry16 hardware) : base(key, name, hardware)
+        {
+            _card = hardware;
+        }
+
+        #region Implementation of IRelayPorts
+
+        public CrestronCollection<Relay> RelayPorts
+        {
+            get { return _card.RelayPorts; }
+        }
+
+        public int NumberOfRelayPorts
+        {
+            get { return _card.NumberOfRelayPorts; }
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry8Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry8Controller.cs
@@ -9,7 +9,7 @@ namespace PepperDash.Essentials.Core.CrestronIO.Cards
 
         public C3Ry8Controller(string key, string name, C3ry8 hardware) : base(key, name, hardware)
         {
-            _card = hardware
+            _card = hardware;
         }
 
         #region Implementation of IRelayPorts

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry8Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/C3Ry8Controller.cs
@@ -1,0 +1,29 @@
+﻿using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    public class C3Ry8Controller:C3CardControllerBase, IRelayPorts
+    {
+        private readonly C3ry8 _card;
+
+        public C3Ry8Controller(string key, string name, C3ry8 hardware) : base(key, name, hardware)
+        {
+            _card = hardware
+        }
+
+        #region Implementation of IRelayPorts
+
+        public CrestronCollection<Relay> RelayPorts
+        {
+            get { return _card.RelayPorts; }
+        }
+
+        public int NumberOfRelayPorts
+        {
+            get { return _card.NumberOfRelayPorts; }
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
@@ -7,6 +7,7 @@ using PepperDash.Essentials.Core.Config;
 
 namespace PepperDash.Essentials.Core.CrestronIO.Cards
 {
+    [ConfigSnippet("\"properties\":{\"card\":\"c3com3\"}")]
     public class CenCi31Controller : CrestronGenericBaseDevice
     {
         private const string CardKeyTemplate = "{0}-card";

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
@@ -9,7 +9,8 @@ namespace PepperDash.Essentials.Core.CrestronIO.Cards
 {
     public class CenCi31Controller : CrestronGenericBaseDevice
     {
-        private const string CardKeyTemplate = "{0}-card{1}";
+        private const string CardKeyTemplate = "{0}-card";
+        private const string CardNameTemplate = "{0}:{1}:{2}";
         private const uint CardSlot = 1;
         private readonly CenCi31 _cardCage;
         private readonly CenCi31Configuration _config;
@@ -27,9 +28,34 @@ namespace PepperDash.Essentials.Core.CrestronIO.Cards
                 {
                     "c3com3",
                     (c, s) =>
-                        new C3Com3Controller(String.Format(CardKeyTemplate, key, s),
-                            String.Format(CardKeyTemplate, key, s), new C3com3(_cardCage))
+                        new C3Com3Controller(String.Format(CardKeyTemplate, key),
+                            String.Format(CardNameTemplate, key, s, "C3Com3"), new C3com3(_cardCage))
                 },
+                {
+                    "c3io16",
+                    (c, s) =>
+                        new C3Io16Controller(String.Format(CardKeyTemplate, key),
+                            String.Format(CardNameTemplate, key, s,"C3Io16"), new C3io16(_cardCage))
+                },
+                {
+                    "c3ir8",
+                    (c, s) =>
+                        new C3Ir8Controller(String.Format(CardKeyTemplate, key),
+                            String.Format(CardNameTemplate, key, s, "C3Ir8"), new C3ir8(_cardCage))
+                },
+                {
+                    "c3ry16",
+                    (c, s) =>
+                        new C3Ry16Controller(String.Format(CardKeyTemplate, key),
+                            String.Format(CardNameTemplate, key, s, "C3Ry16"), new C3ry16(_cardCage))
+                },
+                {
+                    "c3ry8",
+                    (c, s) =>
+                        new C3Ry8Controller(String.Format(CardKeyTemplate, key),
+                            String.Format(CardNameTemplate, key, s, "C3Ry8"), new C3ry8(_cardCage))
+                },
+
             };
 
             GetCards();
@@ -38,13 +64,14 @@ namespace PepperDash.Essentials.Core.CrestronIO.Cards
         private void GetCards()
         {
             Func<CenCi31, uint, C3CardControllerBase> cardBuilder;
-
+            
             if (String.IsNullOrEmpty(_config.Card))
             {
-                
+                Debug.Console(0, this, "No card specified");
+                return;
             }
 
-            if (!_cardDict.TryGetValue(_config.Card, out cardBuilder))
+            if (!_cardDict.TryGetValue(_config.Card.ToLower(), out cardBuilder))
             {
                 Debug.Console(0, "Unable to find factory for 3-Series card type {0}.", _config.Card);
                 return;
@@ -62,9 +89,9 @@ namespace PepperDash.Essentials.Core.CrestronIO.Cards
         public string Card { get; set; }
     }
 
-    public class CenCi3ControllerFactory : EssentialsDeviceFactory<CenCi31Controller>
+    public class CenCi31ControllerFactory : EssentialsDeviceFactory<CenCi31Controller>
     {
-        public CenCi3ControllerFactory()
+        public CenCi31ControllerFactory()
         {
             TypeNames = new List<string> {"cenci31"};
         }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi31Controller.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+using Crestron.SimplSharpProInternal;
+using Newtonsoft.Json;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+
+namespace PepperDash_Essentials_Core.Crestron_IO.Cards
+{
+    public class CenCi31Controller :CrestronGenericBridgeableBaseDevice
+    {
+        private const string CardKeyTemplate = "{0}-card{1}";
+        private readonly CenCi31 _cardCage;
+        private CenCi3Configuration _config;
+
+        private Dictionary<string, Func<CenCi31, uint, C3CardControllerBase>> _cardDict; 
+
+        public CenCi31Controller(string key, string name, DeviceConfig config, CenCi31 hardware) : base(key, name, hardware)
+        {
+            _cardCage = hardware;
+            _config = config.Properties.ToObject<CenCi3Configuration>();
+
+            _cardDict = new Dictionary<string, Func<CenCi31, uint, C3CardControllerBase>>
+            {
+                {
+                    "c3com3",
+                    (c, s) =>
+                        new C3Com3Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardKeyTemplate, key, s), new C3com3(_cardCage))
+                },
+            };
+
+        }
+
+        private void GetCards()
+        {
+            foreach (var card in _config.Cards)
+            {
+                
+            }
+        }
+
+        #region Overrides of CrestronGenericBridgeableBaseDevice
+
+        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    public class CenCi3Configuration
+    {
+        [JsonProperty("cards")]
+        public Dictionary<uint, string> Cards { get; set; }
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi33Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi33Controller.cs
@@ -7,6 +7,7 @@ using PepperDash.Essentials.Core.Config;
 
 namespace PepperDash.Essentials.Core.CrestronIO.Cards
 {
+    [ConfigSnippet("\"properties\":{\"cards\":{\"1\":\"c3com3\",\"2\":\"c3ry16\",\"3\":\"c3ry8\"}}")]
     public class CenCi33Controller : CrestronGenericBaseDevice
     {
         private const string CardKeyTemplate = "{0}-card{1}";

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi33Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/CenCi33Controller.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+using Newtonsoft.Json;
+using PepperDash.Core;
+using PepperDash.Essentials.Core.Config;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    public class CenCi33Controller : CrestronGenericBaseDevice
+    {
+        private const string CardKeyTemplate = "{0}-card{1}";
+        private const string CardNameTemplate = "{0}:{1}:{2}";
+        private const uint CardSlots = 3;
+        private readonly CenCi33 _cardCage;
+        private readonly CenCi33Configuration _config;
+
+        private readonly Dictionary<string, Func<CenCi33, uint, C3CardControllerBase>> _cardDict; 
+
+        public CenCi33Controller(string key, string name, CenCi33Configuration config, CenCi33 hardware) : base(key, name, hardware)
+        {
+            _cardCage = hardware;
+
+            _config = config;
+
+            _cardDict = new Dictionary<string, Func<CenCi33, uint, C3CardControllerBase>>
+            {
+                {
+                    "c3com3",
+                    (c, s) =>
+                        new C3Com3Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Com3"), new C3com3(s,_cardCage))
+                },
+                {
+                    "c3io16",
+                    (c, s) =>
+                        new C3Io16Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Io16"), new C3io16(s,_cardCage))
+                },
+                {
+                    "c3ir8",
+                    (c, s) =>
+                        new C3Ir8Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ir8"), new C3ir8(s,_cardCage))
+                },
+                {
+                    "c3ry16",
+                    (c, s) =>
+                        new C3Ry16Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ry16"), new C3ry16(s,_cardCage))
+                },
+                {
+                    "c3ry8",
+                    (c, s) =>
+                        new C3Ry8Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ry8"), new C3ry8(s,_cardCage))
+                },
+
+            };
+
+            GetCards();
+        }
+
+        private void GetCards()
+        {
+            if (_config.Cards == null)
+            {
+                Debug.Console(0, this, "No card configuration for this device found");
+                return;
+            }
+
+            for (uint i = 1; i <= CardSlots; i++)
+            {
+                string cardType;
+                if (!_config.Cards.TryGetValue(i, out cardType))
+                {
+                    Debug.Console(1, this, "No card found for slot {0}", i);
+                    continue;
+                }
+
+                if (String.IsNullOrEmpty(cardType))
+                {
+                    Debug.Console(0, this, "No card specified for slot {0}", i);
+                    return;
+                }
+
+                Func<CenCi33, uint, C3CardControllerBase> cardBuilder;
+                if (!_cardDict.TryGetValue(cardType.ToLower(), out cardBuilder))
+                {
+                    Debug.Console(0, "Unable to find factory for 3-Series card type {0}.", cardType);
+                    return;
+                }
+
+                var device = cardBuilder(_cardCage, i);
+
+                DeviceManager.AddDevice(device);
+            }
+        }
+    }
+
+    public class CenCi33Configuration
+    {
+        [JsonProperty("cards")]
+        public Dictionary<uint, string> Cards { get; set; }
+    }
+
+    public class CenCi33ControllerFactory : EssentialsDeviceFactory<CenCi33Controller>
+    {
+        public CenCi33ControllerFactory()
+        {
+            TypeNames = new List<string> {"cenci33"};
+        }
+        #region Overrides of EssentialsDeviceFactory<CenCi33Controller>
+
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.Console(1, "Factory attempting to build new CEN-CI-3");
+
+            var controlProperties = CommFactory.GetControlPropertiesConfig(dc);
+            var ipId = controlProperties.IpIdInt;
+
+            var cardCage = new CenCi33(ipId, Global.ControlSystem);
+            var config = dc.Properties.ToObject<CenCi33Configuration>();
+
+            return new CenCi33Controller(dc.Key, dc.Name, config, cardCage);
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/InternalCardCageController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Cards/InternalCardCageController.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using Crestron.SimplSharpPro.ThreeSeriesCards;
+using Newtonsoft.Json;
+using PepperDash.Core;
+using PepperDash.Essentials.Core.Config;
+
+namespace PepperDash.Essentials.Core.CrestronIO.Cards
+{
+    [ConfigSnippet("\"properties\":{\"cards\":{\"1\":\"c3com3\",\"2\":\"c3ry16\",\"3\":\"c3ry8\"}}")]
+    public class InternalCardCageController : EssentialsDevice
+    {
+        private const string CardKeyTemplate = "{0}-card{1}";
+        private const string CardNameTemplate = "{0}:{1}:{2}";
+        private const uint CardSlots = 3;
+    
+        private readonly InternalCardCageConfiguration _config;
+
+        private readonly Dictionary<string, Func<uint, C3CardControllerBase>> _cardDict; 
+
+        public InternalCardCageController(string key, string name, InternalCardCageConfiguration config) : base(key, name)
+        {
+            _config = config;
+
+            _cardDict = new Dictionary<string, Func<uint, C3CardControllerBase>>
+            {
+                {
+                    "c3com3",
+                    (s) =>
+                        new C3Com3Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Com3"), new C3com3(s,Global.ControlSystem))
+                },
+                {
+                    "c3io16",
+                    (s) =>
+                        new C3Io16Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Io16"), new C3io16(s,Global.ControlSystem))
+                },
+                {
+                    "c3ir8",
+                    (s) =>
+                        new C3Ir8Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ir8"), new C3ir8(s,Global.ControlSystem))
+                },
+                {
+                    "c3ry16",
+                    (s) =>
+                        new C3Ry16Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ry16"), new C3ry16(s,Global.ControlSystem))
+                },
+                {
+                    "c3ry8",
+                    (s) =>
+                        new C3Ry8Controller(String.Format(CardKeyTemplate, key, s),
+                            String.Format(CardNameTemplate, key, s, "C3Ry8"), new C3ry8(s,Global.ControlSystem))
+                },
+
+            };
+
+            GetCards();
+        }
+
+        private void GetCards()
+        {
+            if (_config.Cards == null)
+            {
+                Debug.Console(0, this, "No card configuration for this device found");
+                return;
+            }
+
+            for (uint i = 1; i <= CardSlots; i++)
+            {
+                string cardType;
+                if (!_config.Cards.TryGetValue(i, out cardType))
+                {
+                    Debug.Console(1, this, "No card found for slot {0}", i);
+                    continue;
+                }
+
+                if (String.IsNullOrEmpty(cardType))
+                {
+                    Debug.Console(0, this, "No card specified for slot {0}", i);
+                    return;
+                }
+
+                Func<uint, C3CardControllerBase> cardBuilder;
+                if (!_cardDict.TryGetValue(cardType.ToLower(), out cardBuilder))
+                {
+                    Debug.Console(0, "Unable to find factory for 3-Series card type {0}.", cardType);
+                    return;
+                }
+
+                try
+                {
+                    var device = cardBuilder(i);
+
+
+                    DeviceManager.AddDevice(device);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Debug.Console(0, this, Debug.ErrorLogLevel.Error,
+                        "Unable to add card {0} to internal card cage.\r\nError Message: {1}\r\nStack Trace: {2}",
+                        cardType, ex.Message, ex.StackTrace);
+                }
+            }
+        }
+    }
+
+    public class InternalCardCageConfiguration
+    {
+        [JsonProperty("cards")]
+        public Dictionary<uint, string> Cards { get; set; }
+    }
+
+    public class InternalCardCageControllerFactory : EssentialsDeviceFactory<InternalCardCageController>
+    {
+        public InternalCardCageControllerFactory()
+        {
+            TypeNames = new List<string> {"internalcardcage"};
+        }
+        #region Overrides of EssentialsDeviceFactory<InternalCardCageController>
+
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.Console(1, "Factory attempting to build new Internal Card Cage Controller");
+
+            if (!Global.ControlSystem.SupportsThreeSeriesPlugInCards)
+            {
+                Debug.Console(0, Debug.ErrorLogLevel.Warning, "Current control system does NOT support 3-Series cards. Everything is NOT awesome.");
+                return null;
+            }
+
+            var config = dc.Properties.ToObject<InternalCardCageConfiguration>();
+
+            return new InternalCardCageController(dc.Key, dc.Name, config);
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Factory/DeviceFactory.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Factory/DeviceFactory.cs
@@ -103,7 +103,7 @@ namespace PepperDash.Essentials.Core
             // Check for types that have been added by plugin dlls. 
             if (FactoryMethods.ContainsKey(typeName))
             {
-                Debug.Console(0, Debug.ErrorLogLevel.Notice, "Loading '{0}' from plugin", dc.Type);
+                Debug.Console(0, Debug.ErrorLogLevel.Notice, "Loading '{0}' from Essentials Core", dc.Type);
                 return FactoryMethods[typeName].FactoryMethod(dc);
             }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -74,6 +74,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.Remotes.dll</HintPath>
     </Reference>
+    <Reference Include="Crestron.SimplSharpPro.ThreeSeriesCards, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.ThreeSeriesCards.dll</HintPath>
+    </Reference>
     <Reference Include="Crestron.SimplSharpPro.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.UI.dll</HintPath>
@@ -156,6 +160,13 @@
     <Compile Include="Config\Essentials\EssentialsConfig.cs" />
     <Compile Include="Config\SourceDevicePropertiesConfigBase.cs" />
     <Compile Include="Crestron IO\C2nRts\C2nRthsController.cs" />
+    <Compile Include="Crestron IO\Cards\C3CardControllerBase.cs" />
+    <Compile Include="Crestron IO\Cards\C3Com3Controller.cs" />
+    <Compile Include="Crestron IO\Cards\C3Io16Controller.cs" />
+    <Compile Include="Crestron IO\Cards\C3Ir8Controller.cs" />
+    <Compile Include="Crestron IO\Cards\C3Ry16Controller.cs" />
+    <Compile Include="Crestron IO\Cards\C3Ry8Controller.cs" />
+    <Compile Include="Crestron IO\Cards\CenCi31Controller.cs" />
     <Compile Include="Crestron IO\Inputs\CenIoDigIn104Controller.cs" />
     <Compile Include="Crestron IO\Inputs\GenericDigitalInputDevice.cs" />
     <Compile Include="Crestron IO\Inputs\GenericVersiportInputDevice.cs" />

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -170,6 +170,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Crestron IO\Cards\CenCi33Controller.cs" />
+    <Compile Include="Crestron IO\Cards\InternalCardCageController.cs" />
     <Compile Include="Crestron IO\Inputs\CenIoDigIn104Controller.cs" />
     <Compile Include="Crestron IO\Inputs\GenericDigitalInputDevice.cs" />
     <Compile Include="Crestron IO\Inputs\GenericVersiportInputDevice.cs" />

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -166,7 +166,10 @@
     <Compile Include="Crestron IO\Cards\C3Ir8Controller.cs" />
     <Compile Include="Crestron IO\Cards\C3Ry16Controller.cs" />
     <Compile Include="Crestron IO\Cards\C3Ry8Controller.cs" />
-    <Compile Include="Crestron IO\Cards\CenCi31Controller.cs" />
+    <Compile Include="Crestron IO\Cards\CenCi31Controller.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Crestron IO\Cards\CenCi33Controller.cs" />
     <Compile Include="Crestron IO\Inputs\CenIoDigIn104Controller.cs" />
     <Compile Include="Crestron IO\Inputs\GenericDigitalInputDevice.cs" />
     <Compile Include="Crestron IO\Inputs\GenericVersiportInputDevice.cs" />


### PR DESCRIPTION
closes #125 

This PR adds support for 3-Series card cages and all 5 cards. See attached file for test configuration. Prior to approving this, please test against hardware to verify operation.
[democonfigurationFile.txt](https://github.com/PepperDash/Essentials/files/4800050/democonfigurationFile.txt)
