### PR TITLE
Update bridging to eliminate null references & allow backwards compatibility

### DIFF
--- a/PepperDashEssentials/Bridges/EiscBridge.cs
+++ b/PepperDashEssentials/Bridges/EiscBridge.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Crestron.SimplSharp.Reflection;
 using Crestron.SimplSharpPro;
 using Crestron.SimplSharpPro.EthernetCommunication;
 using PepperDash.Core;
@@ -39,18 +40,30 @@ namespace PepperDash.Essentials.Bridges
                     if (device == null) continue;
 
                     Debug.Console(1, this, "Linking Device: '{0}'", device.Key);
-                    if (device is IBridge)      // Check for this first to allow bridges in plugins to override existing bridges that apply to the same type.
+                    if (typeof(IBridge).IsAssignableFrom(device.GetType().GetCType()))      // Check for this first to allow bridges in plugins to override existing bridges that apply to the same type.
                     {
                         Debug.Console(2, this, "'{0}' is IBridge", device.Key);
 
                         var dev = device as IBridge;
 
+                        if (dev == null)
+                        {
+                            Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Cast to IBridge failed for {0}");
+                            continue;
+                        }
+
                         dev.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey);
                     }
-                    if (!(device is IBridgeAdvanced)) continue;
+                    if (!typeof(IBridgeAdvanced).IsAssignableFrom(device.GetType().GetCType())) continue;
                     Debug.Console(2, this, "'{0}' is IBridgeAdvanced", device.Key);
 
                     var advDev = device as IBridgeAdvanced;
+
+                    if (advDev == null)
+                    {
+                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Cast to IBridgeAdvanced failed for {0}");
+                        continue;
+                    }
 
                     try
                     {
@@ -61,7 +74,6 @@ namespace PepperDash.Essentials.Bridges
                         Debug.ConsoleWithLog(0, this,
                             "Please update the bridge config to use EiscBridgeAdvanced with this device: {0}", device.Key);
                     }
-
                 }
                 Debug.Console(1, this, "Devices Linked.");
 

--- a/PepperDashEssentials/Bridges/IBridge.cs
+++ b/PepperDashEssentials/Bridges/IBridge.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Crestron.SimplSharpPro.DeviceSupport;
 
 namespace PepperDash.Essentials.Bridges
 {
@@ -6,7 +7,8 @@ namespace PepperDash.Essentials.Bridges
     /// Defines a device that uses the legacy JoinMapBase for its join map
     /// </summary>
     [Obsolete("IBridgeAdvanced should be used going forward with JoinMapBaseAdvanced")]
-    public interface IBridge:Core.Bridges.IBridge
+    public interface IBridge
     {
+        void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey);
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -7,7 +7,6 @@ using Crestron.SimplSharpPro.EthernetCommunication;
 using Newtonsoft.Json;
 
 using PepperDash.Core;
-using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
 
 //using PepperDash.Essentials.Devices.Common.Cameras;
@@ -111,28 +110,17 @@ namespace PepperDash.Essentials.Core.Bridges
 
                     Debug.Console(1, this, "Linking Device: '{0}'", device.Key);
 
-                    if (typeof (IBridge).IsAssignableFrom(device.GetType().GetCType()))
+                    if (!typeof (IBridgeAdvanced).IsAssignableFrom(device.GetType().GetCType()))
                     {
-                        var basicBridge = device as IBridge;
-                        if (basicBridge != null)
-                        {
-                            Debug.Console(0, this, Debug.ErrorLogLevel.Notice,
-                                "Linking EiscApiAdvanced {0} to device {1} using obsolete join map. Please update the device's join map.",
-                                Key, device.Key);
-                            basicBridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey);
-                        }
+                        Debug.Console(0, this, Debug.ErrorLogLevel.Notice,
+                            "{0} is not compatible with this bridge type. Please use 'eiscapi' instead, or updae the device.",
+                            device.Key);
                         continue;
                     }
 
-                    if (!typeof (IBridgeAdvanced).IsAssignableFrom(device.GetType().GetCType()))
-                    {
-                        continue;
-                    }
                     var bridge = device as IBridgeAdvanced;
                     if (bridge != null) bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
                 }
-
-                
             });
         }
 
@@ -303,7 +291,7 @@ namespace PepperDash.Essentials.Core.Bridges
     {
         public EiscApiAdvancedFactory()
         {
-            TypeNames = new List<string>() { "eiscapiadv", "eiscapiadvanced" };
+            TypeNames = new List<string> { "eiscapiadv", "eiscapiadvanced" };
         }
 
         public override EssentialsDevice BuildDevice(DeviceConfig dc)

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/IBridge.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/IBridge.cs
@@ -1,19 +1,12 @@
-﻿using System;
-using Crestron.SimplSharpPro.DeviceSupport;
-using PepperDash.Core;
+﻿using Crestron.SimplSharpPro.DeviceSupport;
 
 namespace PepperDash.Essentials.Core.Bridges
 {
     /// <summary>
     /// Defines a device that uses JoinMapBaseAdvanced for its join map
     /// </summary>
-    public interface IBridgeAdvanced:IKeyed
+    public interface IBridgeAdvanced
     {
         void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge);
     }
-
-    public interface IBridge:IKeyed
-    {
-        void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey);
-    }   
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Comm and IR/GenericComm.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Comm and IR/GenericComm.cs
@@ -76,7 +76,14 @@ namespace PepperDash.Essentials.Core
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<IBasicCommunicationJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             if (CommPort == null)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/C2nRts/C2nRthsController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/C2nRts/C2nRthsController.cs
@@ -55,7 +55,14 @@ namespace PepperDash.Essentials.Core.CrestronIO
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<C2nRthsControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Inputs/GenericDigitalInputDevice.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Inputs/GenericDigitalInputDevice.cs
@@ -108,7 +108,14 @@ namespace PepperDash.Essentials.Core.CrestronIO
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<IDigitalInputJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             try
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
@@ -148,7 +148,14 @@ namespace PepperDash.Essentials.Core.CrestronIO
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<GenericRelayControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             if (RelayOutput == null)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/StatusSign/StatusSignController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/StatusSign/StatusSignController.cs
@@ -118,7 +118,14 @@ namespace PepperDash.Essentials.Core.CrestronIO
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<StatusSignControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
@@ -128,9 +128,16 @@ namespace PepperDash.Essentials.Core
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DisplayControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+	        if (bridge != null)
+	        {
+	            bridge.AddJoinMap(Key, joinMap);
+	        }
+	        else
+	        {
+	            Debug.Console(0,this,"Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+	        }
 
-            Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
+	        Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(0, "Linking to Display: {0}", displayDevice.Name);
 
             trilist.StringInput[joinMap.Name.JoinNumber].StringValue = displayDevice.Name;

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Lighting/LightingBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Lighting/LightingBase.cs
@@ -80,7 +80,14 @@ namespace PepperDash.Essentials.Core.Lighting
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<GenericLightingJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -209,7 +209,14 @@ namespace PepperDash.Essentials.Core.Monitoring
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<SystemMonitorJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(2, this, "Linking API starting at join: {0}", joinStart);

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Remotes/Hrxx0WirelessRemoteController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Remotes/Hrxx0WirelessRemoteController.cs
@@ -158,7 +158,14 @@ namespace PepperDash.Essentials.Core
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<Hrxxx0WirelessRemoteControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             //List<string> ExcludedKeys = new List<string>();
             foreach (var feedback in Feedbacks)

--- a/essentials-framework/Essentials DM/Essentials_DM/AirMedia/AirMediaController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/AirMedia/AirMediaController.cs
@@ -114,7 +114,14 @@ namespace PepperDash.Essentials.DM.AirMedia
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<AirMediaControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(0, "Linking to Airmedia: {0}", Name);

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
@@ -590,7 +590,14 @@ namespace PepperDash.Essentials.DM {
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DmBladeChassisControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -1112,7 +1112,14 @@ namespace PepperDash.Essentials.DM
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DmChassisControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsAudioOutputController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsAudioOutputController.cs
@@ -111,7 +111,14 @@ namespace PepperDash.Essentials.DM
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DmpsAudioOutputControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -163,7 +163,14 @@ namespace PepperDash.Essentials.DM
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DmpsRoutingControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/HdMdNxM4kEBridgeableController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/HdMdNxM4kEBridgeableController.cs
@@ -262,7 +262,14 @@ namespace PepperDash.Essentials.DM.Chassis
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<HdMdNxM4kEControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.IsOnline.JoinNumber]);
             DeviceNameFeedback[this.Name].LinkInputSig(trilist.StringInput[joinMap.Name.JoinNumber]);

--- a/essentials-framework/Essentials DM/Essentials_DM/DmLite/HdMdxxxCEController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/DmLite/HdMdxxxCEController.cs
@@ -230,7 +230,14 @@ namespace PepperDash.Essentials.DM
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<HdMdxxxCEControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -42,7 +42,14 @@ namespace PepperDash.Essentials.DM
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<DmRmcControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, rmc, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
@@ -206,6 +206,15 @@ namespace PepperDash.Essentials.DM
 
 	    protected void LinkDmTxToApi(DmTxControllerBase tx, BasicTriList trilist, DmTxControllerJoinMap joinMap, EiscApiAdvanced bridge)
 	    {
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
+
 	        Debug.Console(1, tx, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 
             tx.IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.IsOnline.JoinNumber]);

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Cameras/CameraBase.cs
@@ -83,8 +83,14 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
         {
             CameraControllerJoinMap joinMap = new CameraControllerJoinMap(joinStart);
 
-            // Adds the join map to the bridge
-            bridge.AddJoinMap(cameraDevice.Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             var customJoins = JoinMapHelper.TryGetJoinMapAdvancedForDevice(joinMapKey);
 

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Occupancy/CenOdtOccupancySensorBaseController.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Occupancy/CenOdtOccupancySensorBaseController.cs
@@ -447,7 +447,14 @@ namespace PepperDash.Essentials.Devices.Common.Occupancy
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<CenOdtOccupancySensorBaseJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, occController, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Occupancy/GlsOccupancySensorBaseController.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Occupancy/GlsOccupancySensorBaseController.cs
@@ -268,7 +268,14 @@ namespace PepperDash.Essentials.Devices.Common.Occupancy
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<GlsOccupancySensorBaseJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, occController, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 
@@ -379,25 +386,13 @@ namespace PepperDash.Essentials.Devices.Common.Occupancy
         {
             Debug.Console(1, "Factory Attempting to create new GlsOccupancySensorBaseController Device");
 
-            var typeName = dc.Type.ToLower();
             var key = dc.Key;
             var name = dc.Name;
             var comm = CommFactory.GetControlPropertiesConfig(dc);
 
-            GlsOccupancySensorBase occSensor = null;
+            GlsOccupancySensorBase occSensor = new GlsOirCCn(comm.CresnetIdInt, Global.ControlSystem);
 
-            occSensor = new GlsOirCCn(comm.CresnetIdInt, Global.ControlSystem);
-
-            if (occSensor != null)
-            {
-                return new GlsOccupancySensorBaseController(key, name, occSensor);
-            }
-            else
-            {
-                Debug.Console(0, "ERROR: Unable to create Occupancy Sensor Device. Key: '{0}'", key);
-                return null;
-            }
-
+            return new GlsOccupancySensorBaseController(key, name, occSensor);
         }
     }
 

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/SetTopBox/IRSetTopBoxBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/SetTopBox/IRSetTopBoxBase.cs
@@ -380,7 +380,14 @@ namespace PepperDash.Essentials.Devices.Common
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<SetTopBoxControllerJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(0, "Linking to Display: {0}", Name);

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Streaming/AppleTV.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Streaming/AppleTV.cs
@@ -153,7 +153,14 @@ namespace PepperDash.Essentials.Devices.Common
             if (!string.IsNullOrEmpty(joinMapSerialized))
                 joinMap = JsonConvert.DeserializeObject<AppleTvJoinMap>(joinMapSerialized);
 
-            bridge.AddJoinMap(Key, joinMap);
+            if (bridge != null)
+            {
+                bridge.AddJoinMap(Key, joinMap);
+            }
+            else
+            {
+                Debug.Console(0, this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+            }
 
             Debug.Console(1, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
             Debug.Console(0, "Linking to Bridge Type {0}", GetType().Name);


### PR DESCRIPTION
close #237 

All internal Essentials Devices that implement `IBridgeAdvanced` now also have a null check on the bridge device in the `LinkToApi` method. This allows older configs to be used with new versions of Essentials without causing issues. 

Changes made to allow `EiscApiAdvanced` to use `IBridge` have also been reverted. `EiscApiAdvanced` now supports ONLY `IBridgeAdvanced` and `EiscApi` supports both `IBridge` and `IBridgeAdvanced`.