### PR TITLE
Add bulk device add method and update Eisc

### DIFF
--- a/PepperDashEssentials/Bridges/EiscBridge.cs
+++ b/PepperDashEssentials/Bridges/EiscBridge.cs
@@ -151,12 +151,12 @@ namespace PepperDash.Essentials.Bridges
             try
             {
                 if (Debug.Level >= 1)
-                    Debug.Console(1, this, "EiscApi change: {0} {1}={2}", args.Sig.Type, args.Sig.Number, args.Sig.StringValue);
+                    Debug.Console(2, this, "EiscApi change: {0} {1}={2}", args.Sig.Type, args.Sig.Number, args.Sig.StringValue);
                 var uo = args.Sig.UserObject;
 
                 if (uo == null) return;
 
-                Debug.Console(1, this, "Executing Action: {0}", uo.ToString());
+                Debug.Console(2, this, "Executing Action: {0}", uo.ToString());
                 if (uo is Action<bool>)
                     (uo as Action<bool>)(args.Sig.BoolValue);
                 else if (uo is Action<ushort>)

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -190,11 +190,11 @@ namespace PepperDash.Essentials.Core.Bridges
                             var uo = Eisc.BooleanOutput[join].UserObject as Action<bool>;
                             if (uo != null)
                             {
-                                Debug.Console(1, this, "Executing Action: {0}", uo.ToString());
+                                Debug.Console(2, this, "Executing Action: {0}", uo.ToString());
                                 uo(Convert.ToBoolean(state));
                             }
                             else
-                                Debug.Console(1, this, "User Action is null.  Nothing to Execute");
+                                Debug.Console(2, this, "User Action is null.  Nothing to Execute");
                             break;
                         }
                     case "analog":
@@ -202,27 +202,27 @@ namespace PepperDash.Essentials.Core.Bridges
                             var uo = Eisc.BooleanOutput[join].UserObject as Action<ushort>;
                             if (uo != null)
                             {
-                                Debug.Console(1, this, "Executing Action: {0}", uo.ToString());
+                                Debug.Console(2, this, "Executing Action: {0}", uo.ToString());
                                 uo(Convert.ToUInt16(state));
                             }
                             else
-                                Debug.Console(1, this, "User Action is null.  Nothing to Execute"); break;
+                                Debug.Console(2, this, "User Action is null.  Nothing to Execute"); break;
                         }
                     case "serial":
                         {
                             var uo = Eisc.BooleanOutput[join].UserObject as Action<string>;
                             if (uo != null)
                             {
-                                Debug.Console(1, this, "Executing Action: {0}", uo.ToString());
+                                Debug.Console(2, this, "Executing Action: {0}", uo.ToString());
                                 uo(Convert.ToString(state));
                             }
                             else
-                                Debug.Console(1, this, "User Action is null.  Nothing to Execute");
+                                Debug.Console(2, this, "User Action is null.  Nothing to Execute");
                             break;
                         }
                     default:
                         {
-                            Debug.Console(1, "Unknown join type.  Use digital/serial/analog");
+                            Debug.Console(2, "Unknown join type.  Use digital/serial/analog");
                             break;
                         }
                 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -238,6 +238,42 @@ namespace PepperDash.Essentials.Core
 		    }
 		}
 
+	    public static void AddDevice(IEnumerable<IKeyed> devicesToAdd)
+	    {
+	        try
+	        {
+	            if (!DeviceCriticalSection.TryEnter())
+	            {
+	                Debug.Console(0, Debug.ErrorLogLevel.Error,
+	                    "Currently unable to add devices to Device Manager. Please try again");
+	                return;
+	            }
+	            if (!AddDeviceEnabled)
+	            {
+	                Debug.Console(0, Debug.ErrorLogLevel.Error,
+	                    "All devices have been activated. Adding new devices is not allowed.");
+	                return;
+	            }
+
+	            foreach (var dev in devicesToAdd)
+	            {
+	                try
+	                {
+	                    Devices.Add(dev.Key, dev);
+	                }
+	                catch (ArgumentException ex)
+	                {
+	                    Debug.Console(0, "Error adding device with key {0} to Device Manager: {1}\r\nStack Trace: {2}",
+	                        dev.Key, ex.Message, ex.StackTrace);
+	                }
+	            }
+	        }
+	        finally
+	        {
+	            DeviceCriticalSection.Leave();
+	        }
+	    }
+
 		public static void RemoveDevice(IKeyed newDev)
 		{
 		    try


### PR DESCRIPTION
closes #269 
closes #199 

The new `AddDevice` method takes an `IEnumerable<IKeyed>` as it's parameter. The easiest way to consume this is to create a `List<IKeyed>` in a plugin.