### PR TITLE
Move some Fusion Activation steps to PostActivation action

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -177,10 +177,11 @@ namespace PepperDash.Essentials.Core.Fusion
                     }
                 }
 
-                CreateSymbolAndBasicSigs(IpId);
+                
 
                 AddPostActivationAction(() =>
                 {
+                    CreateSymbolAndBasicSigs(IpId);
                     SetUpSources();
                     SetUpCommunitcationMonitors();
                     SetUpDisplay();
@@ -311,7 +312,7 @@ namespace PepperDash.Essentials.Core.Fusion
 
         }
 
-		protected void CreateSymbolAndBasicSigs(uint ipId)
+		protected virtual void CreateSymbolAndBasicSigs(uint ipId)
 		{
             Debug.Console(0, this, Debug.ErrorLogLevel.Notice, "Creating Fusion Room symbol with GUID: {0}", RoomGuid);
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -167,13 +167,6 @@ namespace PepperDash.Essentials.Core.Fusion
                     ReadGuidFile(guidFilePath);
                 }
 
-                CreateSymbolAndBasicSigs(IpId);
-                SetUpSources();
-                SetUpCommunitcationMonitors();
-                SetUpDisplay();
-                SetUpError();
-                ExecuteCustomSteps();
-
                 if (Room.RoomOccupancy != null)
                 {
                     if (Room.OccupancyStatusProviderIsRemote)
@@ -184,6 +177,8 @@ namespace PepperDash.Essentials.Core.Fusion
                     }
                 }
 
+                CreateSymbolAndBasicSigs(IpId);
+
                 AddPostActivationAction(() =>
                 {
                     SetUpSources();
@@ -191,17 +186,6 @@ namespace PepperDash.Essentials.Core.Fusion
                     SetUpDisplay();
                     SetUpError();
                     ExecuteCustomSteps();
-
-                    if (Room.RoomOccupancy == null)
-                    {
-                        return;
-                    }
-                    if (Room.OccupancyStatusProviderIsRemote)
-                        SetUpRemoteOccupancy();
-                    else
-                    {
-                        SetUpLocalOccupancy();
-                    }
 
                     FusionRVI.GenerateFileForAllFusionDevices();
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -184,10 +184,30 @@ namespace PepperDash.Essentials.Core.Fusion
                     }
                 }
 
-                // Make it so!   
-                FusionRVI.GenerateFileForAllFusionDevices();
+                AddPostActivationAction(() =>
+                {
+                    SetUpSources();
+                    SetUpCommunitcationMonitors();
+                    SetUpDisplay();
+                    SetUpError();
+                    ExecuteCustomSteps();
 
-                GenerateGuidFile(guidFilePath);
+                    if (Room.RoomOccupancy == null)
+                    {
+                        return;
+                    }
+                    if (Room.OccupancyStatusProviderIsRemote)
+                        SetUpRemoteOccupancy();
+                    else
+                    {
+                        SetUpLocalOccupancy();
+                    }
+
+                    FusionRVI.GenerateFileForAllFusionDevices();
+
+                    GenerateGuidFile(guidFilePath);
+                });
+
             }
             catch (Exception e)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -307,7 +307,7 @@ namespace PepperDash.Essentials.Core.Fusion
 
         }
 
-		protected virtual void CreateSymbolAndBasicSigs(uint ipId)
+		protected void CreateSymbolAndBasicSigs(uint ipId)
 		{
             Debug.Console(0, this, Debug.ErrorLogLevel.Notice, "Creating Fusion Room symbol with GUID: {0}", RoomGuid);
 


### PR DESCRIPTION
closes #337 
Due to the change to initializing things for Cresnet devices from a Pre-Activation action (see #292) when Fusion is initialized, the CommunicationMonitor isn't created yet. The fix is moving it's activation actions to a PostActivation Action.