### PR TITLE
Add GenericIrController device

### DIFF
--- a/PepperDashEssentials/PepperDashEssentials.csproj
+++ b/PepperDashEssentials/PepperDashEssentials.csproj
@@ -75,10 +75,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>
-    <Reference Include="PepperDash_Essentials_DM, Version=1.0.0.19343, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\essentials-framework\Essentials DM\Essentials_DM\bin\PepperDash_Essentials_DM.dll</HintPath>
-    </Reference>
     <Reference Include="SimplSharpCustomAttributesInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
@@ -214,6 +210,10 @@
     <ProjectReference Include="..\essentials-framework\Essentials Devices Common\Essentials Devices Common\Essentials Devices Common.csproj">
       <Project>{892B761C-E479-44CE-BD74-243E9214AF13}</Project>
       <Name>Essentials Devices Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\essentials-framework\Essentials DM\Essentials_DM\PepperDash_Essentials_DM.csproj">
+      <Project>{9199CE8A-0C9F-4952-8672-3EED798B284F}</Project>
+      <Name>PepperDash_Essentials_DM</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CompactFramework.CSharp.targets" />

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using Crestron.SimplSharpPro.DeviceSupport;
+using PepperDash.Core;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+
+namespace PepperDash_Essentials_Core.Devices
+{
+    public class GenericIRController: EssentialsBridgeableDevice
+    {
+        private readonly IrOutputPortController _port;
+
+        public GenericIRController(string key, string name, IrOutputPortController irPort) : base(key, name)
+        {
+            _port = irPort;
+
+            DeviceManager.AddDevice(_port);
+        }
+
+        #region Overrides of EssentialsBridgeableDevice
+
+        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    public class GenericIrControllerFactory : EssentialsDeviceFactory<GenericIRController>
+    {
+        public GenericIrControllerFactory()
+        {
+            TypeNames = new List<string> {"genericIrController"};
+        }
+        #region Overrides of EssentialsDeviceFactory<GenericIRController>
+
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.Console(1, "Factory Attempting to create new Generic IR Controller Device");
+
+            var irPort = IRPortHelper.GetIrOutputPortController(dc);
+
+            return new GenericIRController(dc.Key, dc.Name, irPort);
+        }
+
+        #endregion
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
@@ -61,17 +61,20 @@ namespace PepperDash_Essentials_Core.Devices
 
             for (uint i = 0; i < _port.IrFileCommands.Length; i++)
             {
-                joinMap.Joins.Add(_port.IrFileCommands[i],
-                    new JoinDataComplete(new JoinData {JoinNumber = i + joinStart, JoinSpan = 1},
-                        new JoinMetadata
-                        {
-                            Description = _port.IrFileCommands[i],
-                            JoinCapabilities = eJoinCapabilities.FromSIMPL,
-                            JoinType = eJoinType.Digital
-                        }));
+                var joinData = new JoinDataComplete(new JoinData {JoinNumber = i + joinStart, JoinSpan = 1},
+                    new JoinMetadata
+                    {
+                        Description = _port.IrFileCommands[i],
+                        JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                        JoinType = eJoinType.Digital
+                    });
+
+                joinData.SetJoinOffset(joinStart);
+
+                joinMap.Joins.Add(_port.IrFileCommands[i],joinData);
 
                 var index = i;
-                trilist.SetBoolSigAction(i + joinStart, (b) => Press(_port.IrFileCommands[index], b));
+                trilist.SetBoolSigAction(joinData.JoinNumber, (b) => Press(_port.IrFileCommands[index], b));
             }
 
             if (bridge != null)

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/GenericIRController.cs
@@ -19,6 +19,8 @@ namespace PepperDash_Essentials_Core.Devices
 
         private readonly IrOutputPortController _port; 
 
+        public string[] IrCommands {get { return _port.IrFileCommands; }}
+
         public GenericIrController(string key, string name, IrOutputPortController irPort) : base(key, name)
         {
             _port = irPort;

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
@@ -52,6 +52,7 @@ namespace PepperDash.Essentials.Core
 	        DeviceConfig config)
 	        : base(key)
 	    {
+            DriverLoaded = new BoolFeedback(() => DriverIsLoaded);
             AddPostActivationAction(() =>
             {
                 IrPort = postActivationFunc(config);
@@ -63,7 +64,7 @@ namespace PepperDash.Essentials.Core
                 }
                 
                 var filePath = Global.FilePathPrefix + "ir" + Global.DirectorySeparator + config.Properties["control"]["irFile"].Value<string>();
-                Debug.Console(1, "*************Attemting to load IR file: {0}***************", filePath);
+                Debug.Console(1, "*************Attempting to load IR file: {0}***************", filePath);
 
                 LoadDriver(filePath);
                     

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
@@ -35,6 +35,8 @@ namespace PepperDash.Essentials.Core
 			: base(key)
 		{
 			//if (port == null) throw new ArgumentNullException("port");
+
+		    DriverLoaded = new BoolFeedback(() => DriverIsLoaded);
 			IrPort = port;
 			if (port == null)
 			{

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IrOutputPortController.cs
@@ -21,6 +21,8 @@ namespace PepperDash.Essentials.Core
 		uint IrPortUid;
 		IROutputPort IrPort;
 
+        public BoolFeedback DriverLoaded { get; private set; }
+
 		public ushort StandardIrPulseTime { get; set; }
 		public string DriverFilepath { get; private set; }
 		public bool DriverIsLoaded { get; private set; }
@@ -93,13 +95,15 @@ namespace PepperDash.Essentials.Core
 	            DriverFilepath = path;
 	            StandardIrPulseTime = 200;
 	            DriverIsLoaded = true;
+
+                DriverLoaded.FireUpdate();
 	        }
 			catch
 			{
 				DriverIsLoaded = false;
 				var message = string.Format("WARNING IR Driver '{0}' failed to load", path);
-				Debug.Console(0, this, message);
-				ErrorLog.Error(message);
+				Debug.Console(0, this, Debug.ErrorLogLevel.Error, message);
+                DriverLoaded.FireUpdate();
 			}
 		}
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Devices\DeviceFeedbackExtensions.cs" />
     <Compile Include="Devices\EssentialsBridgeableDevice.cs" />
     <Compile Include="Devices\EssentialsDevice.cs" />
+    <Compile Include="Devices\GenericIRController.cs" />
     <Compile Include="Devices\IProjectorInterfaces.cs" />
     <Compile Include="Devices\PC\InRoomPc.cs" />
     <Compile Include="Devices\PC\Laptop.cs" />

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Essentials Devices Common.csproj
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Essentials Devices Common.csproj
@@ -71,10 +71,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>
-    <Reference Include="PepperDash_Essentials_Core, Version=0.0.0.22043, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Essentials Core\PepperDashEssentialsBase\bin\PepperDash_Essentials_Core.dll</HintPath>
-    </Reference>
     <Reference Include="SimplSharpCustomAttributesInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
@@ -186,6 +182,12 @@
     <Compile Include="VideoCodec\ZoomRoom\ZoomRoomCamera.cs" />
     <Compile Include="VideoCodec\ZoomRoom\ZoomRoomPropertiesConfig.cs" />
     <None Include="Properties\ControlSystem.cfg" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Essentials Core\PepperDashEssentialsBase\PepperDash_Essentials_Core.csproj">
+      <Project>{A49AD6C8-FC0A-4CC0-9089-DFB4CF92D2B5}</Project>
+      <Name>PepperDash_Essentials_Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CompactFramework.CSharp.targets" />
   <ProjectExtensions>


### PR DESCRIPTION
close #407 
This PR adds the GenericIrController device to allow for loading and bridging ANY IR file to SIMPL. The commands for the IR file are also available as a string array for other Essentials devices to use.