### PR TITLE
Add MC QR Code display to Touch10 and OSD

### DIFF
--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -13,6 +13,7 @@ using PepperDash.Essentials.Room.Config;
 using PepperDash.Essentials.Devices.Common.Codec;
 using PepperDash.Essentials.Devices.Common.VideoCodec;
 using PepperDash.Essentials.Devices.Common.AudioCodec;
+using PepperDash_Essentials_Core.DeviceTypeInterfaces;
 
 namespace PepperDash.Essentials
 {
@@ -703,29 +704,35 @@ namespace PepperDash.Essentials
 			{
 				return;
 			}
-			else
-			{
-				string codecTieLine = "";
-				codecTieLine = ConfigReader.ConfigObject.TieLines.SingleOrDefault(x => x.DestinationKey == VideoCodec.Key).DestinationPort;
-				videoCodecWithExternalSwitching.ClearExternalSources();
-				videoCodecWithExternalSwitching.RunRouteAction = RunRouteAction;
-				var srcList = ConfigReader.ConfigObject.SourceLists.SingleOrDefault(x => x.Key == SourceListKey).Value.OrderBy(kv => kv.Value.Order); ;
 
-				foreach (var kvp in srcList)
-				{
-					var srcConfig = kvp.Value;
+		    string codecTieLine = ConfigReader.ConfigObject.TieLines.SingleOrDefault(x => x.DestinationKey == VideoCodec.Key).DestinationPort;
+		    videoCodecWithExternalSwitching.ClearExternalSources();
+		    videoCodecWithExternalSwitching.RunRouteAction = RunRouteAction;
+		    var srcList = ConfigReader.ConfigObject.SourceLists.SingleOrDefault(x => x.Key == SourceListKey).Value.OrderBy(kv => kv.Value.Order); ;
 
-					if (kvp.Key != DefaultCodecRouteString && kvp.Key != "roomOff")
-					{
+		    foreach (var kvp in srcList)
+		    {
+		        var srcConfig = kvp.Value;
 
-						videoCodecWithExternalSwitching.AddExternalSource(codecTieLine, kvp.Key, srcConfig.PreferredName, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceType.desktop);
-						videoCodecWithExternalSwitching.SetExternalSourceState(kvp.Key, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceMode.Ready);
+		        if (kvp.Key != DefaultCodecRouteString && kvp.Key != "roomOff")
+		        {
+
+		            videoCodecWithExternalSwitching.AddExternalSource(codecTieLine, kvp.Key, srcConfig.PreferredName, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceType.desktop);
+		            videoCodecWithExternalSwitching.SetExternalSourceState(kvp.Key, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceMode.Ready);
 
 
-					}
-				}
-			}
+		        }
+		    }
 		}
+
+        private void SetCodecBranding()
+        {
+            var vcWithBranding = VideoCodec as IHasBranding;
+
+            if (vcWithBranding == null) return;
+
+            vcWithBranding.InitializeBranding(Key);
+        }
 		
         #region IPrivacy Members
 

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -731,6 +731,7 @@ namespace PepperDash.Essentials
 
             if (vcWithBranding == null) return;
 
+            Debug.Console(1, this, "Setting Codec Branding");
             vcWithBranding.InitializeBranding(Key);
         }
 		

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -314,7 +314,7 @@ namespace PepperDash.Essentials
 
 
                 VideoCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();
-				VideoCodec.IsReadyChange += (o, a) => this.SetCodecExternalSources(); 
+				VideoCodec.IsReadyChange += (o, a) => { this.SetCodecExternalSources(); SetCodecBranding(); }; 
 
                 if (AudioCodec != null)
                     AudioCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasBranding.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasBranding.cs
@@ -1,0 +1,8 @@
+﻿namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
+{
+    public interface IHasBranding
+    {
+        bool BrandingEnabled { get; }
+        void InitializeBranding(string roomKey);
+    }
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -98,12 +98,12 @@
     </Reference>
     <Reference Include="SimplSharpCustomAttributesInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpCustomAttributesInterface.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SimplSharpHelperInterface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpHelperInterface.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpHelperInterface.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SimplSharpNewtonsoft, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
@@ -113,7 +113,7 @@
     </Reference>
     <Reference Include="SimplSharpPro, Version=1.5.3.17, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpPro.exe</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SimplSharpPro.exe</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SimplSharpReflectionInterface, Version=1.0.5583.25238, Culture=neutral, PublicKeyToken=1099c178b3b54c3b, processorArchitecture=MSIL">
@@ -206,6 +206,7 @@
     <Compile Include="Devices\PC\Laptop.cs" />
     <Compile Include="Devices\ReconfigurableDevice.cs" />
     <Compile Include="Devices\VolumeDeviceChangeEventArgs.cs" />
+    <Compile Include="DeviceTypeInterfaces\IHasBranding.cs" />
     <Compile Include="DeviceTypeInterfaces\IMobileControl.cs" />
     <Compile Include="Factory\DeviceFactory.cs" />
     <Compile Include="Factory\IDeviceFactory.cs" />

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
@@ -510,6 +510,9 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
             Debug.Console(1, this, "Sending url: {0}", mcBridge.QrCodeUrl);
 
+            SendText("xconfiguration userinterface custommessage: \"Scan the QR code with a mobile phone to get started\"");
+            SendText("xconfiguration userinterface osd halfwakemessage: \"Tap the touch panel or scan the QR code with a mobile phone to get started\"");
+
             SendText(String.Format(
                             "xcommand userinterface branding fetch type: branding url: {0}",
                             mcBridge.QrCodeUrl));

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
@@ -411,12 +411,13 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
             {
                 return;
             }
+            Debug.Console(2, this, "Setting branding properties enable: {0} _brandingUrl {1}", props.UiBranding.Enable,
+                props.UiBranding.BrandingUrl);
 
             BrandingEnabled = props.UiBranding.Enable;
             _brandingUrl = props.UiBranding.BrandingUrl;
         }
 
-        /// <summary>
         /// Runs in it's own thread to dequeue messages in the order they were received to be processed
         /// </summary>
         /// <returns></returns>
@@ -454,6 +455,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
         public void InitializeBranding(string roomKey)
         {
+            Debug.Console(2, this, "Initializing Branding for room {0}", roomKey);
+
             if (!BrandingEnabled)
             {
                 return;
@@ -487,6 +490,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
             } else if (String.IsNullOrEmpty(_brandingUrl))
             {
                 if (mcBridge == null) return;
+
+                Debug.Console(2, this, "Setting QR code URL: {0}", mcBridge.QrCodeUrl);
 
                 mcBridge.UserCodeChanged += (o, a) => SendMcBrandingUrl(mcBridge);
 

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodec.cs
@@ -455,7 +455,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
         public void InitializeBranding(string roomKey)
         {
-            Debug.Console(2, this, "Initializing Branding for room {0}", roomKey);
+            Debug.Console(1, this, "Initializing Branding for room {0}", roomKey);
 
             if (!BrandingEnabled)
             {
@@ -468,6 +468,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
             if (!String.IsNullOrEmpty(_brandingUrl))
             {
+                Debug.Console(1, this, "Branding URL found: {0}", _brandingUrl);
                 if (_brandingTimer != null)
                 {
                     _brandingTimer.Stop();
@@ -489,6 +490,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
                 }, 0, 15000);
             } else if (String.IsNullOrEmpty(_brandingUrl))
             {
+                Debug.Console(1, this, "No Branding URL found");
                 if (mcBridge == null) return;
 
                 Debug.Console(2, this, "Setting QR code URL: {0}", mcBridge.QrCodeUrl);
@@ -506,6 +508,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
                 return;
             }
 
+            Debug.Console(1, this, "Sending url: {0}", mcBridge.QrCodeUrl);
+
             SendText(String.Format(
                             "xcommand userinterface branding fetch type: branding url: {0}",
                             mcBridge.QrCodeUrl));
@@ -516,6 +520,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
 
         private void SendBrandingUrl()
         {
+            Debug.Console(1, this, "Sending url: {0}", _brandingUrl);
+
             SendText(String.Format("xcommand userinterface branding fetch type: branding url: {0}",
                             _brandingUrl));
             SendText(String.Format("xcommand userinterface branding fetch type: halfwakebranding url: {0}",

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodecPropertiesConfig.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodecPropertiesConfig.cs
@@ -57,6 +57,6 @@ namespace PepperDash.Essentials.Devices.Common.Codec
         public bool Enable { get; set; }
 
         [JsonProperty("brandingUrl")]
-        public bool LogoUrl { get; set; }
+        public string BrandingUrl { get; set; }
     }
 }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodecPropertiesConfig.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/CiscoSparkCodecPropertiesConfig.cs
@@ -40,11 +40,23 @@ namespace PepperDash.Essentials.Devices.Common.Codec
         [JsonProperty("phonebookResultsLimit")]
         public uint PhonebookResultsLimit { get; set; }
 
+        [JsonProperty("UiBranding")]
+        public BrandingLogoProperties UiBranding { get; set; }       
+
     }
 
     public class SharingProperties
     {
         [JsonProperty("autoShareContentWhileInCall")]
         public bool AutoShareContentWhileInCall { get; set; }
+    }
+
+    public class BrandingLogoProperties
+    {
+        [JsonProperty("enable")]
+        public bool Enable { get; set; }
+
+        [JsonProperty("brandingUrl")]
+        public bool LogoUrl { get; set; }
     }
 }


### PR DESCRIPTION
Close #414

This PR adds the ability, depending on config, to show the MC QR Code as the branding image on Cisco Touch10 panels and the main display for both awake and half-wake scenarios.