### PR TITLE
Multiple fixes for DMPS and Essentials

### DIFF
--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -149,9 +149,8 @@ namespace PepperDash.Essentials.DM
             foreach (var kvp in OutputNames)
             {
                 var output = (Dmps.SwitcherOutputs[kvp.Key] as DMOutput);
-                if (output != null && output.Name != null)
+                if (output != null && output.Name.Type != eSigType.NA)
                 {
-                    
                     output.Name.StringValue = kvp.Value;
                 }
             }
@@ -166,7 +165,7 @@ namespace PepperDash.Essentials.DM
             foreach (var kvp in InputNames)
             {
                 var input = (Dmps.SwitcherInputs[kvp.Key] as DMInput);
-                if (input != null && input.Name != null)
+                if (input != null && input.Name.Type != eSigType.NA)
                 {
                     input.Name.StringValue = kvp.Value;
                 }
@@ -331,65 +330,57 @@ namespace PepperDash.Essentials.DM
         {
             foreach (var card in Dmps.SwitcherOutputs)
             {
-
                 var outputCard = card as DMOutput;
 
-                Debug.Console(1, this, "Adding Output Card Number {0} Type: {1}", outputCard.Number, outputCard.CardInputOutputType.ToString());
-
-                if (outputCard != null)
+                if (outputCard == null)
                 {
-                    VideoOutputFeedbacks[outputCard.Number] = new IntFeedback(() =>
-                    {
-                        if (outputCard.VideoOutFeedback != null) { return (ushort)outputCard.VideoOutFeedback.Number; }
-                        else { return 0; };
-                    });
-                    AudioOutputFeedbacks[outputCard.Number] = new IntFeedback(() =>
-                    {
-                        if (outputCard.AudioOutFeedback != null) { return (ushort)outputCard.AudioOutFeedback.Number; }
-                        else { return 0; };
-                    });
-
-                    OutputNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
-                    {
-                        if (outputCard.NameFeedback != null && !string.IsNullOrEmpty(outputCard.NameFeedback.StringValue))
-                        {
-                            Debug.Console(2, this, "Output Card {0} Name: {1}", outputCard.Number, outputCard.NameFeedback.StringValue);
-                            return outputCard.NameFeedback.StringValue;
-                        }
-                        else
-                        {
-                            return "";
-                        }
-                    });
-
-                    OutputVideoRouteNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
-                    {
-                        if (outputCard.VideoOutFeedback != null && outputCard.VideoOutFeedback.NameFeedback != null)
-                        {
-                            return outputCard.VideoOutFeedback.NameFeedback.StringValue;
-                        }
-                        else
-                        {
-                            return NoRouteText;
-                        }
-                    });
-                    OutputAudioRouteNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
-                    {
-                        if (outputCard.AudioOutFeedback != null && outputCard.AudioOutFeedback.NameFeedback != null)
-                        {
-                            return outputCard.AudioOutFeedback.NameFeedback.StringValue;
-                        }
-                        else
-                        {
-                            return NoRouteText;
-
-                        }
-                    });
-
-                    OutputEndpointOnlineFeedbacks[outputCard.Number] = new BoolFeedback(() => { return outputCard.EndpointOnlineFeedback; });
-
-                    AddOutputCard(outputCard.Number, outputCard);
+                    continue;
                 }
+
+                Debug.Console(1, this, "Adding Output Card Number {0} Type: {1}", outputCard.Number, outputCard.CardInputOutputType.ToString());
+                VideoOutputFeedbacks[outputCard.Number] = new IntFeedback(() =>
+                {
+                    if (outputCard.VideoOutFeedback != null) { return (ushort)outputCard.VideoOutFeedback.Number; }
+                    return 0;
+                    ;
+                });
+                AudioOutputFeedbacks[outputCard.Number] = new IntFeedback(() =>
+                {
+                    if (outputCard.AudioOutFeedback != null) { return (ushort)outputCard.AudioOutFeedback.Number; }
+                    return 0;
+                    ;
+                });
+
+                OutputNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
+                {
+                    if (outputCard.NameFeedback != null && !string.IsNullOrEmpty(outputCard.NameFeedback.StringValue))
+                    {
+                        Debug.Console(2, this, "Output Card {0} Name: {1}", outputCard.Number, outputCard.NameFeedback.StringValue);
+                        return outputCard.NameFeedback.StringValue;
+                    }
+                    return "";
+                });
+
+                OutputVideoRouteNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
+                {
+                    if (outputCard.VideoOutFeedback != null && outputCard.VideoOutFeedback.NameFeedback != null)
+                    {
+                        return outputCard.VideoOutFeedback.NameFeedback.StringValue;
+                    }
+                    return NoRouteText;
+                });
+                OutputAudioRouteNameFeedbacks[outputCard.Number] = new StringFeedback(() =>
+                {
+                    if (outputCard.AudioOutFeedback != null && outputCard.AudioOutFeedback.NameFeedback != null)
+                    {
+                        return outputCard.AudioOutFeedback.NameFeedback.StringValue;
+                    }
+                    return NoRouteText;
+                });
+
+                OutputEndpointOnlineFeedbacks[outputCard.Number] = new BoolFeedback(() => outputCard.EndpointOnlineFeedback);
+
+                AddOutputCard(outputCard.Number, outputCard);
             }
         }
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -296,7 +296,7 @@ namespace PepperDash.Essentials.DM
 	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
 	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmpsHandler))
 	        {
-	            var output = controller.Dmps.SwitcherOutputs[num] as Card.Dmps3DmOutput;
+	            var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
 
 	            if (output != null)
 	            {

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM;
+using Crestron.SimplSharpPro.DM.Cards;
 using Crestron.SimplSharpPro.DM.Endpoints.Receivers;
 using Newtonsoft.Json;
 using PepperDash.Core;
@@ -295,13 +296,15 @@ namespace PepperDash.Essentials.DM
 	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
 	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmpsHandler))
 	        {
-	            var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
+	            var output = controller.Dmps.SwitcherOutputs[num] as Card.Dmps3DmOutput;
 
 	            if (output != null)
 	            {
 	                return dmpsHandler(key, name, output);
 	            }
-	            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output", typeName, num);
+	            Debug.Console(0, Debug.ErrorLogLevel.Error,
+	                "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output.",
+	                typeName, num);
 	            return null;
 	        }
 


### PR DESCRIPTION
close #456 
close #455 
close #454 

* Added method to build RMC's using same constructor as for Cpu3 chassis
    * Note: This will ALSO need to be applied for TX's that are attaching to the DMPS Chassis at some point
* Fixed LinkToApi method to use the count from the `SwitcherInputs` & `SwitcherOutputs` collection instead of the `NumberOfSwitcherInputs` and `NumberOfSwitcherOutputs` property, as the values weren't matching up in all cases.
* Fixed some casts for adding Output Ports for Essentials routing for the HDMI and DM inputs on 4K DMPS. These are a different class than the non-4K DMPS outputs, and were not getting added to the list.