### PR TITLE
Bugfix/logo server crashing

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -538,6 +538,20 @@ namespace PepperDash.Essentials
         /// </summary>
         void LoadLogoServer()
         {
+            if (ConfigReader.ConfigObject.Rooms == null)
+            {
+                Debug.Console(0, Debug.ErrorLogLevel.Notice, "No rooms configured. Bypassing Logo server startup.");
+                return;
+            }
+
+            if (
+                !ConfigReader.ConfigObject.Rooms.Any(
+                    CheckRoomConfig))
+            {
+                Debug.Console(0, Debug.ErrorLogLevel.Notice, "No rooms configured to use system Logo server. Bypassing Logo server startup");
+                return;
+            }
+
             try
             {
                 LogoServer = new HttpLogoServer(8080, Global.DirectorySeparator + "html" + Global.DirectorySeparator + "logo");
@@ -546,6 +560,31 @@ namespace PepperDash.Essentials
             {
                 Debug.Console(0, Debug.ErrorLogLevel.Notice, "NOTICE: Logo server cannot be started. Likely already running in another program");
             }
+        }
+
+        private bool CheckRoomConfig(DeviceConfig c)
+        {
+            string logoDark = null;
+            string logoLight = null;
+            string logo = null;
+
+            if (c.Properties["logoDark"] != null)
+            {
+                logoDark = c.Properties["logoDark"].Value<string>("type");
+            }
+
+            if (c.Properties["logoLight"] != null)
+            {
+                logoLight = c.Properties["logoLight"].Value<string>("type");
+            }
+
+            if (c.Properties["logo"] != null)
+            {
+                logo = c.Properties["logo"].Value<string>("type");
+            }
+
+            return ((logoDark != null && logoDark == "system") ||
+                    (logoLight != null && logoLight == "system") || (logo != null && logo == "system"));
         }
     }
 }


### PR DESCRIPTION
close #463 
close #436 

The logo server was ALWAYS being instantiated, leaving a port open on 8080. That was causing issues in some situations with security scanners attempting all kinds of paths. The invalid attempts weren't being caught and returned a 404. 

The logo server will also only be instantiated when a room is present in the configuration, and the room is configured to use the `system` type for the logo.