### PR TITLE
Add IRoutingNumericFeedback interface and implementations

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Display/DisplayBase.cs
@@ -18,7 +18,7 @@ namespace PepperDash.Essentials.Core
 	/// <summary>
 	/// 
 	/// </summary>
-	public abstract class DisplayBase : EssentialsDevice, IHasFeedback, IRoutingSinkWithSwitching, IPower, IWarmingCooling, IUsageTracking
+    public abstract class DisplayBase : EssentialsDevice, IHasFeedback, IRoutingSinkWithSwitching, IPower, IWarmingCooling, IUsageTracking
 	{
         public event SourceInfoChangeHandler CurrentSourceChange;
 
@@ -259,12 +259,13 @@ namespace PepperDash.Essentials.Core
             volumeDisplayWithFeedback.MuteFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VolumeMuteOn.JoinNumber]);
             volumeDisplayWithFeedback.MuteFeedback.LinkComplementInputSig(trilist.BooleanInput[joinMap.VolumeMuteOff.JoinNumber]);
 	    }
-	}
+
+    }
 
 	/// <summary>
 	/// 
 	/// </summary>
-    public abstract class TwoWayDisplayBase : DisplayBase
+    public abstract class TwoWayDisplayBase : DisplayBase, IRoutingFeedback
 	{
         public StringFeedback CurrentInputFeedback { get; private set; }
 
@@ -294,6 +295,19 @@ namespace PepperDash.Essentials.Core
 
             
 		}
+
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
+
+        /// <summary>
+        /// Raise an event when the status of a switch object changes.
+        /// </summary>
+        /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
+        protected void OnSwitchChange(RoutingNumericEventArgs e)
+        {
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
+        }
+
 
 	}
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
@@ -139,7 +139,7 @@ namespace PepperDash.Essentials.Core
     public interface IRoutingNumericFeedback : IKeyName
     {
         event EventHandler NumericSwitchChange;
-        void OnSwitchChange(RoutingNumericEventArgs e);
+        //void OnSwitchChange(RoutingNumericEventArgs e);
     }
 
     /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
@@ -111,10 +111,70 @@ namespace PepperDash.Essentials.Core
         IntFeedback AudioVideoSourceNumericFeedback { get; }
     }
 
-	/// <summary>
+
+    /// <summary>
+    /// Defines an IRmcRouting with a feedback event 
+    /// </summary>
+    public interface ITxRoutingWithFeedback : ITxRouting, IRoutingNumericFeedback
+    {
+    }
+
+    /// <summary>
+    /// Defines an IRmcRouting with a feedback event 
+    /// </summary>
+    public interface IRmcRoutingWithFeedback : IRmcRouting, IRoutingNumericFeedback
+    {
+    }
+
+    /// <summary>
 	/// Defines an IRoutingOutputs devices as being a source - the start of the chain
 	/// </summary>
 	public interface IRoutingSource : IRoutingOutputs
 	{
 	}
+
+    /// <summary>
+    /// Defines an event structure for reporting output route data
+    /// </summary>
+    public interface IRoutingNumericFeedback : IKeyName
+    {
+        event EventHandler NumericSwitchChange;
+        void OnSwitchChange(RoutingNumericEventArgs e);
+    }
+
+    /// <summary>
+    /// Defines an IRoutingNumeric with a feedback event 
+    /// </summary>
+    public interface IRoutingNumericWithFeedback : IRoutingNumeric, IRoutingNumericFeedback
+    {
+    }
+
+    public class RoutingNumericEventArgs : EventArgs
+    {
+        private readonly uint _output;
+        private readonly uint _input;
+        private readonly eRoutingSignalType _sigType;
+
+        public uint Output
+        {
+            get { return _output; }
+        }
+
+        public uint Input
+        {
+            get { return _input; }
+        }
+
+        public eRoutingSignalType SigType
+        {
+            get { return _sigType; }
+        }
+
+        public RoutingNumericEventArgs(uint output, uint input, eRoutingSignalType sigType)
+        {
+            _output = output;
+            _input = input;
+            _sigType = sigType;
+        }
+    }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Routing/RoutingInterfaces.cs
@@ -115,14 +115,14 @@ namespace PepperDash.Essentials.Core
     /// <summary>
     /// Defines an IRmcRouting with a feedback event 
     /// </summary>
-    public interface ITxRoutingWithFeedback : ITxRouting, IRoutingNumericFeedback
+    public interface ITxRoutingWithFeedback : ITxRouting
     {
     }
 
     /// <summary>
     /// Defines an IRmcRouting with a feedback event 
     /// </summary>
-    public interface IRmcRoutingWithFeedback : IRmcRouting, IRoutingNumericFeedback
+    public interface IRmcRoutingWithFeedback : IRmcRouting
     {
     }
 
@@ -136,45 +136,62 @@ namespace PepperDash.Essentials.Core
     /// <summary>
     /// Defines an event structure for reporting output route data
     /// </summary>
-    public interface IRoutingNumericFeedback : IKeyName
+    public interface IRoutingFeedback : IKeyName
     {
-        event EventHandler NumericSwitchChange;
+        event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
         //void OnSwitchChange(RoutingNumericEventArgs e);
     }
 
     /// <summary>
     /// Defines an IRoutingNumeric with a feedback event 
     /// </summary>
-    public interface IRoutingNumericWithFeedback : IRoutingNumeric, IRoutingNumericFeedback
+    public interface IRoutingNumericWithFeedback : IRoutingNumeric, IRoutingFeedback
     {
+    }
+
+    /// <summary>
+    /// Defines an IRouting with a feedback event
+    /// </summary>
+    public interface IRoutingWithFeedback : IRouting, IRoutingFeedback
+    {
+        
     }
 
     public class RoutingNumericEventArgs : EventArgs
     {
-        private readonly uint _output;
-        private readonly uint _input;
-        private readonly eRoutingSignalType _sigType;
 
-        public uint Output
+        public uint? Output { get; set; }
+        public uint? Input { get; set; }
+
+        public eRoutingSignalType SigType { get; set; }
+        public RoutingInputPort InputPort { get; set; }
+        public RoutingOutputPort OutputPort { get; set; }
+
+        public RoutingNumericEventArgs(uint output, uint input, eRoutingSignalType sigType) : this(output, input, null, null, sigType)
         {
-            get { return _output; }
         }
 
-        public uint Input
+        public RoutingNumericEventArgs(RoutingOutputPort outputPort, RoutingInputPort inputPort,
+            eRoutingSignalType sigType)
+            : this(null, null, outputPort, inputPort, sigType)
         {
-            get { return _input; }
         }
 
-        public eRoutingSignalType SigType
+        public RoutingNumericEventArgs()
+            : this(null, null, null, null, 0)
         {
-            get { return _sigType; }
+ 
         }
 
-        public RoutingNumericEventArgs(uint output, uint input, eRoutingSignalType sigType)
+        public RoutingNumericEventArgs(uint? output, uint? input, RoutingOutputPort outputPort,
+            RoutingInputPort inputPort, eRoutingSignalType sigType)
         {
-            _output = output;
-            _input = input;
-            _sigType = sigType;
+            OutputPort = outputPort;
+            InputPort = inputPort;
+
+            Output = output;
+            Input = input;
+            SigType = sigType;
         }
     }
 }

--- a/essentials-framework/Essentials DM/Essentials_DM/AirMedia/AirMediaController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/AirMedia/AirMediaController.cs
@@ -160,7 +160,7 @@ namespace PepperDash.Essentials.DM.AirMedia
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -28,7 +28,7 @@ namespace PepperDash.Essentials.DM
         public Switch Chassis { get; private set; }
 
         //IroutingNumericEvent
-        public event EventHandler NumericSwitchChange;
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
 
         // Feedbacks for EssentialDM
         public Dictionary<uint, IntFeedback> VideoOutputFeedbacks { get; private set; }
@@ -191,6 +191,7 @@ namespace PepperDash.Essentials.DM
         public DmChassisController(string key, string name, DmMDMnxn chassis)
             : base(key, name, chassis)
         {
+
             Chassis = chassis;
             InputPorts = new RoutingPortCollection<RoutingInputPort>();
             OutputPorts = new RoutingPortCollection<RoutingOutputPort>();
@@ -740,7 +741,10 @@ namespace PepperDash.Essentials.DM
         {
             var portKey = string.Format("inputCard{0}--{1}", cardNum, portName);
             Debug.Console(2, this, "Adding input port '{0}'", portKey);
-            var inputPort = new RoutingInputPort(portKey, sigType, portType, cardNum, this);
+            var inputPort = new RoutingInputPort(portKey, sigType, portType, cardNum, this)
+            {
+                FeedbackMatchObject = Chassis.Inputs[cardNum]
+            };
 
             InputPorts.Add(inputPort);
         }
@@ -752,7 +756,10 @@ namespace PepperDash.Essentials.DM
         {
             var portKey = string.Format("inputCard{0}--{1}", cardNum, portName);
             Debug.Console(2, this, "Adding input port '{0}'", portKey);
-            var inputPort = new RoutingInputPort(portKey, sigType, portType, cardNum, this);
+            var inputPort = new RoutingInputPort(portKey, sigType, portType, cardNum, this)
+            {
+                FeedbackMatchObject = Chassis.Inputs[cardNum]
+            }; ;
 
             if (cecPort != null)
                 inputPort.Port = cecPort;
@@ -767,7 +774,10 @@ namespace PepperDash.Essentials.DM
         {
             var portKey = string.Format("{0}--{1}", cardName, portName);
             Debug.Console(2, this, "Adding output port '{0}'", portKey);
-            OutputPorts.Add(new RoutingOutputPort(portKey, sigType, portType, selector, this));
+            OutputPorts.Add(new RoutingOutputPort(portKey, sigType, portType, selector, this)
+            {
+                FeedbackMatchObject = Chassis.Outputs[(uint)selector]
+            });
         }
 
         /// <summary>
@@ -777,7 +787,10 @@ namespace PepperDash.Essentials.DM
         {
             var portKey = string.Format("{0}--{1}", cardName, portName);
             Debug.Console(2, this, "Adding output port '{0}'", portKey);
-            var outputPort = new RoutingOutputPort(portKey, sigType, portType, selector, this);
+            var outputPort = new RoutingOutputPort(portKey, sigType, portType, selector, this)
+            {
+                FeedbackMatchObject = Chassis.Outputs[(uint)selector]
+            }; ;
 
             if (cecPort != null)
                 outputPort.Port = cecPort;
@@ -911,12 +924,14 @@ namespace PepperDash.Essentials.DM
         }
 
         /// <summary>
+        /// <summary>
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
         private void OnSwitchChange(RoutingNumericEventArgs e)
         {
-            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
         }
 
         /// 
@@ -952,14 +967,25 @@ namespace PepperDash.Essentials.DM
                 }
                 case DMOutputEventIds.VideoOutEventId:
                 {
-                    if (Chassis.Outputs[output].VideoOutFeedback == null) return;
+                    
+                    var inputNumber = Chassis.Outputs[output].VideoOutFeedback == null ? 0 : Chassis.
+                    Outputs[output].VideoOutFeedback.Number;
 
-                    Debug.Console(2, this, "DMSwitchVideo:{0} Routed Input:{1} Output:{2}'", this.Name, Chassis.Outputs[output].VideoOutFeedback.Number, output);
+                    Debug.Console(2, this, "DMSwitchVideo:{0} Routed Input:{1} Output:{2}'", this.Name, inputNumber, output);
 
                     if (VideoOutputFeedbacks.ContainsKey(output))
                     {
+                        var localInputPort = InputPorts.FirstOrDefault(p => (DMInput)p.FeedbackMatchObject == Chassis.Outputs[output].VideoOutFeedback);
+                        var localOutputPort =
+                            OutputPorts.FirstOrDefault(p => (DMOutput) p.FeedbackMatchObject == Chassis.Outputs[output]);
+
+
                         VideoOutputFeedbacks[output].FireUpdate();
-                        OnSwitchChange(new RoutingNumericEventArgs(output, Chassis.Outputs[output].VideoOutFeedback.Number, eRoutingSignalType.Video));
+                        OnSwitchChange(new RoutingNumericEventArgs(output,
+                            inputNumber,
+                            localOutputPort,
+                            localInputPort,
+                            eRoutingSignalType.Video));
                     }
 
                     if (OutputVideoRouteNameFeedbacks.ContainsKey(output))
@@ -969,14 +995,24 @@ namespace PepperDash.Essentials.DM
                 }
                 case DMOutputEventIds.AudioOutEventId:
                 {
-                    if (Chassis.Outputs[output].AudioOutFeedback == null) return;
+                    var inputNumber = Chassis.Outputs[output].AudioOutFeedback == null ? 0 : Chassis.
+                    Outputs[output].AudioOutFeedback.Number;
 
-                    Debug.Console(2, this, "DMSwitchAudio:{0} Routed Input:{1} Output:{2}'", this.Name, Chassis.Outputs[output].AudioOutFeedback.Number, output);
+                    Debug.Console(2, this, "DMSwitchAudio:{0} Routed Input:{1} Output:{2}'", this.Name, inputNumber, output);
 
                     if (AudioOutputFeedbacks.ContainsKey(output))
                     {
+                        var localInputPort = InputPorts.FirstOrDefault(p => (DMInput)p.FeedbackMatchObject == Chassis.Outputs[output].AudioOutFeedback);
+                        var localOutputPort =
+                            OutputPorts.FirstOrDefault(p => (DMOutput)p.FeedbackMatchObject == Chassis.Outputs[output]);
+
+
                         AudioOutputFeedbacks[output].FireUpdate();
-                        OnSwitchChange(new RoutingNumericEventArgs(output, Chassis.Outputs[output].VideoOutFeedback.Number, eRoutingSignalType.Audio));
+                        OnSwitchChange(new RoutingNumericEventArgs(output,
+                            inputNumber,
+                            localOutputPort,
+                            localInputPort,
+                            eRoutingSignalType.Audio));
                     }
 
                     if (OutputAudioRouteNameFeedbacks.ContainsKey(output))

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -914,7 +914,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -63,7 +63,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/HdMdNxM4kEBridgeableController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/HdMdNxM4kEBridgeableController.cs
@@ -109,7 +109,7 @@ namespace PepperDash.Essentials.DM.Chassis
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
@@ -38,7 +38,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx200Controller.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx200Controller.cs
@@ -17,7 +17,7 @@ namespace PepperDash.Essentials.DM
     /// Controller class for all DM-TX-201C/S/F transmitters
     /// </summary>
     [Description("Wrapper class for DM-TX-200-C")]
-    public class DmTx200Controller : DmTxControllerBase, ITxRouting, IHasFreeRun, IVgaBrightnessContrastControls
+    public class DmTx200Controller : DmTxControllerBase, ITxRoutingWithFeedback, IHasFreeRun, IVgaBrightnessContrastControls
     {
         public DmTx200C2G Tx { get; private set; }
 
@@ -36,6 +36,19 @@ namespace PepperDash.Essentials.DM
 
         public IntFeedback VgaBrightnessFeedback { get; protected set; }
         public IntFeedback VgaContrastFeedback { get; protected set; }
+
+        //IroutingNumericEvent
+        public event EventHandler NumericSwitchChange;
+
+        /// <summary>
+        /// Raise an event when the status of a switch object changes.
+        /// </summary>
+        /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
+        public void OnSwitchChange(RoutingNumericEventArgs e)
+        {
+            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+        }
+
 
         /// <summary>
         /// Helps get the "real" inputs, including when in Auto
@@ -200,6 +213,9 @@ namespace PepperDash.Essentials.DM
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+
 
         }
 
@@ -307,10 +323,12 @@ namespace PepperDash.Essentials.DM
                     Debug.Console(2, this, "  Video Source: {0}", Tx.VideoSourceFeedback);
                     VideoSourceNumericFeedback.FireUpdate();
                     ActiveVideoInputFeedback.FireUpdate();
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
                     Debug.Console(2, this, "  Audio Source: {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
                     break;
             }
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx200Controller.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx200Controller.cs
@@ -44,7 +44,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
@@ -43,7 +43,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201CController.cs
@@ -15,7 +15,7 @@ namespace PepperDash.Essentials.DM
     /// Controller class for all DM-TX-201C/S/F transmitters
     /// </summary>
     [Description("Wrapper class for DM-TX-201-C")]
-    public class DmTx201CController : DmTxControllerBase, ITxRouting, IHasFreeRun, IVgaBrightnessContrastControls
+    public class DmTx201CController : DmTxControllerBase, ITxRoutingWithFeedback, IHasFreeRun, IVgaBrightnessContrastControls
 	{
 		public DmTx201C Tx { get; private set; }
 
@@ -35,6 +35,18 @@ namespace PepperDash.Essentials.DM
 
         public IntFeedback VgaBrightnessFeedback { get; protected set; }
         public IntFeedback VgaContrastFeedback { get; protected set; }
+
+        //IroutingNumericEvent
+        public event EventHandler NumericSwitchChange;
+
+        /// <summary>
+        /// Raise an event when the status of a switch object changes.
+        /// </summary>
+        /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
+        public void OnSwitchChange(RoutingNumericEventArgs e)
+        {
+            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+        }
 
 		/// <summary>
 		/// Helps get the "real" inputs, including when in Auto
@@ -197,7 +209,8 @@ namespace PepperDash.Essentials.DM
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
-            
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
         }
 
         private void VgaInputOnInputStreamChange(EndpointInputStream inputStream, EndpointInputStreamEventArgs args)
@@ -323,10 +336,12 @@ namespace PepperDash.Essentials.DM
                     ActiveVideoInputFeedback.FireUpdate();	                    
                     VideoSourceNumericFeedback.FireUpdate();
             	    ActiveVideoInputFeedback.FireUpdate();
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
                     Debug.Console(2, this, " Audio Source : {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
                     break;
             }          
 		}

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201SController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201SController.cs
@@ -43,7 +43,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201SController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx201SController.cs
@@ -4,6 +4,7 @@ using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM;
 using Crestron.SimplSharpPro.DM.Endpoints;
 using Crestron.SimplSharpPro.DM.Endpoints.Transmitters;
+using System.Linq;
 
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
@@ -37,15 +38,17 @@ namespace PepperDash.Essentials.DM
         public IntFeedback VgaContrastFeedback { get; protected set; }
 
         //IroutingNumericEvent
-        public event EventHandler NumericSwitchChange;
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
 
+        /// <summary>
         /// <summary>
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
         private void OnSwitchChange(RoutingNumericEventArgs e)
         {
-            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
         }
 
 
@@ -105,11 +108,19 @@ namespace PepperDash.Essentials.DM
             Tx = tx;
 
             HdmiInput = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn,
-                eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, DmTx200Base.eSourceSelection.Digital, this,
-                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInput));
+                eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi,
+                DmTx200Base.eSourceSelection.Digital, this,
+                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInput))
+            {
+                FeedbackMatchObject = DmTx200Base.eSourceSelection.Digital
+            };
+
             VgaInput = new RoutingInputPortWithVideoStatuses(DmPortName.VgaIn,
                 eRoutingSignalType.Video, eRoutingPortConnectionType.Vga, DmTx200Base.eSourceSelection.Analog, this,
-                VideoStatusHelper.GetVgaInputStatusFuncs(tx.VgaInput));
+                VideoStatusHelper.GetVgaInputStatusFuncs(tx.VgaInput))
+            {
+                FeedbackMatchObject = DmTx200Base.eSourceSelection.Analog
+            };
 
             ActiveVideoInputFeedback = new StringFeedback("ActiveVideoInput",
                 () => ActualActiveVideoInput.ToString());
@@ -207,11 +218,17 @@ namespace PepperDash.Essentials.DM
 
         void Tx_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
         {
+            var localVideoInputPort =
+                InputPorts.FirstOrDefault(p => (DmTx200Base.eSourceSelection)p.Selector == Tx.VideoSourceFeedback);
+            var localAudioInputPort =
+                InputPorts.FirstOrDefault(p => (DmTx200Base.eSourceSelection)p.Selector == Tx.AudioSourceFeedback);
+
+
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
-            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
-            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localAudioInputPort, eRoutingSignalType.Audio));
         }
 
         private void VgaInputOnInputStreamChange(EndpointInputStream inputStream, EndpointInputStreamEventArgs args)
@@ -333,16 +350,17 @@ namespace PepperDash.Essentials.DM
             switch (id)
             {
                 case EndpointTransmitterBase.VideoSourceFeedbackEventId:
+                    var localVideoInputPort = InputPorts.FirstOrDefault(p => (DmTx200Base.eSourceSelection)p.Selector == Tx.VideoSourceFeedback);
                     Debug.Console(2, this, "  Video Source: {0}", Tx.VideoSourceFeedback);
-                    ActiveVideoInputFeedback.FireUpdate();
                     VideoSourceNumericFeedback.FireUpdate();
                     ActiveVideoInputFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
-                    Debug.Console(2, this, " Audio Source : {0}", Tx.AudioSourceFeedback);
+                    var localInputAudioPort = InputPorts.FirstOrDefault(p => (DmTx200Base.eSourceSelection)p.Selector == Tx.AudioSourceFeedback);
+                    Debug.Console(2, this, "  Audio Source: {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localInputAudioPort, eRoutingSignalType.Audio));
                     break;
             }
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx401CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx401CController.cs
@@ -50,7 +50,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k202CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k202CController.cs
@@ -40,7 +40,7 @@ namespace PepperDash.Essentials.DM
         public BoolFeedback Hdmi2VideoSyncFeedback { get; protected set; }
 
         //IroutingNumericEvent
-        public event EventHandler NumericSwitchChange;
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
 
         /// <summary>
         /// Raise an event when the status of a switch object changes.
@@ -48,7 +48,8 @@ namespace PepperDash.Essentials.DM
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
         private void OnSwitchChange(RoutingNumericEventArgs e)
         {
-            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
         }
 
 
@@ -94,6 +95,7 @@ namespace PepperDash.Essentials.DM
                 return new RoutingPortCollection<RoutingOutputPort> { DmOut, HdmiLoopOut };
             }
         }
+
         public DmTx4k202CController(string key, string name, DmTx4k202C tx)
             : base(key, name, tx)
         {
@@ -101,10 +103,17 @@ namespace PepperDash.Essentials.DM
 
             HdmiIn1 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn1,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi1, this,
-                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]));
+                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]))
+            {
+                FeedbackMatchObject = eVst.Hdmi1
+            };
             HdmiIn2 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn2,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi2, this,
-                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]));
+                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]))
+            {
+                FeedbackMatchObject = eVst.Hdmi2
+            };
+
             ActiveVideoInputFeedback = new StringFeedback("ActiveVideoInput",
                 () => ActualActiveVideoInput.ToString());
 
@@ -115,15 +124,17 @@ namespace PepperDash.Essentials.DM
 
             Tx.BaseEvent += Tx_BaseEvent;
 
-            Tx.OnlineStatusChange +=Tx_OnlineStatusChange;
+            Tx.OnlineStatusChange += Tx_OnlineStatusChange;
 
-            VideoSourceNumericFeedback = new IntFeedback(() => (int)Tx.VideoSourceFeedback);
+            VideoSourceNumericFeedback = new IntFeedback(() => (int) Tx.VideoSourceFeedback);
 
-            AudioSourceNumericFeedback = new IntFeedback(() => (int)Tx.AudioSourceFeedback);
+            AudioSourceNumericFeedback = new IntFeedback(() => (int) Tx.AudioSourceFeedback);
 
-            HdmiIn1HdcpCapabilityFeedback = new IntFeedback("HdmiIn1HdcpCapability", () => (int)tx.HdmiInputs[1].HdcpCapabilityFeedback);
+            HdmiIn1HdcpCapabilityFeedback = new IntFeedback("HdmiIn1HdcpCapability",
+                () => (int) tx.HdmiInputs[1].HdcpCapabilityFeedback);
 
-            HdmiIn2HdcpCapabilityFeedback = new IntFeedback("HdmiIn2HdcpCapability", () => (int)tx.HdmiInputs[2].HdcpCapabilityFeedback);
+            HdmiIn2HdcpCapabilityFeedback = new IntFeedback("HdmiIn2HdcpCapability",
+                () => (int) tx.HdmiInputs[2].HdcpCapabilityFeedback);
 
             HdcpStateFeedback =
                 new IntFeedback(
@@ -134,17 +145,17 @@ namespace PepperDash.Essentials.DM
 
             HdcpSupportCapability = eHdcpCapabilityType.Hdcp2_2Support;
 
-            Hdmi1VideoSyncFeedback = new BoolFeedback(() => (bool)tx.HdmiInputs[1].SyncDetectedFeedback.BoolValue);
+            Hdmi1VideoSyncFeedback = new BoolFeedback(() => (bool) tx.HdmiInputs[1].SyncDetectedFeedback.BoolValue);
 
-            Hdmi2VideoSyncFeedback = new BoolFeedback(() => (bool)tx.HdmiInputs[2].SyncDetectedFeedback.BoolValue);
+            Hdmi2VideoSyncFeedback = new BoolFeedback(() => (bool) tx.HdmiInputs[2].SyncDetectedFeedback.BoolValue);
 
             var combinedFuncs = new VideoStatusFuncsWrapper
             {
                 HdcpActiveFeedbackFunc = () =>
                     (ActualActiveVideoInput == eVst.Hdmi1
-                    && tx.HdmiInputs[1].VideoAttributes.HdcpActiveFeedback.BoolValue)
+                     && tx.HdmiInputs[1].VideoAttributes.HdcpActiveFeedback.BoolValue)
                     || (ActualActiveVideoInput == eVst.Hdmi2
-                    && tx.HdmiInputs[2].VideoAttributes.HdcpActiveFeedback.BoolValue),
+                        && tx.HdmiInputs[2].VideoAttributes.HdcpActiveFeedback.BoolValue),
 
                 HdcpStateFeedbackFunc = () =>
                 {
@@ -165,25 +176,28 @@ namespace PepperDash.Essentials.DM
                 },
                 VideoSyncFeedbackFunc = () =>
                     (ActualActiveVideoInput == eVst.Hdmi1
-                    && tx.HdmiInputs[1].SyncDetectedFeedback.BoolValue)
+                     && tx.HdmiInputs[1].SyncDetectedFeedback.BoolValue)
                     || (ActualActiveVideoInput == eVst.Hdmi2
-                    && tx.HdmiInputs[2].SyncDetectedFeedback.BoolValue)
+                        && tx.HdmiInputs[2].SyncDetectedFeedback.BoolValue)
 
             };
 
             AnyVideoInput = new RoutingInputPortWithVideoStatuses(DmPortName.AnyVideoIn,
-                eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.None, 0, this, combinedFuncs);
+                eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.None, 0, this,
+                combinedFuncs);
 
             DmOut = new RoutingOutputPort(DmPortName.DmOut, eRoutingSignalType.Audio | eRoutingSignalType.Video,
                 eRoutingPortConnectionType.DmCat, null, this);
-            HdmiLoopOut = new RoutingOutputPort(DmPortName.HdmiLoopOut, eRoutingSignalType.Audio | eRoutingSignalType.Video,
+            HdmiLoopOut = new RoutingOutputPort(DmPortName.HdmiLoopOut,
+                eRoutingSignalType.Audio | eRoutingSignalType.Video,
                 eRoutingPortConnectionType.Hdmi, null, this);
 
 
             AddToFeedbackList(ActiveVideoInputFeedback, VideoSourceNumericFeedback, AudioSourceNumericFeedback,
                 AnyVideoInput.VideoStatus.HasVideoStatusFeedback, AnyVideoInput.VideoStatus.HdcpActiveFeedback,
                 AnyVideoInput.VideoStatus.HdcpStateFeedback, AnyVideoInput.VideoStatus.VideoResolutionFeedback,
-                AnyVideoInput.VideoStatus.VideoSyncFeedback, HdmiIn1HdcpCapabilityFeedback, HdmiIn2HdcpCapabilityFeedback,
+                AnyVideoInput.VideoStatus.VideoSyncFeedback, HdmiIn1HdcpCapabilityFeedback,
+                HdmiIn2HdcpCapabilityFeedback,
                 Hdmi1VideoSyncFeedback, Hdmi2VideoSyncFeedback);
 
             // Set Ports for CEC
@@ -313,13 +327,16 @@ namespace PepperDash.Essentials.DM
 
         void Tx_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
         {
+            var localVideoInputPort =
+                InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
+            var localAudioInputPort =
+                InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
+
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
-            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Video));
-            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Audio));
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localAudioInputPort, eRoutingSignalType.Audio));
         }
 
         void Tx_BaseEvent(GenericBase device, BaseEventArgs args)
@@ -330,18 +347,19 @@ namespace PepperDash.Essentials.DM
             switch (id)
             {
                 case EndpointTransmitterBase.VideoSourceFeedbackEventId:
+                    var localVideoInputPort = InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
                     Debug.Console(2, this, "  Video Source: {0}", Tx.VideoSourceFeedback);
-                    ActiveVideoInputFeedback.FireUpdate();
                     VideoSourceNumericFeedback.FireUpdate();
                     ActiveVideoInputFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
-                    Debug.Console(2, this, " Audio Source : {0}", Tx.AudioSourceFeedback);
+                    var localInputAudioPort = InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
+                    Debug.Console(2, this, "  Audio Source: {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localInputAudioPort, eRoutingSignalType.Audio));
                     break;
-            } 
+            }
         }
 
         /// <summary>

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k202CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k202CController.cs
@@ -46,7 +46,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k302CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k302CController.cs
@@ -47,7 +47,7 @@ namespace PepperDash.Essentials.DM
         public IntFeedback VgaContrastFeedback { get; protected set; }
 
         //IroutingNumericEvent
-        public event EventHandler NumericSwitchChange;
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
 
         /// <summary>
         /// Raise an event when the status of a switch object changes.
@@ -55,7 +55,8 @@ namespace PepperDash.Essentials.DM
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
         private void OnSwitchChange(RoutingNumericEventArgs e)
         {
-            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
         }
 
 
@@ -108,13 +109,24 @@ namespace PepperDash.Essentials.DM
 
 			HdmiIn1 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn1,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi1, this,
-				VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]));
+				VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]))
+			{
+			    FeedbackMatchObject = eVst.Hdmi1
+			};
 			HdmiIn2 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn2,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi2, this,
-				VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]));
+				VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]))
+            {
+                FeedbackMatchObject = eVst.Hdmi2
+            };
+            
 			VgaIn = new RoutingInputPortWithVideoStatuses(DmPortName.VgaIn,
                 eRoutingSignalType.Video, eRoutingPortConnectionType.Vga, eVst.Vga, this, 
-				VideoStatusHelper.GetVgaInputStatusFuncs(tx.VgaInput));
+				VideoStatusHelper.GetVgaInputStatusFuncs(tx.VgaInput))
+            {
+                FeedbackMatchObject = eVst.Vga
+            };
+
 			ActiveVideoInputFeedback = new StringFeedback("ActiveVideoInput",
 				() => ActualActiveVideoInput.ToString());
 
@@ -404,30 +416,37 @@ namespace PepperDash.Essentials.DM
         }
         void Tx_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
         {
+            var localVideoInputPort =
+                InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
+            var localAudioInputPort =
+                InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
+
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
-            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Video));
-            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Audio));
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localAudioInputPort, eRoutingSignalType.Audio));
         }
 
         void Tx_BaseEvent(GenericBase device, BaseEventArgs args)
         {
             var id = args.EventId;
+            Debug.Console(2, this, "EventId {0}", args.EventId);
+
             switch (id)
             {
                 case EndpointTransmitterBase.VideoSourceFeedbackEventId:
+                    var localVideoInputPort = InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
                     Debug.Console(2, this, "  Video Source: {0}", Tx.VideoSourceFeedback);
                     VideoSourceNumericFeedback.FireUpdate();
                     ActiveVideoInputFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
+                    var localInputAudioPort = InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
                     Debug.Console(2, this, "  Audio Source: {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localInputAudioPort, eRoutingSignalType.Audio));
                     break;
             }
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k302CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4k302CController.cs
@@ -53,7 +53,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz202CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz202CController.cs
@@ -42,7 +42,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
@@ -1,5 +1,6 @@
 ﻿using Crestron.SimplSharpPro;
 using System;
+using System.Linq;
 //using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM;
@@ -41,7 +42,7 @@ namespace PepperDash.Essentials.DM
         //public override ushort HdcpSupportCapability { get; protected set; }
 
         //IroutingNumericEvent
-        public event EventHandler NumericSwitchChange;
+        public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
 
         /// <summary>
         /// Raise an event when the status of a switch object changes.
@@ -49,7 +50,8 @@ namespace PepperDash.Essentials.DM
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
         private void OnSwitchChange(RoutingNumericEventArgs e)
         {
-            if (NumericSwitchChange != null) NumericSwitchChange(this, e);
+            var newEvent = NumericSwitchChange;
+            if (newEvent != null) newEvent(this, e);
         }
 
         /// <summary>
@@ -96,13 +98,22 @@ namespace PepperDash.Essentials.DM
 
             HdmiIn1 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn1,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi1, this,
-                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]));
+                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[1]))
+            {
+                FeedbackMatchObject = eVst.Hdmi1
+            };
             HdmiIn2 = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn2,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, eVst.Hdmi2, this,
-                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]));
-            DisplayPortIn = new RoutingInputPortWithVideoStatuses(DmPortName.VgaIn,
+                VideoStatusHelper.GetHdmiInputStatusFuncs(tx.HdmiInputs[2]))
+            {
+                FeedbackMatchObject = eVst.Hdmi2
+            };
+            DisplayPortIn = new RoutingInputPortWithVideoStatuses(DmPortName.DisplayPortIn,
                 eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.DisplayPort, eVst.DisplayPort, this,
-                VideoStatusHelper.GetDisplayPortInputStatusFuncs(tx.DisplayPortInput));
+                VideoStatusHelper.GetDisplayPortInputStatusFuncs(tx.DisplayPortInput))
+            {
+                FeedbackMatchObject = eVst.DisplayPort
+            };
             ActiveVideoInputFeedback = new StringFeedback("ActiveVideoInput",
                 () => ActualActiveVideoInput.ToString());
 
@@ -309,33 +320,40 @@ namespace PepperDash.Essentials.DM
             }
         }
 
-        private void Tx_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
+        void Tx_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
         {
+            var localVideoInputPort =
+                InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
+            var localAudioInputPort =
+                InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
+
             ActiveVideoInputFeedback.FireUpdate();
             VideoSourceNumericFeedback.FireUpdate();
             AudioSourceNumericFeedback.FireUpdate();
-            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Video));
-            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue,
-                eRoutingSignalType.Audio));
+            OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
+            OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localAudioInputPort, eRoutingSignalType.Audio));
         }
 
 
         void Tx_BaseEvent(GenericBase device, BaseEventArgs args)
         {
             var id = args.EventId;
+            Debug.Console(2, this, "EventId {0}", args.EventId);
+
             switch (id)
             {
                 case EndpointTransmitterBase.VideoSourceFeedbackEventId:
+                    var localVideoInputPort = InputPorts.FirstOrDefault(p => (eVst)p.Selector == Tx.VideoSourceFeedback);
                     Debug.Console(2, this, "  Video Source: {0}", Tx.VideoSourceFeedback);
                     VideoSourceNumericFeedback.FireUpdate();
                     ActiveVideoInputFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Video));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, OutputPorts.First(), localVideoInputPort, eRoutingSignalType.Video));
                     break;
                 case EndpointTransmitterBase.AudioSourceFeedbackEventId:
+                    var localInputAudioPort = InputPorts.FirstOrDefault(p => (eAst)p.Selector == Tx.AudioSourceFeedback);
                     Debug.Console(2, this, "  Audio Source: {0}", Tx.AudioSourceFeedback);
                     AudioSourceNumericFeedback.FireUpdate();
-                    OnSwitchChange(new RoutingNumericEventArgs(1, VideoSourceNumericFeedback.UShortValue, eRoutingSignalType.Audio));
+                    OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localInputAudioPort, eRoutingSignalType.Audio));
                     break;
             }
         }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTx4kz302CController.cs
@@ -47,7 +47,7 @@ namespace PepperDash.Essentials.DM
         /// Raise an event when the status of a switch object changes.
         /// </summary>
         /// <param name="e">Arguments defined as IKeyName sender, output, input, and eRoutingSignalType</param>
-        public void OnSwitchChange(RoutingNumericEventArgs e)
+        private void OnSwitchChange(RoutingNumericEventArgs e)
         {
             if (NumericSwitchChange != null) NumericSwitchChange(this, e);
         }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/SamsungMDCDisplay.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Display/SamsungMDCDisplay.cs
@@ -24,6 +24,8 @@ namespace PepperDash.Essentials.Devices.Displays
         IInputHdmi1, IInputHdmi2, IInputHdmi3, IInputHdmi4, IBridgeAdvanced
 	{
 		public IBasicCommunication Communication { get; private set; }
+
+
 				
         public StatusMonitorBase CommunicationMonitor { get; private set; }
 
@@ -326,6 +328,9 @@ namespace PepperDash.Essentials.Devices.Displays
             }
         }
 
+        
+
+
         /// <summary>
         /// 
         /// </summary>
@@ -336,6 +341,7 @@ namespace PepperDash.Essentials.Devices.Displays
             {
                 _CurrentInputPort = newInput;
                 CurrentInputFeedback.FireUpdate();
+                OnSwitchChange(new RoutingNumericEventArgs(null, _CurrentInputPort, eRoutingSignalType.AudioVideo));
             }
         }
 


### PR DESCRIPTION
Added several interfaces and implemented them appropriately.

The main purpose of the interface is to expose an event for Routing on each device that supports routing.  Then plugins can get the route data in an easily digestible format, regardless of the device.  It also implements IKeyedName so you can grab a reference to the sender from the DeviceManager without a direct cast to IKeyed.

The base interface hooks into several other interfaces to expand their functionality.