### PR TITLE
Add dm streaming start stop support

### DIFF
--- a/PepperDashEssentials/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
+++ b/PepperDashEssentials/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
@@ -70,6 +70,14 @@ namespace PepperDash.Essentials.Bridges
         /// Range reports the highest supported HDCP state level for the corresponding input card
         /// </summary>
         public uint HdcpSupportCapability { get; set; }
+        /// <summary>
+        /// DM Chassis Stream Input Start (1), Stop (2), Pause (3) with Feedback
+        /// </summary>
+        public uint InputStreamCardStatus { get; set; }
+        /// <summary>
+        /// DM Chassis Stream Output Start (1), Stop (2), Pause (3) with Feedback
+        /// </summary>
+        public uint OutputStreamCardStatus { get; set; }
 #endregion
 
 #region Serials
@@ -115,6 +123,8 @@ namespace PepperDash.Essentials.Bridges
             InputUsb = 700; //701-899
             HdcpSupportState = 1000; //1001-1199
             HdcpSupportCapability = 1200; //1201-1399
+            InputStreamCardStatus = 1500; //1501-1532
+            OutputStreamCardStatus = 1600; //1601-1632
 
 
             //Serial
@@ -145,6 +155,8 @@ namespace PepperDash.Essentials.Bridges
             OutputEndpointOnline = OutputEndpointOnline + joinOffset;
             HdcpSupportState = HdcpSupportState + joinOffset;
             HdcpSupportCapability = HdcpSupportCapability + joinOffset;
+            InputStreamCardStatus = InputStreamCardStatus + joinOffset;
+            OutputStreamCardStatus = OutputStreamCardStatus + joinOffset;
             OutputDisabledByHdcp = OutputDisabledByHdcp + joinOffset;
             TxAdvancedIsPresent = TxAdvancedIsPresent + joinOffset;
         }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
@@ -76,6 +76,14 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete HdcpSupportCapability = new JoinDataComplete(new JoinData { JoinNumber = 1201, JoinSpan = 32 },
             new JoinMetadata { Description = "DM Chassis Input HDCP Support Capability", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Analog });
 
+        [JoinName("InputStreamCardState")]
+        public JoinDataComplete InputStreamCardState = new JoinDataComplete(new JoinData { JoinNumber = 1501, JoinSpan = 32 },
+            new JoinMetadata { Description = "DM Chassis Stream Input Start (1), Stop (2), Pause (3) with Feedback", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Analog });
+
+        [JoinName("OutputStreamCardState")]
+        public JoinDataComplete OutputStreamCardState = new JoinDataComplete(new JoinData { JoinNumber = 1601, JoinSpan = 32 },
+            new JoinMetadata { Description = "DM Chassis Stream Output Start (1), Stop (2), Pause (3) with Feedback", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Analog });
+
         [JoinName("InputNames")]
         public JoinDataComplete InputNames = new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 32 },
             new JoinMetadata { Description = "DM Chassis Input Name", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Serial });

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -320,7 +320,7 @@ namespace PepperDash.Essentials.DM
 
                             if (outputCard.Card is DmcStroAV)
                             {
-                                Debug.Console(0, "Found output stream card in slot: {0}.", tempX);
+                                Debug.Console(2, "Found output stream card in slot: {0}.", tempX);
                                 var streamCard = outputCard.Card as DmcStroAV;
                                 if (streamCard.Control.StartFeedback.BoolValue == true)
                                     return 1;
@@ -446,7 +446,7 @@ namespace PepperDash.Essentials.DM
 
                             if (inputCard.Card is DmcStr)
                             {
-                                Debug.Console(0, "Found input stream card in slot: {0}.", tempX);
+                                Debug.Console(2, "Found input stream card in slot: {0}.", tempX);
                                 var streamCard = inputCard.Card as DmcStr;
                                 if (streamCard.Control.StartFeedback.BoolValue == true)
                                     return 1;
@@ -981,33 +981,10 @@ namespace PepperDash.Essentials.DM
                             Debug.Console(2, this, "DM Input {0} Stream Status EventId", args.Number);
                             if (InputStreamCardStateFeedbacks[args.Number] != null)
                             {
-                                var streamCard = Chassis.Inputs[args.Number].Card as DmcStr;
-                                InputStreamCardStateFeedbacks[args.Number] = new IntFeedback(() => {
-                                    if (streamCard.Control.StartFeedback.BoolValue == true)
-                                    {
-                                        Debug.Console(1, this, "Found start feedback");
-                                        return 1;
-                                    }
-                                    else if (streamCard.Control.StopFeedback.BoolValue == true)
-                                    {
-                                        Debug.Console(1, this, "Found stop feedback");
-                                        return 2;
-                                    }
-                                    else if (streamCard.Control.PauseFeedback.BoolValue == true)
-                                    {
-                                        Debug.Console(1, this, "Found pause feedback");
-                                        return 3;
-                                    }
-                                    else
-                                    {
-                                        Debug.Console(1, this, "Found no feedback");
-                                        return 0;
-                                    }
-                                });
                                 InputStreamCardStateFeedbacks[args.Number].FireUpdate();
                             }
                             else
-                                Debug.Console(1, this, "No index of {0} found in InputStreamCardStateFeedbacks");
+                                Debug.Console(2, this, "No index of {0} found in InputStreamCardStateFeedbacks");
                             break;
                         }
                     default:
@@ -1145,22 +1122,10 @@ namespace PepperDash.Essentials.DM
                     Debug.Console(2, this, "DM Output {0} Stream Status EventId", args.Number);
                     if (OutputStreamCardStateFeedbacks[args.Number] != null)
                     {
-                        var streamCard = Chassis.Outputs[args.Number].Card as DmcStroAV;
-                        OutputStreamCardStateFeedbacks[args.Number] = new IntFeedback(() =>
-                        {
-                            if (streamCard.Control.StartFeedback.BoolValue == true)
-                                return 1;
-                            else if (streamCard.Control.StopFeedback.BoolValue == true)
-                                return 2;
-                            else if (streamCard.Control.PauseFeedback.BoolValue == true)
-                                return 3;
-                            else
-                                return 0;
-                        });
                         OutputStreamCardStateFeedbacks[args.Number].FireUpdate();
                     }
                     else
-                        Debug.Console(1, this, "No index of {0} found in OutputStreamCardStateFeedbacks");
+                        Debug.Console(2, this, "No index of {0} found in OutputStreamCardStateFeedbacks");
                     break;
                 }
                 default:


### PR DESCRIPTION
Proposed feature to resolve:
https://github.com/PepperDash/Essentials/issues/94

Adds DMC-STR (input card) and DMC-STRO (output card) start/stop/pause support via SIMPL bridge.

Input cards: join 1501-1532
Output cards: join 1601-1632

Ushort values:
0=unknown, 1=start, 2=stop 3=pause

Tested on a DMC-STR. DMC-STRO has not been tested.