### PR TITLE
[BUG] Add safety check for casting device into interface

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -360,9 +360,9 @@ namespace PepperDash.Essentials.Core
 	    {
 	        var device = GetDeviceForKey(s);
 
-	        if (device == null) return;
-	        var inputPorts = (device as IRoutingInputsOutputs).InputPorts;
-	        var outputPorts = (device as IRoutingInputsOutputs).OutputPorts;
+            if (device == null) return;
+            var inputPorts = ((device as IRoutingInputs) != null) ? (device as IRoutingInputs).InputPorts : null;
+            var outputPorts = ((device as IRoutingOutputs) != null) ? (device as IRoutingOutputs).OutputPorts : null;
 	        if (inputPorts != null)
 	        {
 	            Debug.Console(0, "Device {0} has {1} Input Ports:", s, inputPorts.Count);


### PR DESCRIPTION
(device as IRoutingInputsOutputs).InputPorts will throw Exception on accessing InputPorts property if device do not implement such interface.
