### PR TITLE
Hotfix/videocodecbase incoming call popup

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -848,7 +848,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 				Debug.Console(1, this, "Call Direction: {0}", args.CallItem.Direction);
 				Debug.Console(1, this, "Call is incoming: {0}", args.CallItem.Direction == eCodecCallDirection.Incoming);
-				trilist.SetBool(joinMap.IncomingCall.JoinNumber, args.CallItem.Direction == eCodecCallDirection.Incoming && args.CallItem.Status != eCodecCallStatus.Disconnected);
+				trilist.SetBool(joinMap.IncomingCall.JoinNumber, args.CallItem.Direction == eCodecCallDirection.Incoming && args.CallItem.Status == eCodecCallStatus.Ringing);				
 
 				if (args.CallItem.Direction == eCodecCallDirection.Incoming)
 				{


### PR DESCRIPTION
Closes #553 

LinkVideoCodecCallControlsToApi IncomingCall bridge action to reference "args.CallItem.Status == eCodecCallStatus.Ringing" (previously referencing "args.CallItem.Status != eCodecCallStatus.Disconnected")