### PR TITLE
Fix old/wrong namespace versions to have copies of types that are in the correct one

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/GlsPartitionSensorJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/GlsPartitionSensorJoinMap.cs
@@ -146,16 +146,139 @@ namespace PepperDash_Essentials_Core.Bridges.JoinMaps
     /// 
     /// </summary>
     [Obsolete("use PepperDash.Essentials.Core.Bridges.JoinMaps version")]
-	public class GlsPartitionSensorJoinMap : PepperDash.Essentials.Core.Bridges.JoinMaps.GlsPartitionSensorJoinMap
+	public class GlsPartitionSensorJoinMap:JoinMapBaseAdvanced
 	{
+        [JoinName("IsOnline")]
+        public JoinDataComplete IsOnline = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 1,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Is Online",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("Name")]
+        public JoinDataComplete Name = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 1,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Name",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("Enable")]
+        public JoinDataComplete Enable = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 2,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Enable",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("PartitionSensed")]
+        public JoinDataComplete PartitionSensed = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 3,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Partition Sensed",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("PartitionNotSensed")]
+        public JoinDataComplete PartitionNotSensed = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 4,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Partition Not Sensed",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("IncreaseSensitivity")]
+        public JoinDataComplete IncreaseSensitivity = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 6,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Increase Sensitivity",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DecreaseSensitivity")]
+        public JoinDataComplete DecreaseSensitivity = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 7,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Decrease Sensitivity",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("Sensitivity")]
+        public JoinDataComplete Sensitivity = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 2,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Sensor Sensitivity",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        /// <summary>
+        /// Constructor to use when instantiating this Join Map without inheriting from it
+        /// </summary>
+        /// <param name="joinStart">Join this join map will start at</param>
         public GlsPartitionSensorJoinMap(uint joinStart)
             : this(joinStart, typeof(GlsPartitionSensorJoinMap))
         {
 
         }
 
-        protected GlsPartitionSensorJoinMap(uint joinStart, Type type) : base(joinStart, type)
+        /// <summary>
+        /// Constructor to use when extending this Join map
+        /// </summary>
+        /// <param name="joinStart">Join this join map will start at</param>
+        /// <param name="type">Type of the child join map</param>
+        protected GlsPartitionSensorJoinMap(uint joinStart, Type type)
+            : base(joinStart, type)
         {
+
         }
 	}
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/VideoCodecControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/VideoCodecControllerJoinMap.cs
@@ -895,15 +895,892 @@ namespace PepperDash.Essentials.Core.Bridges.JoinMaps
 namespace PepperDash_Essentials_Core.Bridges.JoinMaps
 {
     [Obsolete("Use PepperDash.Essentials.Core.Bridges.JoinMaps")]
-    public class VideoCodecControllerJoinMap : PepperDash.Essentials.Core.Bridges.JoinMaps.VideoCodecControllerJoinMap
+    public class VideoCodecControllerJoinMap :JoinMapBaseAdvanced
     {
 
-        public VideoCodecControllerJoinMap(uint joinStart) : this(joinStart, typeof (VideoCodecControllerJoinMap))
+                #region Status
+
+        [JoinName("IsOnline")]
+        public JoinDataComplete IsOnline =
+            new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Device is Online",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        #endregion
+
+        [JoinName("CallDirection")]
+        public JoinDataComplete CallDirection =
+            new JoinDataComplete(new JoinData { JoinNumber = 22, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Call Direction",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("CameraLayout")]
+        public JoinDataComplete CameraLayout =
+            new JoinDataComplete(new JoinData { JoinNumber = 142, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Layout Toggle",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraLayoutStringFb")]
+        public JoinDataComplete CameraLayoutStringFb =
+            new JoinDataComplete(new JoinData { JoinNumber = 141, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Layout Fb",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("CameraModeAuto")]
+        public JoinDataComplete CameraModeAuto =
+            new JoinDataComplete(new JoinData { JoinNumber = 131, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Mode Auto",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraModeManual")]
+        public JoinDataComplete CameraModeManual =
+            new JoinDataComplete(new JoinData { JoinNumber = 132, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Mode Manual",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraModeOff")]
+        public JoinDataComplete CameraModeOff =
+            new JoinDataComplete(new JoinData { JoinNumber = 133, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Mode Off",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraNumberSelect")]
+        public JoinDataComplete CameraNumberSelect =
+            new JoinDataComplete(new JoinData { JoinNumber = 60, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Number Select/FB",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("CameraPanLeft")]
+        public JoinDataComplete CameraPanLeft =
+            new JoinDataComplete(new JoinData { JoinNumber = 113, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Pan Left",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraPanRight")]
+        public JoinDataComplete CameraPanRight =
+            new JoinDataComplete(new JoinData { JoinNumber = 114, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Pan Right",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraPresetNames")]
+        public JoinDataComplete CameraPresetNames =
+            new JoinDataComplete(new JoinData { JoinNumber = 121, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Preset Names - XSIG, max of 15",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("CameraPresetSelect")]
+        public JoinDataComplete CameraPresetSelect =
+            new JoinDataComplete(new JoinData { JoinNumber = 121, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Preset Select",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("CameraPresetSave")]
+        public JoinDataComplete CameraPresetSave =
+            new JoinDataComplete(new JoinData { JoinNumber = 121, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Save Selected Preset",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraSelfView")]
+        public JoinDataComplete CameraSelfView =
+            new JoinDataComplete(new JoinData { JoinNumber = 141, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Self View Toggle/FB",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraSupportsAutoMode")]
+        public JoinDataComplete CameraSupportsAutoMode =
+            new JoinDataComplete(new JoinData { JoinNumber = 143, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Supports Auto Mode FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraSupportsOffMode")]
+        public JoinDataComplete CameraSupportsOffMode =
+            new JoinDataComplete(new JoinData { JoinNumber = 144, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Supports Off Mode FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraTiltDown")]
+        public JoinDataComplete CameraTiltDown =
+            new JoinDataComplete(new JoinData { JoinNumber = 112, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Tilt Down",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraTiltUp")]
+        public JoinDataComplete CameraTiltUp =
+            new JoinDataComplete(new JoinData { JoinNumber = 111, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Tilt Up",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraZoomIn")]
+        public JoinDataComplete CameraZoomIn =
+            new JoinDataComplete(new JoinData { JoinNumber = 115, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Zoom In",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CameraZoomOut")]
+        public JoinDataComplete CameraZoomOut =
+            new JoinDataComplete(new JoinData { JoinNumber = 116, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Camera Zoom Out",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("CurrentCallName")]
+        public JoinDataComplete CurrentCallData =
+            new JoinDataComplete(new JoinData { JoinNumber = 2, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Call Data - XSIG",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("CurrentDialString")]
+        public JoinDataComplete CurrentDialString =
+            new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Dial String",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("CurrentParticipants")]
+        public JoinDataComplete CurrentParticipants =
+            new JoinDataComplete(new JoinData { JoinNumber = 151, JoinSpan = 1 },
+            new JoinMetadata()
+            {
+                Description = "Current Participants XSig",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("CurrentSource")]
+        public JoinDataComplete CurrentSource =
+            new JoinDataComplete(new JoinData { JoinNumber = 201, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Source",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("DialMeeting1")]
+        public JoinDataComplete DialMeeting1 =
+            new JoinDataComplete(new JoinData { JoinNumber = 161, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Join first meeting",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DialMeeting2")]
+        public JoinDataComplete DialMeeting2 =
+            new JoinDataComplete(new JoinData { JoinNumber = 162, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Join second meeting",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DialMeeting3")]
+        public JoinDataComplete DialMeeting3 =
+            new JoinDataComplete(new JoinData { JoinNumber = 163, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Join third meeting",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryDialSelectedLine")]
+        public JoinDataComplete DirectoryDialSelectedLine =
+            new JoinDataComplete(new JoinData { JoinNumber = 106, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Dial selected directory line",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryEntries")]
+        public JoinDataComplete DirectoryEntries =
+            new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Entries - XSig, 255 entries",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("DirectoryEntryIsContact")]
+        public JoinDataComplete DirectoryEntryIsContact =
+            new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Selected Entry Is Contact FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryEntrySelectedName")]
+        public JoinDataComplete DirectoryEntrySelectedName =
+            new JoinDataComplete(new JoinData { JoinNumber = 356, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Selected Directory Entry Name",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("DirectoryEntrySelectedNumber")]
+        public JoinDataComplete DirectoryEntrySelectedNumber =
+            new JoinDataComplete(new JoinData { JoinNumber = 357, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Selected Directory Entry Number",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("DirectoryFolderBack")]
+        public JoinDataComplete DirectoryFolderBack =
+            new JoinDataComplete(new JoinData { JoinNumber = 105, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Go back one directory level",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryHasChanged")]
+        public JoinDataComplete DirectoryHasChanged =
+            new JoinDataComplete(new JoinData { JoinNumber = 103, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory has changed FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryIsRoot")]
+        public JoinDataComplete DirectoryIsRoot =
+            new JoinDataComplete(new JoinData { JoinNumber = 102, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory is on Root FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryLineSelected")]
+        public JoinDataComplete DirectoryLineSelected =
+            new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Line Selected FB",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryRoot")]
+        public JoinDataComplete DirectoryRoot =
+            new JoinDataComplete(new JoinData { JoinNumber = 104, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Go to Directory Root",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectoryRowCount")]
+        public JoinDataComplete DirectoryRowCount =
+            new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Row Count FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("DirectorySearchBusy")]
+        public JoinDataComplete DirectorySearchBusy =
+            new JoinDataComplete(new JoinData { JoinNumber = 100, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Search Busy FB",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DirectorySearchString")]
+        public JoinDataComplete DirectorySearchString =
+            new JoinDataComplete(new JoinData { JoinNumber = 100, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Search String",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("DirectorySelectRow")]
+        public JoinDataComplete DirectorySelectRow =
+            new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Directory Select Row",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("DirectorySelectedFolderName")]
+        public JoinDataComplete DirectorySelectedFolderName =
+            new JoinDataComplete(new JoinData { JoinNumber = 358, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Selected Directory Folder Name",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("0")]
+        public JoinDataComplete Dtmf0 =
+            new JoinDataComplete(new JoinData { JoinNumber = 20, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 0",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("1")]
+        public JoinDataComplete Dtmf1 =
+            new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 1",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("2")]
+        public JoinDataComplete Dtmf2 =
+            new JoinDataComplete(new JoinData { JoinNumber = 12, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 2",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("3")]
+        public JoinDataComplete Dtmf3 =
+            new JoinDataComplete(new JoinData { JoinNumber = 13, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 3",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("4")]
+        public JoinDataComplete Dtmf4 =
+            new JoinDataComplete(new JoinData { JoinNumber = 14, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 4",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("5")]
+        public JoinDataComplete Dtmf5 =
+            new JoinDataComplete(new JoinData { JoinNumber = 15, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 5",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("6")]
+        public JoinDataComplete Dtmf6 =
+            new JoinDataComplete(new JoinData { JoinNumber = 16, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 6",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("7")]
+        public JoinDataComplete Dtmf7 =
+            new JoinDataComplete(new JoinData { JoinNumber = 17, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 7",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("8")]
+        public JoinDataComplete Dtmf8 =
+            new JoinDataComplete(new JoinData { JoinNumber = 18, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 8",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("9")]
+        public JoinDataComplete Dtmf9 =
+            new JoinDataComplete(new JoinData { JoinNumber = 19, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF 9",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("#")]
+        public JoinDataComplete DtmfPound =
+            new JoinDataComplete(new JoinData { JoinNumber = 22, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF #",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("*")]
+        public JoinDataComplete DtmfStar =
+            new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "DTMF *",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("EndCall")]
+        public JoinDataComplete EndCall =
+            new JoinDataComplete(new JoinData { JoinNumber = 24, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Hang Up",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("HookState")]
+        public JoinDataComplete HookState =
+            new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Hook State",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("IncomingAnswer")]
+        public JoinDataComplete IncomingAnswer =
+            new JoinDataComplete(new JoinData { JoinNumber = 51, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Answer Incoming Call",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("IncomingCall")]
+        public JoinDataComplete IncomingCall =
+            new JoinDataComplete(new JoinData { JoinNumber = 50, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Incoming Call",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("IncomingCallName")]
+        public JoinDataComplete IncomingCallName =
+            new JoinDataComplete(new JoinData { JoinNumber = 51, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Incoming Call Name",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("IncomingCallNumber")]
+        public JoinDataComplete IncomingCallNumber =
+            new JoinDataComplete(new JoinData { JoinNumber = 52, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Incoming Call Number",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("IncomingReject")]
+        public JoinDataComplete IncomingReject =
+            new JoinDataComplete(new JoinData { JoinNumber = 52, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Reject Incoming Call",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+
+        [JoinName("ManualDial")]
+        public JoinDataComplete ManualDial =
+            new JoinDataComplete(new JoinData { JoinNumber = 71, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Dial manual string",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("Meeting Count Fb")]
+        public JoinDataComplete MeetingCount =
+            new JoinDataComplete(new JoinData { JoinNumber = 161, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Meeting Count",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("MicMuteOff")]
+        public JoinDataComplete MicMuteOff =
+            new JoinDataComplete(new JoinData { JoinNumber = 172, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Mic Mute Off",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("MicMuteOn")]
+        public JoinDataComplete MicMuteOn =
+            new JoinDataComplete(new JoinData { JoinNumber = 171, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Mic Mute On",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("MicMuteToggle")]
+        public JoinDataComplete MicMuteToggle =
+            new JoinDataComplete(new JoinData { JoinNumber = 173, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Mic Mute Toggle",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("MinutesBeforeMeetingStart")]
+        public JoinDataComplete MinutesBeforeMeetingStart =
+            new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Minutes before meeting start that a meeting is joinable",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("ParticipantCount")]
+        public JoinDataComplete ParticipantCount =
+            new JoinDataComplete(new JoinData { JoinNumber = 151, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Current Participant Count",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("Schedule")]
+        public JoinDataComplete Schedule =
+            new JoinDataComplete(new JoinData { JoinNumber = 102, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Schedule Data - XSIG",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("AutoShareWhileInCall")]
+        public JoinDataComplete SourceShareAutoStart =
+            new JoinDataComplete(new JoinData { JoinNumber = 203, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "When high, will autostart sharing when a call is joined",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("SourceShareEnd")]
+        public JoinDataComplete SourceShareEnd =
+            new JoinDataComplete(new JoinData { JoinNumber = 202, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Stop Sharing & Feedback",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("SourceShareStart")]
+        public JoinDataComplete SourceShareStart =
+            new JoinDataComplete(new JoinData { JoinNumber = 201, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Start Sharing & Feedback",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("RecievingContent")]
+        public JoinDataComplete RecievingContent =
+            new JoinDataComplete(new JoinData { JoinNumber = 204, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Recieving content from the far end",
+                JoinType = eJoinType.Digital,
+                JoinCapabilities = eJoinCapabilities.ToSIMPL
+            });
+
+        [JoinName("SelfviewPosition")]
+        public JoinDataComplete SelfviewPosition =
+            new JoinDataComplete(new JoinData { JoinNumber = 211, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "advance selfview position",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("SelfviewPositionFb")]
+        public JoinDataComplete SelfviewPositionFb =
+            new JoinDataComplete(new JoinData { JoinNumber = 211, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "advance selfview position",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        [JoinName("SpeedDialStart")]
+        public JoinDataComplete SpeedDialStart =
+            new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 4 },
+            new JoinMetadata
+            {
+                Description = "Speed Dial",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("UpdateMeetings")]
+        public JoinDataComplete UpdateMeetings =
+            new JoinDataComplete(new JoinData { JoinNumber = 160, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Update Meetings",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("VolumeDown")]
+        public JoinDataComplete VolumeDown =
+            new JoinDataComplete(new JoinData { JoinNumber = 175, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Down",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("VolumeLevel")]
+        public JoinDataComplete VolumeLevel =
+            new JoinDataComplete(new JoinData { JoinNumber = 174, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Level",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
+        [JoinName("VolumeMuteOff")]
+        public JoinDataComplete VolumeMuteOff =
+            new JoinDataComplete(new JoinData { JoinNumber = 177, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Mute Off",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("VolumeMuteOn")]
+        public JoinDataComplete VolumeMuteOn =
+            new JoinDataComplete(new JoinData { JoinNumber = 176, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Mute On",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("VolumeMuteToggle")]
+        public JoinDataComplete VolumeMuteToggle =
+            new JoinDataComplete(new JoinData { JoinNumber = 178, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Mute Toggle",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("VolumeUp")]
+        public JoinDataComplete VolumeUp =
+            new JoinDataComplete(new JoinData { JoinNumber = 174, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Volume Up",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("DialPhoneCall")]
+        public JoinDataComplete DialPhone =
+            new JoinDataComplete(new JoinData { JoinNumber = 72, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Dial Phone",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("PhoneHookState")]
+        public JoinDataComplete PhoneHookState =
+            new JoinDataComplete(new JoinData { JoinNumber = 72, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Dial Phone",
+                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("EndPhoneCall")]
+        public JoinDataComplete HangUpPhone =
+            new JoinDataComplete(new JoinData { JoinNumber = 73, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Hang Up PHone",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Digital
+            });
+
+        [JoinName("PhoneString")]
+        public JoinDataComplete PhoneDialString =
+            new JoinDataComplete(new JoinData { JoinNumber = 2, JoinSpan = 1 },
+            new JoinMetadata
+            {
+                Description = "Phone Dial String",
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
+                JoinType = eJoinType.Serial
+            });
+
+        public VideoCodecControllerJoinMap(uint joinStart)
+            : base(joinStart, typeof(VideoCodecControllerJoinMap))
         {
         }
 
-        public VideoCodecControllerJoinMap(uint joinStart, Type type) : base(joinStart, type)
+        public VideoCodecControllerJoinMap(uint joinStart, Type type)
+            : base(joinStart, type)
         {
         }
     }
-}
+    }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasBranding.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasBranding.cs
@@ -12,8 +12,9 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
 {
     [Obsolete("Use PepperDash.Essentials.Core.DeviceTypeInterfaces")]
-    public interface IHasBranding:PepperDash.Essentials.Core.DeviceTypeInterfaces.IHasBranding
+    public interface IHasBranding
     {
-
+        bool BrandingEnabled { get; }
+        void InitializeBranding(string roomKey);
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasPhoneDialing.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/IHasPhoneDialing.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using PepperDash.Essentials.Core;
 
 namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 {
@@ -16,7 +17,13 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
 {
     [Obsolete("Use PepperDash.Essentials.Core.DeviceTypeInterfaces")]
-    public interface IHasPhoneDialing:PepperDash.Essentials.Core.DeviceTypeInterfaces.IHasPhoneDialing
+    public interface IHasPhoneDialing
     {
+        BoolFeedback PhoneOffHookFeedback { get; }
+        StringFeedback CallerIdNameFeedback { get; }
+        StringFeedback CallerIdNumberFeedback { get; }
+        void DialPhoneCall(string number);
+        void EndPhoneCall();
+        void SendDtmfToPhone(string digit);
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/ILanguageDefinition.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/ILanguageDefinition.cs
@@ -20,7 +20,16 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
 {
     [Obsolete("Use PepperDash.Essentials.Core.DeviceTypeInterfaces")]
-    public interface ILanguageDefinition:PepperDash.Essentials.Core.DeviceTypeInterfaces.ILanguageDefinition
+    public interface ILanguageDefinition
     {
+        string LocaleName { get; set; }
+        string FriendlyName { get; set; }
+        bool Enable { get; set; }
+        List<LanguageLabel> UiLabels { get; set; }
+        List<LanguageLabel> Sources { get; set; }
+        List<LanguageLabel> Destinations { get; set; }
+        List<LanguageLabel> SourceGroupNames { get; set; }
+        List<LanguageLabel> DestinationGroupNames { get; set; }
+        List<LanguageLabel> RoomNames { get; set; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/ILanguageProvider.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/ILanguageProvider.cs
@@ -15,8 +15,11 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
 {
     [Obsolete("Use PepperDash.Essentials.Core.DeviceTypeInterfaces")]
-    public interface ILanguageProvider:PepperDash.Essentials.Core.DeviceTypeInterfaces.ILanguageProvider
+    public interface ILanguageProvider
     {
+        ILanguageDefinition CurrentLanguage { get; set; }
+
+        event EventHandler CurrentLanguageChanged;
     }
 
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/LanguageLabel.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/DeviceTypeInterfaces/LanguageLabel.cs
@@ -15,7 +15,11 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
 namespace PepperDash_Essentials_Core.DeviceTypeInterfaces
 {
     [Obsolete("Use PepperDash.Essentials.Core.DeviceTypeInterfaces")]
-    public class LanguageLabel: PepperDash.Essentials.Core.DeviceTypeInterfaces.LanguageLabel
+    public class LanguageLabel
     {
+        public string Key { get; set; }
+        public string Description { get; set; }
+        public string DisplayText { get; set; }
+        public uint JoinNumber { get; set; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Factory/ReadyEventArgs.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Factory/ReadyEventArgs.cs
@@ -27,15 +27,20 @@ namespace PepperDash.Essentials.Core
 namespace PepperDash_Essentials_Core
 {
     [Obsolete("Use PepperDash.Essentials.Core")]
-    public class IsReadyEventArgs : PepperDash.Essentials.Core.IsReadyEventArgs
+    public class IsReadyEventArgs : EventArgs
     {
-        public IsReadyEventArgs(bool data) : base(data)
+        public bool IsReady { get; set; }
+
+        public IsReadyEventArgs(bool data)
         {
+            IsReady = data;
         }
     }
 
     [Obsolete("Use PepperDash.Essentials.Core")]
-    public interface IHasReady: PepperDash.Essentials.Core.IHasReady
+    public interface IHasReady
     {
+        event EventHandler<IsReadyEventArgs> IsReadyEvent;
+        bool IsReady { get; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/ComsMessage.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/ComsMessage.cs
@@ -78,15 +78,23 @@ namespace PepperDash_Essentials_Core.Queues
     /// IBasicCommunication Message for IQueue
     /// </summary>
     [Obsolete("Use PepperDash.Essentials.Core.Queues")]
-    public class ComsMessage : PepperDash.Essentials.Core.Queues.ComsMessage
+    public class ComsMessage : IQueueMessage
     {
+        private readonly byte[] _bytes;
+        private readonly IBasicCommunication _coms;
+        private readonly string _string;
+        private readonly bool _isByteMessage;
+
         /// <summary>
         /// Constructor for a string message
         /// </summary>
         /// <param name="coms">IBasicCommunication to send the message</param>
         /// <param name="message">Message to send</param>
-        public ComsMessage(IBasicCommunication coms, string message):base(coms, message)
+        public ComsMessage(IBasicCommunication coms, string message)
         {
+            Validate(coms, message);
+            _coms = coms;
+            _string = message;
         }
 
         /// <summary>
@@ -94,8 +102,44 @@ namespace PepperDash_Essentials_Core.Queues
         /// </summary>
         /// <param name="coms">IBasicCommunication to send the message</param>
         /// <param name="message">Message to send</param>
-        public ComsMessage(IBasicCommunication coms, byte[] message):base(coms, message)
+        public ComsMessage(IBasicCommunication coms, byte[] message)
         {
+            Validate(coms, message);
+            _coms = coms;
+            _bytes = message;
+            _isByteMessage = true;
+        }
+
+        private void Validate(IBasicCommunication coms, object message)
+        {
+            if (coms == null)
+                throw new ArgumentNullException("coms");
+
+            if (message == null)
+                throw new ArgumentNullException("message");
+        }
+
+        /// <summary>
+        /// Dispatchs the string/byte[] to the IBasicCommunication specified
+        /// </summary>
+        public void Dispatch()
+        {
+            if (_isByteMessage)
+            {
+                _coms.SendBytes(_bytes);
+            }
+            else
+            {
+                _coms.SendText(_string);
+            }
+        }
+
+        /// <summary>
+        /// Shows either the byte[] or string to be sent
+        /// </summary>
+        public override string ToString()
+        {
+            return _bytes != null ? _bytes.ToString() : _string;
         }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
@@ -254,14 +254,44 @@ namespace PepperDash_Essentials_Core.Queues
     /// Threadsafe processing of queued items with pacing if required
     /// </summary>
     [Obsolete("Use PepperDash.Essentials.Core.Queues")]
-    public class GenericQueue : PepperDash.Essentials.Core.Queues.GenericQueue
+    public class GenericQueue : IQueue<IQueueMessage>
     {
+        private readonly string _key;
+        protected readonly CrestronQueue<IQueueMessage> _queue;
+        protected readonly Thread _worker;
+        protected readonly CEvent _waitHandle = new CEvent();
+
         private bool _delayEnabled;
         private int _delayTime;
 
         private const Thread.eThreadPriority _defaultPriority = Thread.eThreadPriority.MediumPriority;
 
-        
+        /// <summary>
+        /// If the instance has been disposed.
+        /// </summary>
+        public bool Disposed { get; private set; }
+
+        /// <summary>
+        /// Returns the capacity of the CrestronQueue (fixed Size property)
+        /// </summary>
+        public int QueueCapacity
+        {
+            get
+            {
+                return _queue.Size;
+            }
+        }
+
+        /// <summary>
+        /// Returns the number of elements currently in the CrestronQueue
+        /// </summary>    
+        public int QueueCount
+        {
+            get
+            {
+                return _queue.Count;
+            }
+        }
 
         /// <summary>
         /// Constructor with no thread priority
@@ -344,8 +374,122 @@ namespace PepperDash_Essentials_Core.Queues
         /// <param name="priority"></param>
         /// <param name="capacity"></param>
         /// <param name="pacing"></param>
-        private GenericQueue(string key, Thread.eThreadPriority priority, int capacity, int pacing):base(key, priority, capacity, pacing)
+        protected GenericQueue(string key, Thread.eThreadPriority priority, int capacity, int pacing)
         {
+            _key = key;
+            int cap = 25; // sets default
+            if (capacity > 0)
+            {
+                cap = capacity; // overrides default
+            }
+            _queue = new CrestronQueue<IQueueMessage>(cap);
+            _worker = new Thread(ProcessQueue, null, Thread.eThreadStartOptions.Running)
+            {
+                Priority = priority
+            };
+
+            SetDelayValues(pacing);
+        }
+
+        private void SetDelayValues(int pacing)
+        {
+            _delayEnabled = pacing > 0;
+            _delayTime = pacing;
+
+            CrestronEnvironment.ProgramStatusEventHandler += programEvent =>
+            {
+                if (programEvent != eProgramStatusEventType.Stopping)
+                    return;
+
+                Dispose();
+            };
+        }
+
+        /// <summary>
+        /// Thread callback
+        /// </summary>
+        /// <param name="obj">The action used to process dequeued items</param>
+        /// <returns>Null when the thread is exited</returns>
+        private object ProcessQueue(object obj)
+        {
+            while (true)
+            {
+                IQueueMessage item = null;
+
+                if (_queue.Count > 0)
+                {
+                    item = _queue.Dequeue();
+                    if (item == null)
+                        break;
+                }
+                if (item != null)
+                {
+                    try
+                    {
+                        Debug.Console(2, this, "Processing queue item: '{0}'", item.ToString());
+                        item.Dispatch();
+
+                        if (_delayEnabled)
+                            Thread.Sleep(_delayTime);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue {0}\r{1}\r{2}", ex.Message, ex.InnerException, ex.StackTrace);
+                    }
+                }
+                else _waitHandle.Wait();
+            }
+
+            return null;
+        }
+
+        public void Enqueue(IQueueMessage item)
+        {
+            _queue.Enqueue(item);
+            _waitHandle.Set();
+        }
+
+        /// <summary>
+        /// Disposes the thread and cleans up resources.  Thread cannot be restarted once
+        /// disposed.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            CrestronEnvironment.GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Actually does the disposing.  If you override this method, be sure to either call the base implementation 
+        /// or clean up all the resources yourself.
+        /// </summary>
+        /// <param name="disposing">set to true unless called from finalizer</param>
+        protected void Dispose(bool disposing)
+        {
+            if (Disposed)
+                return;
+
+            if (disposing)
+            {
+                Enqueue(null);
+                _worker.Join();
+                _waitHandle.Close();
+            }
+
+            Disposed = true;
+        }
+
+        ~GenericQueue()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Key
+        /// </summary>
+        public string Key
+        {
+            get { return _key; }
         }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/IQueue.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/IQueue.cs
@@ -17,7 +17,9 @@ namespace PepperDash.Essentials.Core.Queues
 namespace PepperDash_Essentials_Core.Queues
 {
     [Obsolete("Use PepperDash.Essentials.Core.Queues")]
-    public interface IQueue<T> : PepperDash.Essentials.Core.Queues.IQueue<T> where T: class 
+    public interface IQueue<T> : IKeyed, IDisposable where T : class
     {
+        void Enqueue(T item);
+        bool Disposed { get; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/IQueueMessage.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/IQueueMessage.cs
@@ -11,7 +11,8 @@ namespace PepperDash.Essentials.Core.Queues
 namespace PepperDash_Essentials_Core.Queues
 {
     [Obsolete("Use PepperDash.Essentials.Core.Queues")]
-    public interface IQueueMessage:PepperDash.Essentials.Core.Queues.IQueueMessage
+    public interface IQueueMessage
     {
+        void Dispatch();
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/ProcessStringMessage.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/ProcessStringMessage.cs
@@ -49,13 +49,40 @@ namespace PepperDash_Essentials_Core.Queues
     /// Message class for processing strings via an IQueue
     /// </summary>
     [Obsolete("Use PepperDash.Essentials.Core.Queues")]
-    public class ProcessStringMessage : PepperDash.Essentials.Core.Queues.ProcessStringMessage
+    public class ProcessStringMessage : IQueueMessage
     {
+        private readonly Action<string> _action;
+        private readonly string _message;
+
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="message">Message to be processed</param>
         /// <param name="action">Action to invoke on the message</param>
-        public ProcessStringMessage(string message, Action<string> action) : base(message, action){}
+        public ProcessStringMessage(string message, Action<string> action)
+        {
+            _message = message;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Processes the string with the given action
+        /// </summary>
+        public void Dispatch()
+        {
+            if (_action == null || String.IsNullOrEmpty(_message))
+                return;
+
+            _action(_message);
+        }
+
+        /// <summary>
+        /// To string
+        /// </summary>
+        /// <returns>The current message</returns>
+        public override string ToString()
+        {
+            return _message ?? String.Empty;
+        }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/StringResponseProcessor.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/StringResponseProcessor.cs
@@ -111,14 +111,14 @@ namespace PepperDash_Essentials_Core.Queues
     public sealed class StringResponseProcessor : IKeyed, IDisposable
     {
         private readonly Action<string> _processStringAction;
-        private readonly PepperDash.Essentials.Core.Queues.IQueue<PepperDash.Essentials.Core.Queues.IQueueMessage> _queue;
+        private readonly IQueue<IQueueMessage> _queue;
         private readonly IBasicCommunication _coms;
         private readonly CommunicationGather _gather;
 
         private StringResponseProcessor(string key, Action<string> processStringAction)
         {
             _processStringAction = processStringAction;
-            _queue = new PepperDash.Essentials.Core.Queues.GenericQueue(key);
+            _queue = new GenericQueue(key);
 
             CrestronEnvironment.ProgramStatusEventHandler += programEvent =>
             {


### PR DESCRIPTION
Note that changes to types that are in both the wrong namespace and the new one will ONLY be applied to the new namespace.

close #653 