### PR TITLE
added a Disposed check and Debug Message to prevent enqueing messages…

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
@@ -199,6 +199,12 @@ namespace PepperDash.Essentials.Core.Queues
 
         public void Enqueue(IQueueMessage item)
         {
+            if (Disposed)
+            {
+                Debug.Console(1, this, "I've been disposed so you can't enqueue any messages.  Are you trying to dispatch a message while the program is stopping?");
+                return;
+            }
+
             _queue.Enqueue(item);
             _waitHandle.Set();
         }


### PR DESCRIPTION
… after the Generic Queue has been disposed; typically happens at program stop

fixes #665 