### PR TITLE
Adds "AlwaysSendValue" property to Feedbacks 

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/BoolFeedback.cs
@@ -18,6 +18,7 @@ namespace PepperDash.Essentials.Core
         /// </summary>
         public override bool BoolValue { get { return _BoolValue; } }
         bool _BoolValue;
+		public bool AlwaysSendValue;
 
         /// <summary>
         /// Fake value to be used in test mode
@@ -62,10 +63,16 @@ namespace PepperDash.Essentials.Core
             ValueFunc = valueFunc;
         }
 
+		public BoolFeedback(string key, bool alwaysSendValue, Func<bool> valueFunc)
+			: this(key, valueFunc)
+		{
+			AlwaysSendValue = alwaysSendValue;
+		}
+
         public override void FireUpdate()
         {
             bool newValue = InTestMode ? TestValue : ValueFunc.Invoke();
-            if (newValue != _BoolValue)
+            if (newValue != _BoolValue || AlwaysSendValue)
             {
                 _BoolValue = newValue;
                 LinkedInputSigs.ForEach(s => UpdateSig(s));

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/IntFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/IntFeedback.cs
@@ -12,6 +12,7 @@ namespace PepperDash.Essentials.Core
         public override int IntValue { get { return _IntValue; } } // ValueFunc.Invoke(); } }
         int _IntValue;
         public ushort UShortValue { get { return (ushort)_IntValue; } }
+		public bool AlwaysSendValue; 
 
         //public override eCueType Type { get { return eCueType.Int; } }
 
@@ -51,10 +52,16 @@ namespace PepperDash.Essentials.Core
             ValueFunc = valueFunc;
         }
 
+		public IntFeedback(string key, bool alwaysSendValue, Func<int> valueFunc)
+			: this(key, valueFunc)
+		{
+			AlwaysSendValue = alwaysSendValue;
+		}
+
         public override void FireUpdate()
         {
             var newValue = InTestMode ? TestValue : ValueFunc.Invoke();
-            if (newValue != _IntValue)
+			if (newValue != _IntValue || AlwaysSendValue)
             {
                 _IntValue = newValue;
                 LinkedInputSigs.ForEach(s => UpdateSig(s));

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Feedbacks/StringFeedback.cs
@@ -23,6 +23,7 @@ namespace PepperDash.Essentials.Core
         /// </summary>
         public Func<string> ValueFunc { get; private set; }
         List<StringInputSig> LinkedInputSigs = new List<StringInputSig>();
+		public bool AlwaysSendValue; 
 
         /// <summary>
         /// Creates the feedback with the Func as described.
@@ -51,13 +52,17 @@ namespace PepperDash.Essentials.Core
         {
             ValueFunc = valueFunc;
         }
-
+		public StringFeedback(string key, bool alwaysSendValue, Func<string> valueFunc)
+			: this(key, valueFunc)
+		{
+			AlwaysSendValue = alwaysSendValue;
+		}
 
 
         public override void FireUpdate()
         {
             var newValue = InTestMode ? TestValue : ValueFunc.Invoke();
-            if (newValue != _StringValue)
+            if (newValue != _StringValue || AlwaysSendValue)
             {
                 _StringValue = newValue;
                 LinkedInputSigs.ForEach(s => UpdateSig(s));


### PR DESCRIPTION
feature(feedbacks): adds public property AlwaysSendValue and new constructor to Bool, Int, and String Feedbacks that will always perform a FireUpdate event even when value is the same.

Closes #757 