### PR TITLE
Feature/dmps endpoint fixes

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -46,6 +46,13 @@ namespace PepperDash.Essentials
         public override void InitializeSystem()
         {
             _startTimer = new CTimer(StartSystem,StartupTime);
+            ushort count = 0;
+            while (!DeviceManager.AllDevicesActivatedFb && count < 60)
+            {
+                //Wait for devices to register before returning, as required by DMPS. Max wait is 60 seconds.
+                CrestronEnvironment.Sleep(1000);
+                count++;
+            }
         }
 
         private void StartSystem(object obj)
@@ -361,10 +368,7 @@ namespace PepperDash.Essentials
                             if(propertiesConfig == null)
                                 propertiesConfig =  new DM.Config.DmpsRoutingPropertiesConfig();
 
-                            bool dmps4kType = this.ControllerPrompt.IndexOf("4k", StringComparison.OrdinalIgnoreCase) > -1;
-                            var dmpsRoutingController = DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig, dmps4kType);                            
-
-                            DeviceManager.AddDevice(dmpsRoutingController);
+                            DeviceManager.AddDevice(DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig));
                         }
                         else if (this.ControllerPrompt.IndexOf("mpc3", StringComparison.OrdinalIgnoreCase) > -1)
                         {

--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -343,7 +343,7 @@ namespace PepperDash.Essentials
                     {
                         var prompt = Global.ControlSystem.ControllerPrompt;
 
-                        var typeMatch = String.Equals(devConf.Type, prompt, StringComparison.OrdinalIgnoreCase) &&
+                        var typeMatch = String.Equals(devConf.Type, prompt, StringComparison.OrdinalIgnoreCase) ||
                                         String.Equals(devConf.Type, prompt.Replace("-", ""), StringComparison.OrdinalIgnoreCase);
 
                         if (!typeMatch)
@@ -361,7 +361,8 @@ namespace PepperDash.Essentials
                             if(propertiesConfig == null)
                                 propertiesConfig =  new DM.Config.DmpsRoutingPropertiesConfig();
 
-                            var dmpsRoutingController = DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig);
+                            bool dmps4kType = this.ControllerPrompt.IndexOf("4k", StringComparison.OrdinalIgnoreCase) > -1;
+                            var dmpsRoutingController = DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig, dmps4kType);                            
 
                             DeviceManager.AddDevice(dmpsRoutingController);
                         }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
@@ -10,7 +10,7 @@ namespace PepperDash.Essentials.Core.Bridges
             new JoinMetadata
             {
                 Description = "DM Chassis enable audio breakaway routing",
-                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 
@@ -20,7 +20,7 @@ namespace PepperDash.Essentials.Core.Bridges
             new JoinMetadata
             {
                 Description = "DM Chassis enable USB breakaway routing",
-                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsRoutingControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsRoutingControllerJoinMap.cs
@@ -4,6 +4,14 @@ namespace PepperDash.Essentials.Core.Bridges
 {
     public class DmpsRoutingControllerJoinMap : JoinMapBaseAdvanced
     {
+        [JoinName("SystemPowerOn")]
+        public JoinDataComplete SystemPowerOn = new JoinDataComplete(new JoinData { JoinNumber = 12, JoinSpan = 1 },
+            new JoinMetadata { Description = "DMPS System Power On Get/Set", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("SystemPowerOff")]
+        public JoinDataComplete SystemPowerOff = new JoinDataComplete(new JoinData { JoinNumber = 13, JoinSpan = 1 },
+            new JoinMetadata { Description = "DMPS System Power Off Get/Set", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
         [JoinName("VideoSyncStatus")]
         public JoinDataComplete VideoSyncStatus = new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 32 },
             new JoinMetadata { Description = "DM Input Video Sync", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -28,9 +28,11 @@ namespace PepperDash.Essentials.Core
 		public static List<IKeyed> AllDevices { get { return new List<IKeyed>(Devices.Values); } }
 
 	    public static bool AddDeviceEnabled;
+        public static bool AllDevicesActivatedFb;
 
 		public static void Initialize(CrestronControlSystem cs)
 		{
+            AllDevicesActivatedFb = false;
 		    AddDeviceEnabled = true;
 			CrestronConsole.AddNewConsoleCommand(ListDeviceCommStatuses, "devcommstatus", "Lists the communication status of all devices",
 				ConsoleAccessLevelEnum.AccessOperator);
@@ -122,6 +124,7 @@ namespace PepperDash.Essentials.Core
 
         private static void OnAllDevicesActivated()
         {
+            AllDevicesActivatedFb = true;
             var handler = AllDevicesActivated;
             if (handler != null)
             {

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -723,28 +723,36 @@ namespace PepperDash.Essentials.DM
 
         void Dmps_DMInputChange(Switch device, DMInputEventArgs args)
         {
-            //Debug.Console(2, this, "DMSwitch:{0} Input:{1} Event:{2}'", this.Name, args.Number, args.EventId.ToString());
-
-            switch (args.EventId)
+            try
             {
-                case (DMInputEventIds.OnlineFeedbackEventId):
-                    {
-                        Debug.Console(2, this, "DM Input OnlineFeedbackEventId for input: {0}. State: {1}", args.Number, device.Inputs[args.Number].EndpointOnlineFeedback);
-                        InputEndpointOnlineFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
-                case (DMInputEventIds.VideoDetectedEventId):
-                    {
-                        Debug.Console(2, this, "DM Input {0} VideoDetectedEventId", args.Number);
-                        VideoInputSyncFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
-                case (DMInputEventIds.InputNameEventId):
-                    {
-                        Debug.Console(2, this, "DM Input {0} NameFeedbackEventId", args.Number);
-                        InputNameFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
+                switch (args.EventId)
+                {
+                    case (DMInputEventIds.OnlineFeedbackEventId):
+                        {
+                            Debug.Console(2, this, "DM Input OnlineFeedbackEventId for input: {0}. State: {1}", args.Number, device.Inputs[args.Number].EndpointOnlineFeedback);
+                            InputEndpointOnlineFeedbacks[args.Number].FireUpdate();
+                            break;
+                        }
+                    case (DMInputEventIds.VideoDetectedEventId):
+                        {
+                            Debug.Console(2, this, "DM Input {0} VideoDetectedEventId", args.Number);
+                            VideoInputSyncFeedbacks[args.Number].FireUpdate();
+                            break;
+                        }
+                    case (DMInputEventIds.InputNameEventId):
+                        {
+                            Debug.Console(2, this, "DM Input {0} NameFeedbackEventId", args.Number);
+                            if(InputNameFeedbacks.ContainsKey(args.Number))
+                            {
+                                InputNameFeedbacks[args.Number].FireUpdate();
+                            }
+                            break;
+                        }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Console(0, Debug.ErrorLogLevel.Notice, "DMSwitch Input Change:{0} Input:{1} Event:{2}\rException: {3}", this.Name, args.Number, args.EventId.ToString(), e.ToString());
             }
         }
         void Dmps_DMOutputChange(Switch device, DMOutputEventArgs args)

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -25,6 +25,9 @@ namespace PepperDash.Essentials.DM
 
         public CrestronControlSystem Dmps { get; set; }
         public ISystemControl SystemControl { get; private set; }
+        
+        //Check if DMPS is a DMPS3-4K type for endpoint creation
+        public bool Dmps4kType { get; private set; }
 
         //IroutingNumericEvent
         public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
@@ -73,7 +76,7 @@ namespace PepperDash.Essentials.DM
 
 
         public static DmpsRoutingController GetDmpsRoutingController(string key, string name,
-            DmpsRoutingPropertiesConfig properties)
+            DmpsRoutingPropertiesConfig properties, bool dmps4kType)
         {
             try
             {
@@ -84,7 +87,7 @@ namespace PepperDash.Essentials.DM
                     return null;
                 }
 
-                var controller = new DmpsRoutingController(key, name, systemControl)
+                var controller = new DmpsRoutingController(key, name, systemControl, dmps4kType)
                 {
                     InputNames = properties.InputNames,
                     OutputNames = properties.OutputNames
@@ -110,12 +113,13 @@ namespace PepperDash.Essentials.DM
         /// <param name="key"></param>
         /// <param name="name"></param>
         /// <param name="chassis"></param>
-        public DmpsRoutingController(string key, string name, ISystemControl systemControl)
+        public DmpsRoutingController(string key, string name, ISystemControl systemControl, bool dmps4kType)
             : base(key, name)
         {
             
             Dmps = Global.ControlSystem;
             SystemControl = systemControl;
+            Dmps4kType = dmps4kType;
 
             InputPorts = new RoutingPortCollection<RoutingInputPort>();
             OutputPorts = new RoutingPortCollection<RoutingOutputPort>();

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -329,7 +329,14 @@ namespace PepperDash.Essentials.DM
 	        var parentDev = DeviceManager.GetDeviceForKey(pKey);
 	        if (parentDev is DmpsRoutingController)
 	        {
-	            return GetDmRmcControllerForDmps(key, name, typeName, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                if ((parentDev as DmpsRoutingController).Dmps4kType)
+                {
+                    return GetDmRmcControllerForDmps4k(key, name, typeName, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                }
+                else
+                {
+                    return GetDmRmcControllerForDmps(key, name, typeName, ipid, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                }
 	        }
 	        if (!(parentDev is IDmSwitch))
 	        {
@@ -395,25 +402,47 @@ namespace PepperDash.Essentials.DM
 	        return null;
 	    }
 
-	    private static CrestronGenericBaseDevice GetDmRmcControllerForDmps(string key, string name, string typeName,
+        private static CrestronGenericBaseDevice GetDmRmcControllerForDmps(string key, string name, string typeName,
+            uint ipid, DmpsRoutingController controller, uint num)
+        {
+            Func<string, string, uint, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
+            if (ChassisDict.TryGetValue(typeName.ToLower(), out dmpsHandler))
+            {
+                var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
+
+                if (output != null)
+                {
+                    return dmpsHandler(key, name, ipid, output);
+                }
+                Debug.Console(0, Debug.ErrorLogLevel.Error,
+                    "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output.",
+                    typeName, num);
+                return null;
+            }
+
+            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS chassis", typeName, num);
+            return null;
+        }
+
+	    private static CrestronGenericBaseDevice GetDmRmcControllerForDmps4k(string key, string name, string typeName,
 	        DmpsRoutingController controller, uint num)
 	    {
-	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
-	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmpsHandler))
+	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmps4kHandler;
+	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmps4kHandler))
 	        {
 	            var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
 
 	            if (output != null)
 	            {
-	                return dmpsHandler(key, name, output);
+	                return dmps4kHandler(key, name, output);
 	            }
 	            Debug.Console(0, Debug.ErrorLogLevel.Error,
-	                "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output.",
+	                "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS-4K chassis. Output is not a DM Output.",
 	                typeName, num);
 	            return null;
 	        }
 
-            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS chassis", typeName, num);
+            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS-4K chassis", typeName, num);
 	        return null;
 	    }
 


### PR DESCRIPTION
-Resolves minor issue where control proc name comparison fails due to "-" in processor name (DMPS3-300-C)
-Adds property to DMPS chassis to define if it is a 4K type DMPS
-Fixes creation for DM-RX on a DMPS is the IP ID is required, such as on a DMPS3-300-C
-Fixes creation for all DM-TX types on DMPS, both with IPID and without IPID