### PR TITLE
Maintenance/merge fork

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -60,7 +60,7 @@ namespace PepperDash.Essentials
                     _initializeEvent.Set();
                 };
 
-                _initializeEvent.Wait(20000);
+                _initializeEvent.Wait(30000);
             }
         }
 

--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -46,6 +46,13 @@ namespace PepperDash.Essentials
         public override void InitializeSystem()
         {
             _startTimer = new CTimer(StartSystem,StartupTime);
+            ushort count = 0;
+            while (!DeviceManager.AllDevicesActivatedFb && count < 60)
+            {
+                //Wait for devices to register before returning, as required by DMPS. Max wait is 60 seconds.
+                CrestronEnvironment.Sleep(1000);
+                count++;
+            }
         }
 
         private void StartSystem(object obj)
@@ -343,7 +350,7 @@ namespace PepperDash.Essentials
                     {
                         var prompt = Global.ControlSystem.ControllerPrompt;
 
-                        var typeMatch = String.Equals(devConf.Type, prompt, StringComparison.OrdinalIgnoreCase) &&
+                        var typeMatch = String.Equals(devConf.Type, prompt, StringComparison.OrdinalIgnoreCase) ||
                                         String.Equals(devConf.Type, prompt.Replace("-", ""), StringComparison.OrdinalIgnoreCase);
 
                         if (!typeMatch)
@@ -361,9 +368,7 @@ namespace PepperDash.Essentials
                             if(propertiesConfig == null)
                                 propertiesConfig =  new DM.Config.DmpsRoutingPropertiesConfig();
 
-                            var dmpsRoutingController = DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig);
-
-                            DeviceManager.AddDevice(dmpsRoutingController);
+                            DeviceManager.AddDevice(DmpsRoutingController.GetDmpsRoutingController("processor-avRouting", this.ControllerPrompt, propertiesConfig));
                         }
                         else if (this.ControllerPrompt.IndexOf("mpc3", StringComparison.OrdinalIgnoreCase) > -1)
                         {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmChassisControllerJoinMap.cs
@@ -10,7 +10,7 @@ namespace PepperDash.Essentials.Core.Bridges
             new JoinMetadata
             {
                 Description = "DM Chassis enable audio breakaway routing",
-                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 
@@ -20,7 +20,7 @@ namespace PepperDash.Essentials.Core.Bridges
             new JoinMetadata
             {
                 Description = "DM Chassis enable USB breakaway routing",
-                JoinCapabilities = eJoinCapabilities.ToSIMPL,
+                JoinCapabilities = eJoinCapabilities.FromSIMPL,
                 JoinType = eJoinType.Digital
             });
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsRoutingControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsRoutingControllerJoinMap.cs
@@ -4,6 +4,14 @@ namespace PepperDash.Essentials.Core.Bridges
 {
     public class DmpsRoutingControllerJoinMap : JoinMapBaseAdvanced
     {
+        [JoinName("SystemPowerOn")]
+        public JoinDataComplete SystemPowerOn = new JoinDataComplete(new JoinData { JoinNumber = 12, JoinSpan = 1 },
+            new JoinMetadata { Description = "DMPS System Power On Get/Set", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("SystemPowerOff")]
+        public JoinDataComplete SystemPowerOff = new JoinDataComplete(new JoinData { JoinNumber = 13, JoinSpan = 1 },
+            new JoinMetadata { Description = "DMPS System Power Off Get/Set", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
         [JoinName("VideoSyncStatus")]
         public JoinDataComplete VideoSyncStatus = new JoinDataComplete(new JoinData { JoinNumber = 101, JoinSpan = 32 },
             new JoinMetadata { Description = "DM Input Video Sync", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -28,11 +28,9 @@ namespace PepperDash.Essentials.Core
 		public static List<IKeyed> AllDevices { get { return new List<IKeyed>(Devices.Values); } }
 
 	    public static bool AddDeviceEnabled;
-        public static bool AllDevicesActivatedFb;
 
 		public static void Initialize(CrestronControlSystem cs)
 		{
-            AllDevicesActivatedFb = false;
 		    AddDeviceEnabled = true;
 			CrestronConsole.AddNewConsoleCommand(ListDeviceCommStatuses, "devcommstatus", "Lists the communication status of all devices",
 				ConsoleAccessLevelEnum.AccessOperator);
@@ -124,7 +122,6 @@ namespace PepperDash.Essentials.Core
 
         private static void OnAllDevicesActivated()
         {
-            AllDevicesActivatedFb = true;
             var handler = AllDevicesActivated;
             if (handler != null)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -28,9 +28,11 @@ namespace PepperDash.Essentials.Core
 		public static List<IKeyed> AllDevices { get { return new List<IKeyed>(Devices.Values); } }
 
 	    public static bool AddDeviceEnabled;
+        public static bool AllDevicesActivatedFb;
 
 		public static void Initialize(CrestronControlSystem cs)
 		{
+            AllDevicesActivatedFb = false;
 		    AddDeviceEnabled = true;
 			CrestronConsole.AddNewConsoleCommand(ListDeviceCommStatuses, "devcommstatus", "Lists the communication status of all devices",
 				ConsoleAccessLevelEnum.AccessOperator);
@@ -122,6 +124,7 @@ namespace PepperDash.Essentials.Core
 
         private static void OnAllDevicesActivated()
         {
+            AllDevicesActivatedFb = true;
             var handler = AllDevicesActivated;
             if (handler != null)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Global/Global.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Global/Global.cs
@@ -32,6 +32,16 @@ namespace PepperDash.Essentials.Core
         // TODO: consider making this configurable later
         public static IFormatProvider Culture = CultureInfo.CreateSpecificCulture("en-US");
 
+        /// <summary>
+        /// True when the processor type is a DMPS variant
+        /// </summary>
+        public static bool ControlSystemIsDmpsType
+        {
+            get
+            {
+                return ControlSystem.ControllerPrompt.ToLower().IndexOf("dmps") > -1;
+            }
+        }
 
         /// <summary>
         /// The file path prefix to the folder containing configuration files

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -25,9 +25,16 @@ namespace PepperDash.Essentials.DM
 
         public CrestronControlSystem Dmps { get; set; }
         public ISystemControl SystemControl { get; private set; }
+        
+        //Check if DMPS is a DMPS3-4K type for endpoint creation
+        public bool Dmps4kType { get; private set; }
 
         //IroutingNumericEvent
         public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
+        
+        //Feedback for DMPS System Power
+        public BoolFeedback SystemPowerOnFeedback { get; private set; }
+        public BoolFeedback SystemPowerOffFeedback { get; private set; }
 
         // Feedbacks for EssentialDM
         public Dictionary<uint, IntFeedback> VideoOutputFeedbacks { get; private set; }
@@ -112,16 +119,58 @@ namespace PepperDash.Essentials.DM
         /// <param name="chassis"></param>
         public DmpsRoutingController(string key, string name, ISystemControl systemControl)
             : base(key, name)
-        {
-            
+        {            
             Dmps = Global.ControlSystem;
-            SystemControl = systemControl;
+            
+            switch (name.Replace("-", "").Replace("c", "").Replace("C", ""))
+            {
+                case "dmps34k50":
+                case "dmps34k100":
+                case "dmps34k150":
+                    SystemControl = systemControl as Dmps34K150CSystemControl;
+                    Dmps4kType = true;
+                    break;
+                case "dmps34k200":
+                case "dmps34k250":
+                case "dmps34k300":
+                case "dmps34k350":
+                    SystemControl = systemControl as Dmps34K300CSystemControl;
+                    Dmps4kType = true;
+                    break;
+                default:
+                    SystemControl = systemControl as Dmps3SystemControl;
+                    Dmps4kType = false;
+                    break;
+            }
 
             InputPorts = new RoutingPortCollection<RoutingInputPort>();
             OutputPorts = new RoutingPortCollection<RoutingOutputPort>();
             VolumeControls = new Dictionary<uint, DmCardAudioOutputController>();
             TxDictionary = new Dictionary<uint, string>();
             RxDictionary = new Dictionary<uint, string>();
+
+            SystemPowerOnFeedback = new BoolFeedback(() =>
+            {
+                if (SystemControl is Dmps3SystemControl)
+                {
+                    return ((Dmps3SystemControl)SystemControl).SystemPowerOnFeedBack.BoolValue;
+                }
+                else
+                {
+                    return false;
+                }
+            });
+            SystemPowerOffFeedback = new BoolFeedback(() =>
+            {
+                if (SystemControl is Dmps3SystemControl)
+                {
+                    return ((Dmps3SystemControl)SystemControl).SystemPowerOffFeedBack.BoolValue;
+                }
+                else
+                {
+                    return false;
+                }
+            });
 
             VideoOutputFeedbacks = new Dictionary<uint, IntFeedback>();
             AudioOutputFeedbacks = new Dictionary<uint, IntFeedback>();
@@ -154,6 +203,7 @@ namespace PepperDash.Essentials.DM
             // Subscribe to events
             Dmps.DMInputChange += Dmps_DMInputChange;
             Dmps.DMOutputChange += Dmps_DMOutputChange;
+            Dmps.DMSystemChange += Dmps_DMSystemChange;
 
             return base.CustomActivate();
         }
@@ -191,6 +241,22 @@ namespace PepperDash.Essentials.DM
             }
         }
 
+        public void SetPowerOn(bool a)
+        {
+            if (SystemControl is Dmps3SystemControl)
+            {
+                ((Dmps3SystemControl)SystemControl).SystemPowerOn();
+            }
+        }
+
+        public void SetPowerOff(bool a)
+        {
+            if (SystemControl is Dmps3SystemControl)
+            {
+                ((Dmps3SystemControl)SystemControl).SystemPowerOff();
+            }
+        }
+
         public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
         {
             var joinMap = new DmpsRoutingControllerJoinMap(joinStart);
@@ -211,9 +277,22 @@ namespace PepperDash.Essentials.DM
 
             Debug.Console(1, this, "Linking to Trilist '{0}'", trilist.ID.ToString("X"));
 
+            //Link up system
+            trilist.SetBoolSigAction(joinMap.SystemPowerOn.JoinNumber, SetPowerOn);
+            trilist.SetBoolSigAction(joinMap.SystemPowerOff.JoinNumber, SetPowerOff);
+            if (SystemPowerOnFeedback != null)
+            {
+                SystemPowerOnFeedback.LinkInputSig(
+                    trilist.BooleanInput[joinMap.SystemPowerOn.JoinNumber]);
+            }
+            if (SystemPowerOffFeedback != null)
+            {
+                SystemPowerOffFeedback.LinkInputSig(
+                    trilist.BooleanInput[joinMap.SystemPowerOff.JoinNumber]);
+            }
+
             // Link up outputs
             LinkInputsToApi(trilist, joinMap);
-
             LinkOutputsToApi(trilist, joinMap);
         }
 
@@ -719,28 +798,36 @@ namespace PepperDash.Essentials.DM
 
         void Dmps_DMInputChange(Switch device, DMInputEventArgs args)
         {
-            //Debug.Console(2, this, "DMSwitch:{0} Input:{1} Event:{2}'", this.Name, args.Number, args.EventId.ToString());
-
-            switch (args.EventId)
+            try
             {
-                case (DMInputEventIds.OnlineFeedbackEventId):
-                    {
-                        Debug.Console(2, this, "DM Input OnlineFeedbackEventId for input: {0}. State: {1}", args.Number, device.Inputs[args.Number].EndpointOnlineFeedback);
-                        InputEndpointOnlineFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
-                case (DMInputEventIds.VideoDetectedEventId):
-                    {
-                        Debug.Console(2, this, "DM Input {0} VideoDetectedEventId", args.Number);
-                        VideoInputSyncFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
-                case (DMInputEventIds.InputNameEventId):
-                    {
-                        Debug.Console(2, this, "DM Input {0} NameFeedbackEventId", args.Number);
-                        InputNameFeedbacks[args.Number].FireUpdate();
-                        break;
-                    }
+                switch (args.EventId)
+                {
+                    case (DMInputEventIds.OnlineFeedbackEventId):
+                        {
+                            Debug.Console(2, this, "DM Input OnlineFeedbackEventId for input: {0}. State: {1}", args.Number, device.Inputs[args.Number].EndpointOnlineFeedback);
+                            InputEndpointOnlineFeedbacks[args.Number].FireUpdate();
+                            break;
+                        }
+                    case (DMInputEventIds.VideoDetectedEventId):
+                        {
+                            Debug.Console(2, this, "DM Input {0} VideoDetectedEventId", args.Number);
+                            VideoInputSyncFeedbacks[args.Number].FireUpdate();
+                            break;
+                        }
+                    case (DMInputEventIds.InputNameEventId):
+                        {
+                            Debug.Console(2, this, "DM Input {0} NameFeedbackEventId", args.Number);
+                            if(InputNameFeedbacks.ContainsKey(args.Number))
+                            {
+                                InputNameFeedbacks[args.Number].FireUpdate();
+                            }
+                            break;
+                        }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Console(0, Debug.ErrorLogLevel.Notice, "DMSwitch Input Change:{0} Input:{1} Event:{2}\rException: {3}", this.Name, args.Number, args.EventId.ToString(), e.ToString());
             }
         }
         void Dmps_DMOutputChange(Switch device, DMOutputEventArgs args)
@@ -812,6 +899,23 @@ namespace PepperDash.Essentials.DM
 
         }
 
+        void Dmps_DMSystemChange(Switch device, DMSystemEventArgs args)
+        {
+            switch (args.EventId)
+            {
+                case DMSystemEventIds.SystemPowerOnEventId:
+                {
+                    SystemPowerOnFeedback.FireUpdate();
+                    break;
+                }
+                case DMSystemEventIds.SystemPowerOffEventId:
+                {
+                    SystemPowerOffFeedback.FireUpdate();
+                    break;
+                }
+            }
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -879,7 +983,6 @@ namespace PepperDash.Essentials.DM
                     // NOTE THAT BITWISE COMPARISONS - TO CATCH ALL ROUTING TYPES 
                     if ((sigType & eRoutingSignalType.Video) == eRoutingSignalType.Video)
                     {
-                        
                             output.VideoOut = input;
                     }
 
@@ -903,7 +1006,6 @@ namespace PepperDash.Essentials.DM
 
                     if ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput)
                     {
-                        
                             output.USBRoutedTo = input;
                     }
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -329,7 +329,14 @@ namespace PepperDash.Essentials.DM
 	        var parentDev = DeviceManager.GetDeviceForKey(pKey);
 	        if (parentDev is DmpsRoutingController)
 	        {
-	            return GetDmRmcControllerForDmps(key, name, typeName, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                if ((parentDev as DmpsRoutingController).Dmps4kType)
+                {
+                    return GetDmRmcControllerForDmps4k(key, name, typeName, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                }
+                else
+                {
+                    return GetDmRmcControllerForDmps(key, name, typeName, ipid, parentDev as DmpsRoutingController, props.ParentOutputNumber);
+                }
 	        }
 	        if (!(parentDev is IDmSwitch))
 	        {
@@ -395,25 +402,47 @@ namespace PepperDash.Essentials.DM
 	        return null;
 	    }
 
-	    private static CrestronGenericBaseDevice GetDmRmcControllerForDmps(string key, string name, string typeName,
+        private static CrestronGenericBaseDevice GetDmRmcControllerForDmps(string key, string name, string typeName,
+            uint ipid, DmpsRoutingController controller, uint num)
+        {
+            Func<string, string, uint, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
+            if (ChassisDict.TryGetValue(typeName.ToLower(), out dmpsHandler))
+            {
+                var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
+
+                if (output != null)
+                {
+                    return dmpsHandler(key, name, ipid, output);
+                }
+                Debug.Console(0, Debug.ErrorLogLevel.Error,
+                    "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output.",
+                    typeName, num);
+                return null;
+            }
+
+            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS chassis", typeName, num);
+            return null;
+        }
+
+	    private static CrestronGenericBaseDevice GetDmRmcControllerForDmps4k(string key, string name, string typeName,
 	        DmpsRoutingController controller, uint num)
 	    {
-	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmpsHandler;
-	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmpsHandler))
+	        Func<string, string, DMOutput, CrestronGenericBaseDevice> dmps4kHandler;
+	        if (ChassisCpu3Dict.TryGetValue(typeName.ToLower(), out dmps4kHandler))
 	        {
 	            var output = controller.Dmps.SwitcherOutputs[num] as DMOutput;
 
 	            if (output != null)
 	            {
-	                return dmpsHandler(key, name, output);
+	                return dmps4kHandler(key, name, output);
 	            }
 	            Debug.Console(0, Debug.ErrorLogLevel.Error,
-	                "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS chassis. Output is not a DM Output.",
+	                "Cannot attach DM-RMC of type '{0}' to output {1} on DMPS-4K chassis. Output is not a DM Output.",
 	                typeName, num);
 	            return null;
 	        }
 
-            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS chassis", typeName, num);
+            Debug.Console(0, Debug.ErrorLogLevel.Error, "Cannot create DM-RMC of type '{0}' to output {1} on DMPS-4K chassis", typeName, num);
 	        return null;
 	    }
 


### PR DESCRIPTION
Reworked initialization logic to only run if the processor is a DMPS type and replaces while loop with CEvent and uses the existing `DeviceManager.AllDevicesActivated` event as the trigger to signal the event.