### PR TITLE
fix(essentials): #842 Adds back in code to register Crestron devices …

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -53,11 +53,14 @@ namespace PepperDash.Essentials
             // to allow any HD-BaseT DM endpoints to register first.
             if (Global.ControlSystemIsDmpsType)
             {
+                Debug.Console(2, "******************* InitializeSystem() Entering **********************");
+
                 _initializeEvent = new CEvent();
 
                 DeviceManager.AllDevicesActivated += (o, a) =>
                 {
                     _initializeEvent.Set();
+                    Debug.Console(2, "******************* InitializeSystem() Exiting **********************");
                 };
 
                 _initializeEvent.Wait(30000);

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron/CrestronGenericBaseDevice.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron/CrestronGenericBaseDevice.cs
@@ -69,19 +69,28 @@ namespace PepperDash.Essentials.Core
 		public override bool CustomActivate()
 		{
             Debug.Console(0, this, "Activating");
-			if (!PreventRegistration)
-			{
+            if (!PreventRegistration)
+            {
                 //Debug.Console(1, this, "  Does not require registration. Skipping");
 
-				var response = Hardware.RegisterWithLogging(Key);
-				if (response != eDeviceRegistrationUnRegistrationResponse.Success)
-				{
-					//Debug.Console(0, this, "ERROR: Cannot register Crestron device: {0}", response);
-					return false;
-				}
+                var response = Hardware.RegisterWithLogging(Key);
+                if (response != eDeviceRegistrationUnRegistrationResponse.Success)
+                {
+                    //Debug.Console(0, this, "ERROR: Cannot register Crestron device: {0}", response);
+                    return false;
+                }
 
                 IsRegistered.FireUpdate();
-			}
+            }
+            else
+            {
+                AddPostActivationAction(() =>
+                    {
+                        var response = Hardware.RegisterWithLogging(Key);
+
+                        IsRegistered.FireUpdate();
+                    });
+            }
 
             foreach (var f in Feedbacks)
             {

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Global/Global.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Global/Global.cs
@@ -44,6 +44,17 @@ namespace PepperDash.Essentials.Core
         }
 
         /// <summary>
+        /// True when the processor type is a DMPS 4K variant
+        /// </summary>
+        public static bool ControlSystemIsDmps4kType
+        {
+            get
+            {
+                return ControlSystemIsDmpsType && ControlSystem.ControllerPrompt.ToLower().IndexOf("4k") > -1;
+            }
+        }
+
+        /// <summary>
         /// The file path prefix to the folder containing configuration files
         /// </summary>
         public static string FilePathPrefix { get; private set; }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
@@ -36,7 +36,7 @@ namespace PepperDash.Essentials.DM
 	        var ipid = props.Control.IpIdInt;
 	        var pKey = props.ParentDeviceKey.ToLower();
 
-	        if (pKey == "processor")
+            if (pKey == "processor")
 	        {
 				// Catch constructor failures, mainly dues to IPID
 				try
@@ -70,7 +70,7 @@ namespace PepperDash.Essentials.DM
 
             var parentDev = DeviceManager.GetDeviceForKey(pKey);
             DMInput dmInput;
-            bool noIpId = false;
+            bool isCpu3 = false;
 
 		    if (parentDev is IDmSwitch)
             {
@@ -96,7 +96,7 @@ namespace PepperDash.Essentials.DM
                     chassis is DmMd16x16Cpu3rps || chassis is DmMd32x32Cpu3rps ||
                     chassis is DmMd128x128 || chassis is DmMd64x64)
                 {
-                    noIpId = true;
+                    isCpu3 = true;
                 }
 
             }
@@ -116,7 +116,6 @@ namespace PepperDash.Essentials.DM
                 }
 
                 dmpsDev.TxDictionary.Add(num, key);
-                noIpId = dmpsDev.Dmps4kType;
 
                 try
                 {
@@ -138,7 +137,7 @@ namespace PepperDash.Essentials.DM
         	try
 		    {
 			    // Must use different constructor for CPU3 or DMPS3-4K types. No IPID
-			    if (noIpId)
+			    if (isCpu3 || Global.ControlSystemIsDmps4kType)
 			    {
 				    if (typeName.StartsWith("dmtx200"))
 					    return new DmTx200Controller(key, name, new DmTx200C2G(dmInput));
@@ -222,11 +221,12 @@ namespace PepperDash.Essentials.DM
 	    protected DmTxControllerBase(string key, string name, EndpointTransmitterBase hardware)
 			: base(key, name, hardware) 
 		{
-			// if wired to a chassis, skip registration step in base class
-			if (hardware.DMInput != null)
-			{
-				this.PreventRegistration = true;
-			}
+            // if wired to a chassis or DMPS, skip registration step in base class
+            if (hardware.DMInput != null || (Global.ControlSystemIsDmpsType && hardware.DMInput != null))
+            {
+                this.PreventRegistration = true;
+            }
+
             AddToFeedbackList(ActiveVideoInputFeedback);
 		}
 


### PR DESCRIPTION
closes #842

Tested on DMPS-300-C and MC4.  Tested with configs that had endpoints on DMPS as well as on DM-MD-8x8 with and without CPU3.  Endpoints appear to register correctly now in all tests.