### PR TITLE
Feature/dmps audio fixes

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
@@ -23,7 +23,7 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("MasterVolumeDown")]
         public JoinDataComplete MasterVolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 4, JoinSpan = 1 },
-            new JoinMetadata { Description = "Master Volume Mute Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+            new JoinMetadata { Description = "Master Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
         [JoinName("SourceVolumeLevel")]
         public JoinDataComplete SourceVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
@@ -43,7 +43,7 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("SourceVolumeDown")]
         public JoinDataComplete SourceVolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 14, JoinSpan = 1 },
-            new JoinMetadata { Description = "Source Volume Mute Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+            new JoinMetadata { Description = "Source Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
         [JoinName("Codec1VolumeLevel")]
         public JoinDataComplete Codec1VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
@@ -63,7 +63,7 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("Codec1VolumeDown")]
         public JoinDataComplete Codec1VolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 24, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec1 Volume Mute Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+            new JoinMetadata { Description = "Codec1 Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
         [JoinName("Codec2VolumeLevel")]
         public JoinDataComplete Codec2VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
@@ -83,7 +83,7 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("Codec2VolumeDown")]
         public JoinDataComplete Codec2VolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 34, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec2 Volume Mute Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+            new JoinMetadata { Description = "Codec2 Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
 
         /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
@@ -7,11 +7,11 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("MasterVolumeLevel")]
         public JoinDataComplete MasterVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
-            new JoinMetadata { Description = "Master Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Master Volume Signed dB Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("MasterVolumeLevelScaled")]
         public JoinDataComplete MasterVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 2, JoinSpan = 1 },
-            new JoinMetadata { Description = "Master Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Master Volume 16bit Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("MasterVolumeMuteOn")]
         public JoinDataComplete MasterVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
@@ -31,11 +31,11 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("SourceVolumeLevel")]
         public JoinDataComplete SourceVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
-            new JoinMetadata { Description = "Source Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Source Volume Signed dB Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("SourceVolumeLevelScaled")]
         public JoinDataComplete SourceVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 12, JoinSpan = 1 },
-            new JoinMetadata { Description = "Source Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Source Volume 16bit Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("SourceVolumeMuteOn")]
         public JoinDataComplete SourceVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
@@ -55,11 +55,11 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("Codec1VolumeLevel")]
         public JoinDataComplete Codec1VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec1 Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Codec1 Volume Signed dB Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("Codec1VolumeLevelScaled")]
         public JoinDataComplete Codec1VolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 22, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec1 Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Codec1 Volume 16bit Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("Codec1VolumeMuteOn")]
         public JoinDataComplete Codec1VolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
@@ -79,11 +79,11 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("Codec2VolumeLevel")]
         public JoinDataComplete Codec2VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec2 Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Codec2 Volume Signed dB Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("Codec2VolumeLevelScaled")]
         public JoinDataComplete Codec2VolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 32, JoinSpan = 1 },
-            new JoinMetadata { Description = "Codec2 Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "Codec2 Volume 16bit Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("Codec2VolumeMuteOn")]
         public JoinDataComplete Codec2VolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
@@ -103,11 +103,11 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("MicsMasterVolumeLevel")]
         public JoinDataComplete MicsMasterVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 1 },
-            new JoinMetadata { Description = "MicsMaster Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "MicsMaster Volume Signed dB Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("MicsMasterVolumeLevelScaled")]
         public JoinDataComplete MicsMasterVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 42, JoinSpan = 1 },
-            new JoinMetadata { Description = "MicsMaster Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+            new JoinMetadata { Description = "MicsMaster Volume 16bit Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("MicsMasterVolumeMuteOn")]
         public JoinDataComplete MicsMasterVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 1 },

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/DmpsAudioOutputControllerJoinMap.cs
@@ -9,6 +9,10 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete MasterVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
             new JoinMetadata { Description = "Master Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
+        [JoinName("MasterVolumeLevelScaled")]
+        public JoinDataComplete MasterVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 2, JoinSpan = 1 },
+            new JoinMetadata { Description = "Master Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
         [JoinName("MasterVolumeMuteOn")]
         public JoinDataComplete MasterVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
             new JoinMetadata { Description = "Master Volume Mute On Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
@@ -28,6 +32,10 @@ namespace PepperDash.Essentials.Core.Bridges
         [JoinName("SourceVolumeLevel")]
         public JoinDataComplete SourceVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
             new JoinMetadata { Description = "Source Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
+        [JoinName("SourceVolumeLevelScaled")]
+        public JoinDataComplete SourceVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 12, JoinSpan = 1 },
+            new JoinMetadata { Description = "Source Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
         [JoinName("SourceVolumeMuteOn")]
         public JoinDataComplete SourceVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
@@ -49,6 +57,10 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete Codec1VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
             new JoinMetadata { Description = "Codec1 Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
+        [JoinName("Codec1VolumeLevelScaled")]
+        public JoinDataComplete Codec1VolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 22, JoinSpan = 1 },
+            new JoinMetadata { Description = "Codec1 Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
         [JoinName("Codec1VolumeMuteOn")]
         public JoinDataComplete Codec1VolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 21, JoinSpan = 1 },
             new JoinMetadata { Description = "Codec1 Volume Mute On Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
@@ -69,6 +81,10 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete Codec2VolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
             new JoinMetadata { Description = "Codec2 Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
 
+        [JoinName("Codec2VolumeLevelScaled")]
+        public JoinDataComplete Codec2VolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 32, JoinSpan = 1 },
+            new JoinMetadata { Description = "Codec2 Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
         [JoinName("Codec2VolumeMuteOn")]
         public JoinDataComplete Codec2VolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 31, JoinSpan = 1 },
             new JoinMetadata { Description = "Codec2 Volume Mute On Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
@@ -85,6 +101,29 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete Codec2VolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 34, JoinSpan = 1 },
             new JoinMetadata { Description = "Codec2 Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
+        [JoinName("MicsMasterVolumeLevel")]
+        public JoinDataComplete MicsMasterVolumeLevel = new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
+        [JoinName("MicsMasterVolumeLevelScaled")]
+        public JoinDataComplete MicsMasterVolumeLevelScaled = new JoinDataComplete(new JoinData { JoinNumber = 42, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Scaled Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Analog });
+
+        [JoinName("MicsMasterVolumeMuteOn")]
+        public JoinDataComplete MicsMasterVolumeMuteOn = new JoinDataComplete(new JoinData { JoinNumber = 41, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Mute On Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("MicsMasterVolumeMuteOff")]
+        public JoinDataComplete MicsMasterVolumeMuteOff = new JoinDataComplete(new JoinData { JoinNumber = 42, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Mute Off Set / Get", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("MicsMasterVolumeUp")]
+        public JoinDataComplete MicsMasterVolumeUp = new JoinDataComplete(new JoinData { JoinNumber = 43, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Level Up", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("MicsMasterVolumeDown")]
+        public JoinDataComplete MicsMasterVolumeDown = new JoinDataComplete(new JoinData { JoinNumber = 44, JoinSpan = 1 },
+            new JoinMetadata { Description = "MicsMaster Volume Level Down", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
 
         /// <summary>
         /// Constructor to use when instantiating this Join Map without inheriting from it

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsAudioOutputController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsAudioOutputController.cs
@@ -38,34 +38,31 @@ namespace PepperDash.Essentials.DM
 
             if (card is Card.Dmps3ProgramOutput)
             {
-                MasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Master)
-                {
-                    Mixer = (card as Card.Dmps3ProgramOutput).OutputMixer
-                };
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(card, eDmpsLevelType.Master, (card as Card.Dmps3ProgramOutput).OutputMixer);
                 SourceVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Source);
                 MicsMasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.MicsMaster);
                 Codec1VolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Codec1);
                 Codec2VolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Codec2);
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMax();
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMin();
             }
             else if (card is Card.Dmps3Aux1Output)
             {
-                MasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Master)
-                {
-                    Mixer = (card as Card.Dmps3Aux1Output).OutputMixer
-                };
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(card, eDmpsLevelType.Master, (card as Card.Dmps3Aux1Output).OutputMixer);
                 SourceVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Source);
                 MicsMasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.MicsMaster);
                 Codec2VolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Codec2);
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMax();
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMin();
             }
             else if (card is Card.Dmps3Aux2Output)
             {
-                MasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Master)
-                {
-                    Mixer = (card as Card.Dmps3Aux2Output).OutputMixer
-                };
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(card, eDmpsLevelType.Master, (card as Card.Dmps3Aux2Output).OutputMixer);
                 SourceVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Source);
                 MicsMasterVolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.MicsMaster);
                 Codec1VolumeLevel = new DmpsAudioOutput(card, eDmpsLevelType.Codec1);
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMax();
+                ((DmpsAudioOutputWithMixer)MasterVolumeLevel).GetVolumeMin();
             }
             else //Digital Outputs
             {
@@ -80,86 +77,88 @@ namespace PepperDash.Essentials.DM
             switch (args.EventId)
             {
                 case DMOutputEventIds.MasterVolumeFeedBackEventId:
-                {
-                    MasterVolumeLevel.VolumeLevelFeedback.FireUpdate();
-                    MasterVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        MasterVolumeLevel.VolumeLevelFeedback.FireUpdate();
+                        MasterVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.MasterMuteOnFeedBackEventId:
-                {
-                    MasterVolumeLevel.MuteFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        MasterVolumeLevel.MuteFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.SourceLevelFeedBackEventId:
-                {
-                    SourceVolumeLevel.VolumeLevelFeedback.FireUpdate();
-                    SourceVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        SourceVolumeLevel.VolumeLevelFeedback.FireUpdate();
+                        SourceVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.SourceMuteOnFeedBackEventId:
-                {
-                    SourceVolumeLevel.MuteFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        SourceVolumeLevel.MuteFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.MicMasterLevelFeedBackEventId:
-                {
-                    MicsMasterVolumeLevel.VolumeLevelFeedback.FireUpdate();
-                    MicsMasterVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        MicsMasterVolumeLevel.VolumeLevelFeedback.FireUpdate();
+                        MicsMasterVolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.MicMasterMuteOnFeedBackEventId:
-                {
-                    MicsMasterVolumeLevel.MuteFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        MicsMasterVolumeLevel.MuteFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.Codec1LevelFeedBackEventId:
-                {
-                    if (Codec1VolumeLevel != null)
                     {
-                        Codec1VolumeLevel.VolumeLevelFeedback.FireUpdate();
-                        Codec1VolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        if (Codec1VolumeLevel != null)
+                        {
+                            Codec1VolumeLevel.VolumeLevelFeedback.FireUpdate();
+                            Codec1VolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        }
+                        break;
                     }
-                    break;
-                }
                 case DMOutputEventIds.Codec1MuteOnFeedBackEventId:
-                {
-                    if (Codec1VolumeLevel != null)
-                        Codec1VolumeLevel.MuteFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        if (Codec1VolumeLevel != null)
+                            Codec1VolumeLevel.MuteFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.Codec2LevelFeedBackEventId:
-                {
-                    if (Codec2VolumeLevel != null)
                     {
-                        Codec2VolumeLevel.VolumeLevelFeedback.FireUpdate();
-                        Codec2VolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        if (Codec2VolumeLevel != null)
+                        {
+                            Codec2VolumeLevel.VolumeLevelFeedback.FireUpdate();
+                            Codec2VolumeLevel.VolumeLevelScaledFeedback.FireUpdate();
+                        }
+                        break;
                     }
-                    break;
-                }
                 case DMOutputEventIds.Codec2MuteOnFeedBackEventId:
-                {
-                    if (Codec2VolumeLevel != null)
-                        Codec2VolumeLevel.MuteFeedback.FireUpdate();
-                    break;
-                }
+                    {
+                        if (Codec2VolumeLevel != null)
+                            Codec2VolumeLevel.MuteFeedback.FireUpdate();
+                        break;
+                    }
                 case DMOutputEventIds.MinVolumeFeedBackEventId:
-                {
-                    Debug.Console(2, this, "MinVolumeFeedBackEventId: {0}", args.Index);
-                    if (MasterVolumeLevel != null)
                     {
-                        MasterVolumeLevel.GetVolumeMin();
+                        Debug.Console(2, this, "MinVolumeFeedBackEventId: {0}", args.Index);
+                        var level = MasterVolumeLevel as DmpsAudioOutputWithMixer;
+                        if (level != null)
+                        {
+                            level.GetVolumeMin();
+                        }
+                        break;
                     }
-                    break;
-                }
                 case DMOutputEventIds.MaxVolumeFeedBackEventId:
-                {
-                    Debug.Console(2, this, "MaxVolumeFeedBackEventId: {0}", args.Index);
-                    if (MasterVolumeLevel != null)
                     {
-                        MasterVolumeLevel.GetVolumeMax();
+                        Debug.Console(2, this, "MaxVolumeFeedBackEventId: {0}", args.Index);
+                        var level = MasterVolumeLevel as DmpsAudioOutputWithMixer;
+                        if (level != null)
+                        {
+                            level.GetVolumeMax();
+                        }
+                        break;
                     }
-                    break;
-                }
             }
         }
 
@@ -218,7 +217,7 @@ namespace PepperDash.Essentials.DM
             var muteOffJoin = joinStart + 1;
             var volumeUpJoin = joinStart + 2;
             var volumeDownJoin = joinStart + 3;
-            
+
             trilist.SetUShortSigAction(volumeLevelJoin, output.SetVolume);
             output.VolumeLevelFeedback.LinkInputSig(trilist.UShortInput[volumeLevelJoin]);
 
@@ -232,6 +231,38 @@ namespace PepperDash.Essentials.DM
 
             trilist.SetBoolSigAction(volumeUpJoin, output.VolumeUp);
             trilist.SetBoolSigAction(volumeDownJoin, output.VolumeDown);
+
+            trilist.OnlineStatusChange += (a, b) => output.VolumeLevelFeedback.FireUpdate();
+            trilist.OnlineStatusChange += (a, b) => output.VolumeLevelScaledFeedback.FireUpdate();
+        }
+    }
+
+    public class DmpsAudioOutputWithMixer : DmpsAudioOutput
+    {
+        CrestronControlSystem.Dmps3OutputMixerWithMonoAndStereo Mixer;
+
+        public DmpsAudioOutputWithMixer(Card.Dmps3OutputBase output, eDmpsLevelType type, CrestronControlSystem.Dmps3OutputMixerWithMonoAndStereo mixer)
+            : base(output, type)
+        {
+            Mixer = mixer;
+        }
+
+        public void GetVolumeMin()
+        {
+            MinLevel = (short)Mixer.MinVolumeFeedback.UShortValue;
+            if (VolumeLevelScaledFeedback != null)
+            {
+                VolumeLevelScaledFeedback.FireUpdate();
+            }
+        }
+
+        public void GetVolumeMax()
+        {
+            MaxLevel = (short)Mixer.MaxVolumeFeedback.UShortValue;
+            if (VolumeLevelScaledFeedback != null)
+            {
+                VolumeLevelScaledFeedback.FireUpdate();
+            }
         }
     }
 
@@ -241,10 +272,9 @@ namespace PepperDash.Essentials.DM
         eDmpsLevelType Type;
         UShortInputSig Level;
 
-        public short MinLevel { get; private set; }
-        public short MaxLevel { get; private set; }
+        protected short MinLevel { get; set; }
+        protected short MaxLevel { get; set; }
 
-        public CrestronControlSystem.Dmps3OutputMixerWithMonoAndStereo Mixer { get; set; }
         public BoolFeedback MuteFeedback { get; private set; }
         public IntFeedback VolumeLevelFeedback { get; private set; }
         public IntFeedback VolumeLevelScaledFeedback { get; private set; }
@@ -253,7 +283,7 @@ namespace PepperDash.Essentials.DM
         Action MuteOffAction;
         Action<bool> VolumeUpAction;
         Action<bool> VolumeDownAction;
- 
+
         public DmpsAudioOutput(Card.Dmps3OutputBase output, eDmpsLevelType type)
         {
             Output = output;
@@ -267,13 +297,12 @@ namespace PepperDash.Essentials.DM
                     {
                         Level = output.MasterVolume;
 
-                        MuteFeedback = new BoolFeedback( new Func<bool> (() => Output.MasterMuteOnFeedBack.BoolValue));
+                        MuteFeedback = new BoolFeedback(new Func<bool>(() => Output.MasterMuteOnFeedBack.BoolValue));
                         VolumeLevelFeedback = new IntFeedback(new Func<int>(() => Output.MasterVolumeFeedBack.UShortValue));
                         MuteOnAction = new Action(Output.MasterMuteOn);
                         MuteOffAction = new Action(Output.MasterMuteOff);
                         VolumeUpAction = new Action<bool>((b) => Output.MasterVolumeUp.BoolValue = b);
                         VolumeDownAction = new Action<bool>((b) => Output.MasterVolumeDown.BoolValue = b);
-
                         break;
                     }
                 case eDmpsLevelType.MicsMaster:
@@ -381,32 +410,6 @@ namespace PepperDash.Essentials.DM
             short signedLevel = (short)level;
             Debug.Console(2, Debug.ErrorLogLevel.None, "Scaling DMPS volume:{0} feedback:{1} min:{2} max:{3}", Output.Name, signedLevel.ToString(), MinLevel.ToString(), MaxLevel.ToString());
             return (ushort)((signedLevel - MinLevel) * ushort.MaxValue / (MaxLevel - MinLevel));
-        }
-
-        public void GetVolumeMin()
-        {
-            if (Mixer != null)
-            {
-                MinLevel = (short)Mixer.MinVolumeFeedback.UShortValue;
-                Debug.Console(2, Debug.ErrorLogLevel.None, "DMPS set {0} min level:{1}", Output.Name, MinLevel);
-                if (VolumeLevelScaledFeedback != null)
-                {
-                    VolumeLevelScaledFeedback.FireUpdate();
-                }
-            }
-        }
-
-        public void GetVolumeMax()
-        {
-            if (Mixer != null)
-            {
-                MaxLevel = (short)Mixer.MaxVolumeFeedback.UShortValue;
-                Debug.Console(2, Debug.ErrorLogLevel.None, "DMPS set {0} max level:{1}", Output.Name, MaxLevel);
-                if (VolumeLevelScaledFeedback != null)
-                {
-                    VolumeLevelScaledFeedback.FireUpdate();
-                }
-            }
         }
 
         #region IBasicVolumeWithFeedback Members

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmpsRoutingController.cs
@@ -586,7 +586,7 @@ namespace PepperDash.Essentials.DM
             {
                 AddAudioOnlyOutputPort(number, "Program");
 
-                var programOutput = new DmpsAudioOutputController(string.Format("processor-programAudioOutput"), "Program Audio Output", outputCard as Card.Dmps3OutputBase);
+                var programOutput = new DmpsAudioOutputController(string.Format("processor-programAudioOutput"), "Program Audio Output", outputCard as Card.Dmps3ProgramOutput);
 
                 DeviceManager.AddDevice(programOutput);
             }
@@ -598,7 +598,7 @@ namespace PepperDash.Essentials.DM
                     {
                         AddAudioOnlyOutputPort(number, "Aux1");
 
-                        var aux1Output = new DmpsAudioOutputController(string.Format("processor-aux1AudioOutput"), "Program Audio Output", outputCard as Card.Dmps3OutputBase);
+                        var aux1Output = new DmpsAudioOutputController(string.Format("processor-aux1AudioOutput"), "Program Audio Output", outputCard as Card.Dmps3Aux1Output);
 
                         DeviceManager.AddDevice(aux1Output);
                     }
@@ -607,7 +607,7 @@ namespace PepperDash.Essentials.DM
                     {
                         AddAudioOnlyOutputPort(number, "Aux2");
 
-                        var aux2Output = new DmpsAudioOutputController(string.Format("processor-aux2AudioOutput"), "Program Audio Output", outputCard as Card.Dmps3OutputBase);
+                        var aux2Output = new DmpsAudioOutputController(string.Format("processor-aux2AudioOutput"), "Program Audio Output", outputCard as Card.Dmps3Aux2Output);
 
                         DeviceManager.AddDevice(aux2Output);
                     }


### PR DESCRIPTION
This PR fixes a number of DMPS3 audio issues. Tested on DMPS3-300 and DMPS3-200 devices. Not yet tested on DMPS3-4K devices, but it appears to use all the same audio classes.

This does expand the join map a bit. Both to add the analog scaled get/set and to add mic master volume controls.

The scaled analog value set/get will account for the min/max settings on the main volume. Source, codec, and mic volumes do not have min/max settings and must scale from -80 to 10 dB.