### PR TITLE
Feature/cenodtcpoe sensor sensitivity configuration

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/CenOdtOccupancySensorBaseJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/CenOdtOccupancySensorBaseJoinMap.cs
@@ -46,6 +46,14 @@ namespace PepperDash.Essentials.Core.Bridges
         public JoinDataComplete RawOccupancyUsFeedback = new JoinDataComplete(new JoinData { JoinNumber = 7, JoinSpan = 1 },
             new JoinMetadata { Description = "Raw Occupancy Us Feedback", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });
 
+        [JoinName("IdentityModeOn")]
+        public JoinDataComplete IdentityMode = new JoinDataComplete(new JoinData { JoinNumber = 8, JoinSpan = 1 },
+            new JoinMetadata { Description = "Enable Identity Mode", JoinCapabilities = eJoinCapabilities.FromSIMPL, JoinType = eJoinType.Digital });
+
+        [JoinName("IdentityModeFeedback")]
+        public JoinDataComplete IdentityModeFeedback = new JoinDataComplete(new JoinData { JoinNumber = 8, JoinSpan = 1 },
+            new JoinMetadata { Description = "Identity Mode Feedback", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });
+
         [JoinName("EnableLedFlash")]
         public JoinDataComplete EnableLedFlash = new JoinDataComplete(new JoinData { JoinNumber = 11, JoinSpan = 1 },
             new JoinMetadata { Description = "Enable Led Flash", JoinCapabilities = eJoinCapabilities.ToFromSIMPL, JoinType = eJoinType.Digital });

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/CenOdtOccupancySensorBaseController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/CenOdtOccupancySensorBaseController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Resources;
 using System.Text;
 using Crestron.SimplSharp;
 using Crestron.SimplSharpPro.DeviceSupport;
@@ -199,6 +200,27 @@ namespace PepperDash.Essentials.Core
             {
                 SetAndWhenVacatedState((bool)PropertiesConfig.AndWhenVacatedState);
             }
+
+            // TODO [ ] feature/cenoodtcpoe-sensor-sensitivity-configuration
+            if (PropertiesConfig.UsSensitivityOccupied != null)
+            {
+                SetUsSensitivityOccupied((ushort)PropertiesConfig.UsSensitivityOccupied);
+            }
+
+            if (PropertiesConfig.UsSensitivityVacant != null)
+            {
+                SetUsSensitivityVacant((ushort)PropertiesConfig.UsSensitivityVacant);
+            }
+
+            if (PropertiesConfig.PirSensitivityOccupied != null)
+            {
+                SetPirSensitivityOccupied((ushort)PropertiesConfig.PirSensitivityOccupied);
+            }
+
+            if (PropertiesConfig.PirSensitivityVacant != null)
+            {
+                SetPirSensitivityVacant((ushort)PropertiesConfig.PirSensitivityVacant);
+            }
         }
 
 		/// <summary>
@@ -279,7 +301,21 @@ namespace PepperDash.Essentials.Core
 			}
 		}
 
-		/// <summary>
+        /// <summary>
+        /// Sets the identity mode on or off
+        /// </summary>
+        /// <param name="state"></param>
+	    public void SetIdentityMode(bool state)
+        {
+            if (state)
+                OccSensor.IdentityModeOn();
+            else
+                OccSensor.IdentityModeOff();
+
+            Debug.Console(1, this, "Identity Mode: {0}", OccSensor.IdentityModeOnFeedback.BoolValue ? "On" : "Off");
+        }
+
+	    /// <summary>
 		/// Enables or disables the PIR sensor
 		/// </summary>
 		/// <param name="state"></param>
@@ -506,6 +542,54 @@ namespace PepperDash.Essentials.Core
 			}
 		}
 
+        /// <summary>
+        /// Sets the US sensor sensitivity for occupied state
+        /// </summary>
+        /// <param name="sensitivity"></param>
+	    public void SetUsSensitivityOccupied(ushort sensitivity)
+        {
+            var level = (eSensitivityLevel) sensitivity;
+            if (level == 0) return;
+
+            OccSensor.UltrasonicSensorSensitivityInOccupiedState = level;
+        }
+
+        /// <summary>
+        /// Sets the US sensor sensitivity for vacant state
+        /// </summary>
+        /// <param name="sensitivity"></param>
+        public void SetUsSensitivityVacant(ushort sensitivity)
+        {
+            var level = (eSensitivityLevel)sensitivity;
+            if (level == 0) return;
+
+            OccSensor.UltrasonicSensorSensitivityInVacantState = level;
+        }
+
+        /// <summary>
+        /// Sets the PIR sensor sensitivity for occupied state
+        /// </summary>
+        /// <param name="sensitivity"></param>
+        public void SetPirSensitivityOccupied(ushort sensitivity)
+        {
+            var level = (eSensitivityLevel)sensitivity;
+            if (level == 0) return;
+
+            OccSensor.PassiveInfraredSensorSensitivityInOccupiedState = level;
+        }
+
+        /// <summary>
+        /// Sets the PIR sensor sensitivity for vacant state
+        /// </summary>
+        /// <param name="sensitivity"></param>
+        public void SetPirSensitivityVacant(ushort sensitivity)
+        {
+            var level = (eSensitivityLevel)sensitivity;
+            if (level == 0) return;
+
+            OccSensor.PassiveInfraredSensorSensitivityInVacantState = level;
+        }
+
 		/// <summary>
 		/// Method to print current settings to console
 		/// </summary>
@@ -647,8 +731,7 @@ namespace PepperDash.Essentials.Core
 
 			//Sensor Raw States
 			occController.RawOccupancyPirFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyPirFeedback.JoinNumber]);
-			occController.RawOccupancyUsFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyUsFeedback.JoinNumber]);
-
+			occController.RawOccupancyUsFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyUsFeedback.JoinNumber]);           
 		}
 
 		public class CenOdtOccupancySensorBaseControllerFactory : EssentialsDeviceFactory<CenOdtOccupancySensorBaseController>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/CenOdtOccupancySensorBaseController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/CenOdtOccupancySensorBaseController.cs
@@ -62,6 +62,8 @@ namespace PepperDash.Essentials.Core
 
 		public BoolFeedback RawOccupancyUsFeedback { get; private set; }
 
+        public BoolFeedback IdentityModeFeedback { get; private set; }
+
 		// Debug properties
 		public bool InTestMode { get; private set; }
 
@@ -117,6 +119,8 @@ namespace PepperDash.Essentials.Core
 			RawOccupancyPirFeedback = new BoolFeedback(() => OccSensor.RawOccupancyDetectedByPassiveInfraredSensorFeedback.BoolValue);
 
 			RawOccupancyUsFeedback = new BoolFeedback(() => OccSensor.RawOccupancyDetectedByUltrasonicSensorFeedback.BoolValue);
+
+            IdentityModeFeedback = new BoolFeedback(()=>OccSensor.IdentityModeOnFeedback.BoolValue);
 
 			UltrasonicSensitivityInVacantStateFeedback = new IntFeedback(() => (int)OccSensor.UltrasonicSensorSensitivityInVacantStateFeedback);
 
@@ -731,7 +735,11 @@ namespace PepperDash.Essentials.Core
 
 			//Sensor Raw States
 			occController.RawOccupancyPirFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyPirFeedback.JoinNumber]);
-			occController.RawOccupancyUsFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyUsFeedback.JoinNumber]);           
+			occController.RawOccupancyUsFeedback.LinkInputSig(trilist.BooleanInput[joinMap.RawOccupancyUsFeedback.JoinNumber]);  
+         
+            // Identity mode
+		    trilist.SetBoolSigAction(joinMap.IdentityMode.JoinNumber, occController.SetIdentityMode);
+            occController.IdentityModeFeedback.LinkInputSig(trilist.BooleanInput[joinMap.IdentityModeFeedback.JoinNumber]);
 		}
 
 		public class CenOdtOccupancySensorBaseControllerFactory : EssentialsDeviceFactory<CenOdtOccupancySensorBaseController>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/GlsOccupancySensorPropertiesConfig.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/GlsOccupancySensorPropertiesConfig.cs
@@ -47,5 +47,35 @@ namespace PepperDash.Essentials.Core
 
         [JsonProperty("andWhenVacatedState")]
         public bool? AndWhenVacatedState { get; set; }
+
+        // PoE Sensors: CenOdtCPoe
+
+        /// <summary>
+        /// Sets the sensitivity level for US while sensor is in occupied state
+        /// 1 = low; 2 = medium; 3 = high; 4 = xlow; 5 = 2xlow; 6 = 3xlow
+        /// </summary>
+        [JsonProperty("usSensitivityOccupied")]
+        public ushort? UsSensitivityOccupied { get; set; }
+
+        /// <summary>
+        /// Sets the sensitivity level for US while sensor is in vacant state
+        /// 1 = low; 2 = medium; 3 = high; 4 = xlow; 5 = 2xlow; 6 = 3xlow
+        /// </summary>
+        [JsonProperty("usSensitivityVacant")]
+        public ushort? UsSensitivityVacant { get; set; }
+
+        /// <summary>
+        /// Sets the sensitivity level for PIR while sensor is in occupied state
+        /// 1 = low; 2 = medium; 3 = high
+        /// </summary>
+        [JsonProperty("pirSensitivityOccupied")]
+        public ushort? PirSensitivityOccupied { get; set; }
+
+        /// <summary>
+        /// Sets the sensitivity level for PIR while sensor is in vacant state
+        /// 1 = low; 2 = medium; 3 = high
+        /// </summary>
+        [JsonProperty("PirSensitivityVacant")]
+        public ushort? PirSensitivityVacant { get; set; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/GlsOccupancySensorPropertiesConfig.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Occupancy/GlsOccupancySensorPropertiesConfig.cs
@@ -75,7 +75,7 @@ namespace PepperDash.Essentials.Core
         /// Sets the sensitivity level for PIR while sensor is in vacant state
         /// 1 = low; 2 = medium; 3 = high
         /// </summary>
-        [JsonProperty("PirSensitivityVacant")]
+        [JsonProperty("pirSensitivityVacant")]
         public ushort? PirSensitivityVacant { get; set; }
     }
 }


### PR DESCRIPTION
Updates for CEN-ODT-C-POE Occupancy Sensors
1. Added configuration for Ultra-Sonic (US) and PIR Sensitivity Occupied and vacant states.  
2. Added the ability to enable/disable identity mode 

Bench tested configuration properties to verify values were properly read and adjustments made via the bridge did not cause errors or exceptions.