### PR TITLE
Fixes program info for slots 2-10 on join map if joinOffset is > 0

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/SystemMonitorJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/SystemMonitorJoinMap.cs
@@ -45,7 +45,7 @@ namespace PepperDash.Essentials.Core.Bridges
             new JoinMetadata { Description = "Processor Last Boot", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Serial });
 
         [JoinName("ProgramOffsetJoin")]
-        public JoinDataComplete ProgramOffsetJoin = new JoinDataComplete(new JoinData { JoinNumber = 5, JoinSpan = 1 },
+        public JoinDataComplete ProgramOffsetJoin = new JoinDataComplete(new JoinData { JoinNumber = 5, JoinSpan = 5 },
             new JoinMetadata { Description = "All Program Data is offset between slots by 5 - First Joins Start at 11", JoinCapabilities = eJoinCapabilities.None, JoinType = eJoinType.None });
 
         [JoinName("ProgramStart")]

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Monitoring/SystemMonitorController.cs
@@ -301,7 +301,7 @@ namespace PepperDash.Essentials.Core.Monitoring
                 p.Value.AggregatedProgramInfoFeedback.LinkInputSig(
                     trilist.StringInput[programSlotJoinStart + joinMap.AggregatedProgramInfo.JoinNumber]);
 
-                programSlotJoinStart = programSlotJoinStart + joinMap.ProgramOffsetJoin.JoinNumber;
+                programSlotJoinStart = programSlotJoinStart + joinMap.ProgramOffsetJoin.JoinSpan;
             }
         }
 


### PR DESCRIPTION
Resolves issue where program info join map increments for each program slot using a number that includes the join offset. This works if the join offset is 0.

Use case was SysMon was using join offset 1000. Each program slot would increment by 1005 joins instead of 5 joins.

Resolves #877 