### PR TITLE
fix: Added MeetingsToDisplay analog join to join map

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/VideoCodecControllerJoinMap.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/VideoCodecControllerJoinMap.cs
@@ -924,6 +924,21 @@ namespace PepperDash.Essentials.Core.Bridges.JoinMaps
 
 		#region Analog
 
+        // TODO [ ] hotfix/videocodecbase-max-meeting-xsig-set
+        [JoinName("MeetingsToDisplay")]
+        public JoinDataComplete MeetingsToDisplay = new JoinDataComplete(
+            new JoinData
+            {
+                JoinNumber = 40,
+                JoinSpan = 1
+            },
+            new JoinMetadata
+            {
+                Description = "Set/FB the number of meetings to display via the bridge xsig; default: 3 meetings.",
+                JoinCapabilities = eJoinCapabilities.ToFromSIMPL,
+                JoinType = eJoinType.Analog
+            });
+
 		[JoinName("MinutesBeforeMeetingStart")]
 		public JoinDataComplete MinutesBeforeMeetingStart = new JoinDataComplete(
 			new JoinData


### PR DESCRIPTION
Closes #884.  Added MeetingsToDisplay analog join to join map to take in number of MeetingsToDisplay via the xsig bridge and provide feedback of property.  fix: Added MeetingsToDisplay property with backer field and feedback.  Updated LinkVideoCodecScheduleToApi method with new property.  Updated Constructor to instantiate the feedback property.