### PR TITLE
Add `IRelayPorts` interface to `DmRmc4kzScalerCController`

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
@@ -90,12 +90,13 @@ namespace PepperDash.Essentials.Core.CrestronIO
                 return null;
             }
 
-            if (dc.PortNumber > relayDevice.NumberOfRelayPorts)
+            if (dc.PortNumber <= relayDevice.NumberOfRelayPorts)
             {
-                Debug.Console(0, "Device {0} does not contain a port {1}", dc.PortDeviceKey, dc.PortNumber);
+                return relayDevice.RelayPorts[dc.PortNumber];
             }
-            
-            return relayDevice.RelayPorts[dc.PortNumber];
+
+            Debug.Console(0, "Device {0} does not contain a port {1}", dc.PortDeviceKey, dc.PortNumber);
+            return null;
         }
 
         #endregion

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/GenericRelayDevice.cs
@@ -208,58 +208,6 @@ namespace PepperDash.Essentials.Core.CrestronIO
                 var portDevice = new GenericRelayDevice(dc.Key, dc.Name, GetRelay, props);
 
                 return portDevice;
-
-
-                /*
-                if (props.PortDeviceKey == "processor")
-                    portDevice = Global.ControlSystem as IRelayPorts;
-                else
-                    portDevice = DeviceManager.GetDeviceForKey(props.PortDeviceKey) as IRelayPorts;
-
-                if (portDevice == null)
-                    Debug.Console(0, "Unable to add relay device with key '{0}'. Port Device does not support relays", key);
-                else
-                {
-                    var cs = (portDevice as CrestronControlSystem);
-
-                    if (cs != null)
-                    {
-                        // The relay is on a control system processor
-                        if (!cs.SupportsRelay || props.PortNumber > cs.NumberOfRelayPorts)
-                        {
-                            Debug.Console(0, "Port Device: {0} does not support relays or does not have enough relays");
-                            return null;
-                        }
-                    }
-                    else
-                    {
-                        // The relay is on another device type
-
-                        if (props.PortNumber > portDevice.NumberOfRelayPorts)
-                        {
-                            Debug.Console(0, "Port Device: {0} does not have enough relays");
-                            return null;
-                        }
-                    }
-
-                    Relay relay = portDevice.RelayPorts[props.PortNumber];
-
-                    if (!relay.Registered)
-                    {
-                        if (relay.Register() == eDeviceRegistrationUnRegistrationResponse.Success)
-                            return new GenericRelayDevice(key, relay);
-                        else
-                            Debug.Console(0, "Attempt to register relay {0} on device with key '{1}' failed.", props.PortNumber, props.PortDeviceKey);
-                    }
-                    else
-                    {
-                        return new GenericRelayDevice(key, relay);
-                    }
-
-                    // Future: Check if portDevice is 3-series card or other non control system that supports versiports
-                }
-                */
-
             }
         }
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmc4kZScalerCController.cs
@@ -14,7 +14,7 @@ namespace PepperDash.Essentials.DM
 {
     [Description("Wrapper Class for DM-RMC-4K-Z-SCALER-C")]
     public class DmRmc4kZScalerCController : DmRmcControllerBase, IRmcRoutingWithFeedback,
-        IIROutputPorts, IComPorts, ICec
+        IIROutputPorts, IComPorts, ICec, IRelayPorts
     {
         private readonly DmRmc4kzScalerC _rmc;
 
@@ -168,5 +168,18 @@ namespace PepperDash.Essentials.DM
         }
         #endregion
 
+        #region Implementation of IRelayPorts
+
+        public CrestronCollection<Relay> RelayPorts
+        {
+            get { return _rmc.RelayPorts; }
+        }
+
+        public int NumberOfRelayPorts
+        {
+            get { return _rmc.NumberOfRelayPorts; }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
close #891 

This PR also fixes some issues in the `GenericRelayController` class:
1. It implements a check for null and logs a message to the console and the error log if the `GetRelay` method fails to get a relay to use
2. Separates out the check for the existence of the device and whether or not the device implements `IRelayPorts`. This allows for a clearer indication of what went wrong.