### PR TITLE
Add Support for CEN-IO devices

### DIFF
--- a/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleSpaceRoom.cs
+++ b/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleSpaceRoom.cs
@@ -7,7 +7,7 @@ using PepperDash.Essentials.Room.Config;
 
 namespace PepperDash.Essentials
 {
-    public interface IEssentialsHuddleSpaceRoom : IEssentialsRoom, IHasCurrentSourceInfoChange, IRunRouteAction, IRunDefaultPresentRoute, IHasDefaultDisplay
+    public interface IEssentialsHuddleSpaceRoom : IEssentialsRoom, IHasCurrentSourceInfoChange, IRunRouteAction, IRunDefaultPresentRoute, IHasDefaultDisplay, IHasCurrentVolumeControls
     {
         bool ExcludeFromGlobalFunctions { get; }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/DinCenCn/DinCenCnController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/DinCenCn/DinCenCnController.cs
@@ -34,7 +34,7 @@ namespace PepperDash.Essentials.Core
 
             public override EssentialsDevice BuildDevice(DeviceConfig dc)
             {
-                Debug.Console(1, "Factory Attempting to create new C2N-RTHS Device");
+                Debug.Console(1, "Factory Attempting to create new DIN-CEN-CN2 Device");
 
                 var control = CommFactory.GetControlPropertiesConfig(dc);
                 var ipid = control.IpIdInt;

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Inputs/CenIoDigIn104Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Inputs/CenIoDigIn104Controller.cs
@@ -16,7 +16,7 @@ namespace PepperDash.Essentials.Core
     /// Wrapper class for CEN-IO-DIGIN-104 digital input module
     /// </summary>
     [Description("Wrapper class for the CEN-IO-DIGIN-104 diginal input module")]
-    public class CenIoDigIn104Controller : EssentialsDevice, IDigitalInputPorts
+    public class CenIoDigIn104Controller : CrestronGenericBaseDevice, IDigitalInputPorts
     {
         public CenIoDi104 Di104 { get; private set; }
 
@@ -53,9 +53,16 @@ namespace PepperDash.Essentials.Core
             Debug.Console(1, "Factory Attempting to create new CEN-DIGIN-104 Device");
 
             var control = CommFactory.GetControlPropertiesConfig(dc);
+	        if (control == null)
+	        {
+				Debug.Console(1, "Factory failed to create a new CEN-DIGIN-104 Device, control properties not found");
+				return null;
+	        }
             var ipid = control.IpIdInt;
+			if (ipid != 0) return new CenIoDigIn104Controller(dc.Key, dc.Name, new CenIoDi104(ipid, Global.ControlSystem));
 
-            return new CenIoDigIn104Controller(dc.Key, dc.Name, new Crestron.SimplSharpPro.GeneralIO.CenIoDi104(ipid, Global.ControlSystem));
+			Debug.Console(1, "Factory failed to create a new CEN-IO-IR-104 Device using IP-ID-{0}", ipid);
+			return null;
         }
     }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
@@ -18,44 +18,75 @@ namespace PepperDash.Essentials.Core
     [Description("Wrapper class for the CEN-IO-IR-104 module")]
     public class CenIoIr104Controller : EssentialsDevice, IIROutputPorts
     {
-        public CenIoIr104 Ir104 { get; private set; }
+	    private readonly CenIoIr104 _ir104;
 
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="name"></param>
+		/// <param name="ir104"></param>
         public CenIoIr104Controller(string key, string name, CenIoIr104 ir104)
             : base(key, name)
         {
-            Ir104 = ir104;
+            _ir104 = ir104;
         }
 
         #region IDigitalInputPorts Members
 
+		/// <summary>
+		/// IR port collection
+		/// </summary>
 		public CrestronCollection<IROutputPort> IROutputPorts
         {
-            get { return Ir104.IROutputPorts; }
+            get { return _ir104.IROutputPorts; }
         }
 
+		/// <summary>
+		/// Number of relay ports property
+		/// </summary>
 		public int NumberOfIROutputPorts
         {
-            get { return Ir104.NumberOfIROutputPorts; }
+            get { return _ir104.NumberOfIROutputPorts; }
         }
 
         #endregion
     }
 
+	/// <summary>
+	/// CEN-IO-IR-104 controller fatory
+	/// </summary>
     public class CenIoIr104ControllerFactory : EssentialsDeviceFactory<CenIoIr104Controller>
     {
+		/// <summary>
+		/// Constructor
+		/// </summary>
         public CenIoIr104ControllerFactory()
         {
             TypeNames = new List<string>() { "cenioir104" };
         }
 
+		/// <summary>
+		/// Build device CEN-IO-IR-104
+		/// </summary>
+		/// <param name="dc"></param>
+		/// <returns></returns>
         public override EssentialsDevice BuildDevice(DeviceConfig dc)
         {
-            Debug.Console(1, "Factory Attempting to create new CEN-IR-104 Device");
+            Debug.Console(1, "Factory Attempting to create new CEN-IO-IR-104 Device");
 
             var control = CommFactory.GetControlPropertiesConfig(dc);
-            var ipid = control.IpIdInt;
+			if (control == null)
+			{
+				Debug.Console(1, "Factory failed to create a new CEN-IO-IR-104 Device");
+				return null;
+			}
 
-            return new CenIoIr104Controller(dc.Key, dc.Name, new Crestron.SimplSharpPro.GeneralIO.CenIoIr104(ipid, Global.ControlSystem));
+            var ipid = control.IpIdInt;
+			if(ipid != 0) return new CenIoIr104Controller(dc.Key, dc.Name, new CenIoIr104(ipid, Global.ControlSystem));
+
+			Debug.Console(1, "Factory failed to create a new CEN-IO-IR-104 Device using IP-ID-{0}", ipid);
+			return null;
         }
     }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crestron.SimplSharp;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.GeneralIO;
+using PepperDash.Essentials.Core.Config;
+
+
+using PepperDash.Core;
+
+namespace PepperDash.Essentials.Core
+{
+    /// <summary>
+    /// Wrapper class for CEN-IO-IR-104 module
+    /// </summary>
+    [Description("Wrapper class for the CEN-IO-IR-104 module")]
+    public class CenIoIr104Controller : EssentialsDevice, IIROutputPorts
+    {
+        public CenIoIr104 Ir104 { get; private set; }
+
+        public CenIoIr104Controller(string key, string name, CenIoIr104 ir104)
+            : base(key, name)
+        {
+            Ir104 = ir104;
+        }
+
+        #region IDigitalInputPorts Members
+
+		public CrestronCollection<IROutputPort> IROutputPorts
+        {
+            get { return Ir104.IROutputPorts; }
+        }
+
+		public int NumberOfIROutputPorts
+        {
+            get { return Ir104.NumberOfIROutputPorts; }
+        }
+
+        #endregion
+    }
+
+    public class CenIoIr104ControllerFactory : EssentialsDeviceFactory<CenIoIr104Controller>
+    {
+        public CenIoIr104ControllerFactory()
+        {
+            TypeNames = new List<string>() { "cenioir104" };
+        }
+
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.Console(1, "Factory Attempting to create new CEN-IR-104 Device");
+
+            var control = CommFactory.GetControlPropertiesConfig(dc);
+            var ipid = control.IpIdInt;
+
+            return new CenIoIr104Controller(dc.Key, dc.Name, new Crestron.SimplSharpPro.GeneralIO.CenIoIr104(ipid, Global.ControlSystem));
+        }
+    }
+
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Ir/CenIoIr104Controller.cs
@@ -16,7 +16,7 @@ namespace PepperDash.Essentials.Core
     /// Wrapper class for CEN-IO-IR-104 module
     /// </summary>
     [Description("Wrapper class for the CEN-IO-IR-104 module")]
-    public class CenIoIr104Controller : EssentialsDevice, IIROutputPorts
+    public class CenIoIr104Controller : CrestronGenericBaseDevice, IIROutputPorts
     {
 	    private readonly CenIoIr104 _ir104;
 
@@ -27,7 +27,7 @@ namespace PepperDash.Essentials.Core
 		/// <param name="name"></param>
 		/// <param name="ir104"></param>
         public CenIoIr104Controller(string key, string name, CenIoIr104 ir104)
-            : base(key, name)
+            : base(key, name, ir104)
         {
             _ir104 = ir104;
         }
@@ -78,7 +78,7 @@ namespace PepperDash.Essentials.Core
             var control = CommFactory.GetControlPropertiesConfig(dc);
 			if (control == null)
 			{
-				Debug.Console(1, "Factory failed to create a new CEN-IO-IR-104 Device");
+				Debug.Console(1, "Factory failed to create a new CEN-IO-IR-104 Device, control properties not found");
 				return null;
 			}
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/CenIoRy104Controller.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Crestron IO/Relay/CenIoRy104Controller.cs
@@ -10,7 +10,7 @@ namespace PepperDash.Essentials.Core
     /// Wrapper class for CEN-IO-RY-104 relay module
     /// </summary>
     [Description("Wrapper class for the CEN-IO-RY-104 relay module")]
-    public class CenIoRy104Controller : EssentialsDevice, IRelayPorts
+    public class CenIoRy104Controller : CrestronGenericBaseDevice, IRelayPorts
     {
         private readonly CenIoRy104 _ry104;
 
@@ -21,7 +21,7 @@ namespace PepperDash.Essentials.Core
         /// <param name="name"></param>
         /// <param name="ry104"></param>
         public CenIoRy104Controller(string key, string name, CenIoRy104 ry104)
-            : base(key, name)
+            : base(key, name, ry104)
         {
             _ry104 = ry104;
         }
@@ -63,7 +63,7 @@ namespace PepperDash.Essentials.Core
             var controlPropertiesConfig = CommFactory.GetControlPropertiesConfig(dc);
             if (controlPropertiesConfig == null)
             {
-                Debug.Console(1, "Factory failed to create a new CEN-IO-RY-104 Device");
+				Debug.Console(1, "Factory failed to create a new CEN-IO-RY-104 Device, control properties not found");
                 return null;
             }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Crestron IO\Inputs\GenericVersiportInputDevice.cs" />
     <Compile Include="Crestron IO\Inputs\IDigitalInput.cs" />
     <Compile Include="Crestron IO\IOPortConfig.cs" />
+    <Compile Include="Crestron IO\Ir\CenIoIr104Controller.cs" />
     <Compile Include="Crestron IO\Relay\CenIoRy104Controller.cs" />
     <Compile Include="Crestron IO\Relay\GenericRelayDevice.cs" />
     <Compile Include="Crestron IO\Relay\ISwitchedOutput.cs" />


### PR DESCRIPTION
Updated CEN-IO class inheritance of EssentialsDevice to CrestronGenericBaseDevice 
1. DIGIN-104
2. RY-104
3. IR-104

Tested in the field with CEN-IO-IR-104 and CEN-IO-RY-104.  Merged [hotfix/huddle-room-interfaces](https://github.com/PepperDash/Essentials/tree/hotfix/huddle-room-interfaces) branch.