### PR TITLE
Hotfix/video codec base xsig fixes

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -1409,7 +1409,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 				stringIndex += maxStrings;
                 digitalIndex += maxDigitals;
 			}
-			while (digitalIndex < maxCalls * offset)
+            while (arrayIndex < maxCalls * offset)
 			{
 				//digitals
                 tokenArray[digitalIndex] = new XSigDigitalToken(digitalIndex + 1, false);

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -1407,9 +1407,9 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 				arrayIndex += offset;
 				stringIndex += maxStrings;
-				digitalIndex++;
+                digitalIndex += maxDigitals;
 			}
-			while (digitalIndex < maxCalls)
+			while (digitalIndex < maxCalls * offset)
 			{
 				//digitals
                 tokenArray[digitalIndex] = new XSigDigitalToken(digitalIndex + 1, false);
@@ -1426,7 +1426,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 				arrayIndex += offset;
 				stringIndex += maxStrings;
-				digitalIndex++;
+				digitalIndex += maxDigitals;
 			}
 
 			return GetXSigString(tokenArray);


### PR DESCRIPTION
Update the XSig methods in VideoCodecBase to fix an issue where it wasn't depopulating empty values.

This has been tested.

Resolves #1012 