### PR TITLE
Feature/joinmap markdown

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -83,10 +83,10 @@ namespace PepperDash.Essentials
 
             CrestronConsole.AddNewConsoleCommand(BridgeHelper.PrintJoinMap, "getjoinmap", "map(s) for bridge or device on bridge [brKey [devKey]]", ConsoleAccessLevelEnum.AccessOperator);
 
-            CrestronConsole.AddNewConsoleCommand(s =>
-            {
-                Debug.Console(0, Debug.ErrorLogLevel.Notice, "CONSOLE MESSAGE: {0}", s);
-            }, "appdebugmessage", "Writes message to log", ConsoleAccessLevelEnum.AccessOperator);
+            CrestronConsole.AddNewConsoleCommand(BridgeHelper.JoinmapMarkdown, "getjoinmapmarkdown"
+                , "generate markdown of map(s) for bridge or device on bridge [brKey [devKey]]", ConsoleAccessLevelEnum.AccessOperator);
+
+            CrestronConsole.AddNewConsoleCommand(s => Debug.Console(0, Debug.ErrorLogLevel.Notice, "CONSOLE MESSAGE: {0}", s), "appdebugmessage", "Writes message to log", ConsoleAccessLevelEnum.AccessOperator);
 
             CrestronConsole.AddNewConsoleCommand(s =>
             {
@@ -103,12 +103,16 @@ namespace PepperDash.Essentials
                     (ConfigReader.ConfigObject, Newtonsoft.Json.Formatting.Indented));
             }, "showconfig", "Shows the current running merged config", ConsoleAccessLevelEnum.AccessOperator);
 
-            CrestronConsole.AddNewConsoleCommand(s =>
-            {
-                CrestronConsole.ConsoleCommandResponse("This system can be found at the following URLs:\r\n" +
-                    "System URL:   {0}\r\n" +
-                    "Template URL: {1}", ConfigReader.ConfigObject.SystemUrl, ConfigReader.ConfigObject.TemplateUrl);
-            }, "portalinfo", "Shows portal URLS from configuration", ConsoleAccessLevelEnum.AccessOperator);
+            CrestronConsole.AddNewConsoleCommand(s => 
+                CrestronConsole.ConsoleCommandResponse(
+                "This system can be found at the following URLs:\r\n" +
+                "System URL:   {0}\r\n" +
+                "Template URL: {1}", 
+                ConfigReader.ConfigObject.SystemUrl, 
+                ConfigReader.ConfigObject.TemplateUrl), 
+                "portalinfo", 
+                "Shows portal URLS from configuration", 
+                ConsoleAccessLevelEnum.AccessOperator);
 
 
             CrestronConsole.AddNewConsoleCommand(DeviceManager.GetRoutingPorts,
@@ -295,6 +299,10 @@ namespace PepperDash.Essentials
             var pluginDir = Global.FilePathPrefix + "plugins";
             if (!Directory.Exists(pluginDir))
                 Directory.Create(pluginDir);
+
+            var joinmapDir = Global.FilePathPrefix + "joinmaps";
+            if(!Directory.Exists(joinmapDir))
+                Directory.Create(joinmapDir);
 
 			return configExists;
 		}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -46,6 +46,33 @@ namespace PepperDash.Essentials.Core.Bridges
                 bridge.PrintJoinMaps();
             }
         }
+        public static void JoinmapMarkdown(string command)
+        {
+            var targets = command.Split(' ');
+
+            var bridgeKey = targets[0].Trim();
+
+            var bridge = DeviceManager.GetDeviceForKey(bridgeKey) as EiscApiAdvanced;
+
+            if (bridge == null)
+            {
+                Debug.Console(0, "Unable to find advanced bridge with key: '{0}'", bridgeKey);
+                return;
+            }
+
+            if (targets.Length > 1)
+            {
+                var deviceKey = targets[1].Trim();
+
+                if (string.IsNullOrEmpty(deviceKey)) return;
+                bridge.MarkdownJoinMapForDevice(deviceKey, bridgeKey);
+            }
+            else
+            {
+                bridge.MarkdownForBridge(bridgeKey);
+
+            }
+        }
     }
 
 
@@ -227,6 +254,19 @@ namespace PepperDash.Essentials.Core.Bridges
                 joinMap.Value.PrintJoinMapInfo();
             }
         }
+        /// <summary>
+        /// Generates markdown for all join maps on this bridge
+        /// </summary>
+        public virtual void MarkdownForBridge(string bridgeKey)
+        {
+            Debug.Console(0, this, "Writing Joinmaps to files for EISC IPID: {0}", Eisc.ID.ToString("X"));
+
+            foreach (var joinMap in JoinMaps)
+            {
+                Debug.Console(0, "Generating markdown for device '{0}':", joinMap.Key);
+                joinMap.Value.MarkdownJoinMapInfo(joinMap.Key, bridgeKey);
+            }
+        }
 
         /// <summary>
         /// Prints the join map for a device by key
@@ -242,8 +282,25 @@ namespace PepperDash.Essentials.Core.Bridges
                 return;
             }
 
-            Debug.Console(0, "Join map for device '{0}' on EISC '{1}':", deviceKey, Key); 
+            Debug.Console(0, "Join map for device '{0}' on EISC '{1}':", deviceKey, Key);
             joinMap.PrintJoinMapInfo();
+        }
+        /// <summary>
+        /// Prints the join map for a device by key
+        /// </summary>
+        /// <param name="deviceKey"></param>
+        public void MarkdownJoinMapForDevice(string deviceKey, string bridgeKey)
+        {
+            var joinMap = JoinMaps[deviceKey];
+
+            if (joinMap == null)
+            {
+                Debug.Console(0, this, "Unable to find joinMap for device with key: '{0}'", deviceKey);
+                return;
+            }
+
+            Debug.Console(0, "Join map for device '{0}' on EISC '{1}':", deviceKey, Key);
+            joinMap.MarkdownJoinMapInfo(deviceKey, bridgeKey);
         }
 
         /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Extensions/StringExtensions.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Extensions/StringExtensions.cs
@@ -16,5 +16,9 @@ namespace PepperDash.Essentials.Core
         {
             return string.IsNullOrEmpty(s.Trim()) ? null : s;
         }
+        public static string ReplaceIfNullOrEmpty(this string s, string newString)
+        {
+            return string.IsNullOrEmpty(s) ? newString : s;
+        }
     }
 }


### PR DESCRIPTION
Add a new console command `getjoinmapmarkdown` that functions identically to getjoinmap, except instead of printing them, it writes them to a markdown file that's placed in a new directory program<x>/joinmap

I imagine we want to maybe change the directory, but that's trivial.

This works well, but it's an intermediary step to being able to actually document a plugin automatically through github actions....this was mostly based on some experience Devito had converting copied joinmaps to a readme.