### PR TITLE
Update Zoom polling/sending blocks for more scenarios

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
@@ -3493,10 +3493,11 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
         void OnPasswordRequired(bool lastAttemptIncorrect, bool loginFailed, bool loginCancelled, string message)
         {
+			_meetingPasswordRequired = !loginFailed || !loginCancelled;
+
             var handler = PasswordRequired;
             if (handler != null)
-            {
-	            _meetingPasswordRequired = !loginFailed || !loginCancelled;
+            {	            
 				Debug.Console(2, this, "Meeting Password Required: {0}", _meetingPasswordRequired);
 
 	            handler(this, new PasswordPromptEventArgs(lastAttemptIncorrect, loginFailed, loginCancelled, message));

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
@@ -2583,7 +2583,6 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 				if (args.LoginAttemptCancelled)
 				{
 					trilist.SetBool(joinMap.MeetingPasswordRequired.JoinNumber, false);
-					_meetingPasswordRequired = false;
 					return;
 				}
 
@@ -2595,7 +2594,6 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 				if (args.LoginAttemptFailed)
 				{
 					// login attempt failed
-					_meetingPasswordRequired = false;
 					return;
 				}
 
@@ -2820,24 +2818,24 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
         public void LeaveMeeting()
         {
-			if (_meetingPasswordRequired) _meetingPasswordRequired = false;
-			if (_waitingForUserToAcceptOrRejectIncomingCall) _waitingForUserToAcceptOrRejectIncomingCall = false;
-			
+			_meetingPasswordRequired = false;
+			_waitingForUserToAcceptOrRejectIncomingCall = false;
+
 			SendText("zCommand Call Leave");
         }
 
 		public override void EndCall(CodecActiveCallItem call)
 		{
-			if (_meetingPasswordRequired) _meetingPasswordRequired = false;
-			if (_waitingForUserToAcceptOrRejectIncomingCall) _waitingForUserToAcceptOrRejectIncomingCall = false;
+			_meetingPasswordRequired = false;
+			_waitingForUserToAcceptOrRejectIncomingCall = false;
 
 			SendText("zCommand Call Disconnect");
 		}
 
 		public override void EndAllCalls()
 		{
-			if (_meetingPasswordRequired) _meetingPasswordRequired = false;
-			if (_waitingForUserToAcceptOrRejectIncomingCall) _waitingForUserToAcceptOrRejectIncomingCall = false;
+			_meetingPasswordRequired = false;
+			_waitingForUserToAcceptOrRejectIncomingCall = false;
 
 			SendText("zCommand Call Disconnect");
 		}


### PR DESCRIPTION
for prompt property tracking and set/reset to handle unknown user scenarios.

Closes #1028 