### PR TITLE
Feature/video codec x sig updates

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -1393,11 +1393,11 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
                 tokenArray[digitalIndex + 1] = new XSigDigitalToken(digitalIndex + 2, call.IsOnHold);
 
 				//serials
-				tokenArray[arrayIndex] = new XSigSerialToken(stringIndex + 1, call.Name ?? String.Empty);
-				tokenArray[arrayIndex + 1] = new XSigSerialToken(stringIndex + 2, call.Number ?? String.Empty);
-				tokenArray[arrayIndex + 2] = new XSigSerialToken(stringIndex + 3, call.Direction.ToString());
-				tokenArray[arrayIndex + 3] = new XSigSerialToken(stringIndex + 4, call.Type.ToString());
-				tokenArray[arrayIndex + 4] = new XSigSerialToken(stringIndex + 5, call.Status.ToString());
+                tokenArray[stringIndex] = new XSigSerialToken(stringIndex + 1, call.Name ?? String.Empty);
+                tokenArray[stringIndex + 1] = new XSigSerialToken(stringIndex + 2, call.Number ?? String.Empty);
+                tokenArray[stringIndex + 2] = new XSigSerialToken(stringIndex + 3, call.Direction.ToString());
+                tokenArray[stringIndex + 3] = new XSigSerialToken(stringIndex + 4, call.Type.ToString());
+                tokenArray[stringIndex + 4] = new XSigSerialToken(stringIndex + 5, call.Status.ToString());
                 if(call.Duration != null)
                 {
                     // May need to verify correct string format here
@@ -1417,12 +1417,12 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 
                 //serials
-				tokenArray[arrayIndex] = new XSigSerialToken(stringIndex + 1, String.Empty);
-				tokenArray[arrayIndex + 1] = new XSigSerialToken(stringIndex + 2, String.Empty);
-				tokenArray[arrayIndex + 2] = new XSigSerialToken(stringIndex + 3, String.Empty);
-				tokenArray[arrayIndex + 3] = new XSigSerialToken(stringIndex + 4, String.Empty);
-				tokenArray[arrayIndex + 4] = new XSigSerialToken(stringIndex + 5, String.Empty);
-                tokenArray[arrayIndex + 5] = new XSigSerialToken(stringIndex + 6, String.Empty);
+                tokenArray[stringIndex] = new XSigSerialToken(stringIndex + 1, String.Empty);
+                tokenArray[stringIndex + 1] = new XSigSerialToken(stringIndex + 2, String.Empty);
+                tokenArray[stringIndex + 2] = new XSigSerialToken(stringIndex + 3, String.Empty);
+                tokenArray[stringIndex + 3] = new XSigSerialToken(stringIndex + 4, String.Empty);
+                tokenArray[stringIndex + 4] = new XSigSerialToken(stringIndex + 5, String.Empty);
+                tokenArray[stringIndex + 5] = new XSigSerialToken(stringIndex + 6, String.Empty);
 
 				arrayIndex += offset;
 				stringIndex += maxStrings;


### PR DESCRIPTION
I believe the renaming that was requested for my previous pull request on this feature led to some erroneous tracking.  I did the requested renaming, and did NOT test post-rename, and I apparently associated with an extant variable which broke functionality.

This rectifies this issue - it has been tested in-lab.