### PR TITLE
Updates for VC-4

### DIFF
--- a/PepperDashEssentials/ControlSystem.cs
+++ b/PepperDashEssentials/ControlSystem.cs
@@ -195,6 +195,8 @@ namespace PepperDash.Essentials
                 }
                 else   // Handles Linux OS (Virtual Control)
                 {
+                    Debug.SetDebugLevel(2);
+
                     Debug.Console(0, Debug.ErrorLogLevel.Notice, "Starting Essentials v{0} on Virtual Control Server", Global.AssemblyVersion);
 
                     // Set path to User/

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -418,6 +418,12 @@ namespace PepperDash.Essentials.Core.Bridges
                 case "vceiscapiadv":
                 case "vceiscapiadvanced":
                 {
+                    if (string.IsNullOrEmpty(controlProperties.RoomId))
+                    {
+                        Debug.Console(0, Debug.ErrorLogLevel.Error, "Unable to build VC-4 EISC Client for device {0}. Room ID is missing or empty", dc.Key);
+                        eisc = null;
+                        break;
+                    }
                     eisc = new VirtualControlEISCClient(controlProperties.IpIdInt, controlProperties.RoomId,
                         Global.ControlSystem);
                     break;

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/BridgeBase.cs
@@ -394,35 +394,45 @@ namespace PepperDash.Essentials.Core.Bridges
 
             var controlProperties = CommFactory.GetControlPropertiesConfig(dc);
 
+            BasicTriList eisc;
+
             switch (dc.Type.ToLower())
             {
                 case "eiscapiadv":
                 case "eiscapiadvanced":
                 {
-                    var eisc = new ThreeSeriesTcpIpEthernetIntersystemCommunications(controlProperties.IpIdInt,
+                    eisc = new ThreeSeriesTcpIpEthernetIntersystemCommunications(controlProperties.IpIdInt,
                         controlProperties.TcpSshProperties.Address, Global.ControlSystem);
-                    return new EiscApiAdvanced(dc, eisc);
+                    break;
                 }
                 case "eiscapiadvancedserver":
                 {
-                    var eisc = new EISCServer(controlProperties.IpIdInt, Global.ControlSystem);
-                    return new EiscApiAdvanced(dc, eisc);
+                    eisc = new EISCServer(controlProperties.IpIdInt, Global.ControlSystem);
+                    break;
                 }
                 case "eiscapiadvancedclient":
                 {
-                    var eisc = new EISCClient(controlProperties.IpIdInt, controlProperties.TcpSshProperties.Address, Global.ControlSystem);
-                    return new EiscApiAdvanced(dc, eisc);
+                    eisc = new EISCClient(controlProperties.IpIdInt, controlProperties.TcpSshProperties.Address, Global.ControlSystem);
+                    break;
                 }
                 case "vceiscapiadv":
                 case "vceiscapiadvanced":
                 {
-                    var eisc = new VirtualControlEISCClient(controlProperties.IpIdInt, InitialParametersClass.RoomId,
+                    eisc = new VirtualControlEISCClient(controlProperties.IpIdInt, controlProperties.RoomId,
                         Global.ControlSystem);
-                    return new EiscApiAdvanced(dc, eisc);
+                    break;
                 }
                 default:
-                    return null;
+                    eisc = null;
+                    break;
             }
+
+            if (eisc == null)
+            {
+                return null;
+            }
+
+            return new EiscApiAdvanced(dc, eisc);
         }
     }
 

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashCore" version="1.1.3-hotfix-278" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashCore" version="1.1.3" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashCore" version="1.1.1" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashCore" version="1.1.3-hotfix-276" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashCore" version="1.1.3-hotfix-276" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashCore" version="1.1.3-hotfix-277" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-  <package id="PepperDashCore" version="1.1.3-hotfix-277" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+  <package id="PepperDashCore" version="1.1.3-hotfix-278" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>


### PR DESCRIPTION
In order to facilitate debugging and other inter-room communication, several changes needed to be made, both in PD Core and in Essentials. 

* Essentials now sets the debug level to 2 when it starts on a server. This is to help with those situations where devices are doing their own conditional logic based on `Debug.Level`. On processors, this value is set using the `appdebug` command, which is not available on VC-4
* The `vcEiscApiAdvanced` type now needs a roomId for the room it's communicating with in the configuration file.