### PR TITLE
Prevent vacancy from shutting down the room when a call is active

### DIFF
--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -753,13 +753,13 @@ namespace PepperDash.Essentials
 
             if (VideoCodec != null)
             {
-                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} is in a video call. Not allowing auto power off", Key);
+                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} {1} in a video call", Key, VideoCodec.IsInCall ? "is" : "is not");
                 allowVideo = !VideoCodec.IsInCall;
             }
 
             if (AudioCodec != null)
             {
-                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} is in an audio call. Not allowing auto power off", Key);
+                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} {1} in an audio call", Key, AudioCodec.IsInCall ? "is" : "is not");
                 allowAudio = !AudioCodec.IsInCall;
             }
 

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -745,6 +745,24 @@ namespace PepperDash.Essentials
         {
             //Implement this
         }
+
+        protected override bool AllowVacancyTimerToStart()
+        {
+            bool allowVideo = true;
+            bool allowAudio = true;
+
+            if (VideoCodec != null)
+            {
+                allowVideo = !VideoCodec.IsInCall;
+            }
+
+            if (AudioCodec != null)
+            {
+                allowAudio = !AudioCodec.IsInCall;
+            }
+
+            return allowVideo && allowAudio;
+        }
         
         /// <summary>
         /// Does what it says

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -753,13 +753,17 @@ namespace PepperDash.Essentials
 
             if (VideoCodec != null)
             {
+                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} is in a video call. Not allowing auto power off", Key);
                 allowVideo = !VideoCodec.IsInCall;
             }
 
             if (AudioCodec != null)
             {
+                Debug.Console(2,this, Debug.ErrorLogLevel.Notice, "Room {0} is in an audio call. Not allowing auto power off", Key);
                 allowAudio = !AudioCodec.IsInCall;
             }
+
+            Debug.Console(2, this, "Room {0} allowing vacancy timer to start: {1}", Key, allowVideo && allowAudio);
 
             return allowVideo && allowAudio;
         }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
@@ -343,7 +343,7 @@ namespace PepperDash.Essentials.Core
 
         void RoomIsOccupiedFeedback_OutputChange(object sender, EventArgs e)
         {
-            if (RoomOccupancy.RoomIsOccupiedFeedback.BoolValue == false)
+            if (RoomOccupancy.RoomIsOccupiedFeedback.BoolValue == false  && AllowVacancyTimerToStart())
             {
                 Debug.Console(1, this, Debug.ErrorLogLevel.Notice, "Notice: Vacancy Detected");
                 // Trigger the timer when the room is vacant
@@ -361,7 +361,19 @@ namespace PepperDash.Essentials.Core
         /// Executes when RoomVacancyShutdownTimer expires.  Used to trigger specific room actions as needed.  Must nullify the timer object when executed
         /// </summary>
         /// <param name="o"></param>
-        public abstract void RoomVacatedForTimeoutPeriod(object o);
+        public abstract void RoomVacatedForTimeoutPeriod(object o)
+        {
+ 
+        }
+
+        /// <summary>
+        /// Allow the vacancy event from an occupancy sensor to turn the room off.
+        /// </summary>
+        /// <returns>If the timer should be allowed. Defaults to true</returns>
+        protected virtual bool AllowVacancyTimerToStart()
+        {
+            return true;
+        }
     }
         
     /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
@@ -361,10 +361,7 @@ namespace PepperDash.Essentials.Core
         /// Executes when RoomVacancyShutdownTimer expires.  Used to trigger specific room actions as needed.  Must nullify the timer object when executed
         /// </summary>
         /// <param name="o"></param>
-        public abstract void RoomVacatedForTimeoutPeriod(object o)
-        {
- 
-        }
+        public abstract void RoomVacatedForTimeoutPeriod(object o);
 
         /// <summary>
         /// Allow the vacancy event from an occupancy sensor to turn the room off.


### PR DESCRIPTION
In some cases, the vacancy timer will shut down a room even while a call is active. The added method and logic should prevent that from happening.