### PR TITLE
Fix issues with TouchpanelBase

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/UI/TouchpanelBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/UI/TouchpanelBase.cs
@@ -31,7 +31,7 @@ namespace PepperDash.Essentials.Core.UI
             :base(key, name)
         {
 
-            if (Panel == null)
+            if (panel == null)
             {
                 Debug.Console(0, this, "Panel is not valid. Touchpanel class WILL NOT work correctly");
                 return;

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/UI/TouchpanelBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/UI/TouchpanelBase.cs
@@ -71,6 +71,8 @@ namespace PepperDash.Essentials.Core.UI
                         return;
                     }
                 }
+
+                Panel.LoadSmartObjects(sgdName);
             });
 
             AddPostActivationAction(() =>


### PR DESCRIPTION
After the creation of the `TouchpanelBase` class, a couple of bugs were found
* The constructor was checking against the wrong property to determine if the panel object had been created correctly
* The Preactivation action was NOT loading the smart graphics objects from the SGD.;