### PR TITLE
Fix Empty Zoom Phonebook

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Queues/GenericQueue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Crestron.SimplSharp;
+using Crestron.SimplSharp.Reflection;
 using Crestron.SimplSharpPro.CrestronThread;
 using PepperDash.Core;
 
@@ -187,9 +188,20 @@ namespace PepperDash.Essentials.Core.Queues
                         if (_delayEnabled)
                             Thread.Sleep(_delayTime);
                     }
+                    catch (System.Threading.ThreadAbortException)
+                    {
+                        //swallowing this exception, as it should only happen on shut down
+                    }
                     catch (Exception ex)
                     {
-                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue {0}\r{1}\r{2}", ex.Message, ex.InnerException, ex.StackTrace);
+                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue: {1}:{0}", ex.Message, ex);
+                        Debug.Console(2, this, Debug.ErrorLogLevel.Error, "Stack Trace: {0}", ex.StackTrace);
+
+                        if (ex.InnerException != null)
+                        {
+                            Debug.Console(0, this, Debug.ErrorLogLevel.Error, "---\r\n{0}", ex.InnerException.Message);
+                            Debug.Console(2, this, Debug.ErrorLogLevel.Error, "Stack Trace: {0}", ex.InnerException.StackTrace);
+                        }
                     }
                 }
                 else _waitHandle.Wait();
@@ -202,7 +214,7 @@ namespace PepperDash.Essentials.Core.Queues
         {
             if (Disposed)
             {
-                Debug.Console(1, this, "I've been disposed so you can't enqueue any messages.  Are you trying to dispatch a message while the program is stopping?");
+                Debug.Console(1, this, "Queue has been disposed. Enqueuing messages not allowed while program is stopping.");
                 return;
             }
 
@@ -446,7 +458,14 @@ namespace PepperDash_Essentials_Core.Queues
                     }
                     catch (Exception ex)
                     {
-                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue {0}\r{1}\r{2}", ex.Message, ex.InnerException, ex.StackTrace);
+                        Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue {0}", ex.Message);
+                        Debug.Console(2, this, Debug.ErrorLogLevel.Error, "Stack Trace: {0}", ex.StackTrace);
+
+                        if (ex.InnerException != null)
+                        {
+                            Debug.Console(0, this, Debug.ErrorLogLevel.Error, "Caught an exception in the Queue {0}", ex.InnerException.Message);
+                            Debug.Console(2, this, Debug.ErrorLogLevel.Error, "Stack Trace: {0}", ex.InnerException.StackTrace);
+                        }
                     }
                 }
                 else _waitHandle.Wait();

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
@@ -59,6 +59,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 		private CameraBase _selectedCamera;
         private string _lastDialedMeetingNumber;
 
+        private CTimer contactsDebounceTimer;
+
 
 		private readonly ZoomRoomPropertiesConfig _props;
 
@@ -1511,35 +1513,36 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 						{
 							case "phonebook":
 							{
+                                zStatus.Contact contact = new zStatus.Contact();
+
 								if (responseObj["Updated Contact"] != null)
-								{
-									var updatedContact =
-										JsonConvert.DeserializeObject<zStatus.Contact>(
-											responseObj["Updated Contact"].ToString());
-
-									var existingContact =
-										Status.Phonebook.Contacts.FirstOrDefault(c => c.Jid.Equals(updatedContact.Jid));
-
-									if (existingContact != null)
-									{
-										// Update existing contact
-										JsonConvert.PopulateObject(responseObj["Updated Contact"].ToString(),
-											existingContact);
-									}
+								{                                    
+                                    contact = responseObj["Updated Contact"].ToObject<zStatus.Contact>();									
 								}
 								else if (responseObj["Added Contact"] != null)
 								{
-									var jToken = responseObj["Updated Contact"];
-									if (jToken != null)
-									{
-										var newContact =
-											JsonConvert.DeserializeObject<zStatus.Contact>(
-												jToken.ToString());
-
-										// Add a new contact
-										Status.Phonebook.Contacts.Add(newContact);
-									}
+									contact = responseObj["Added Contact"].ToObject<zStatus.Contact>();
 								}
+
+                                var existingContactIndex = Status.Phonebook.Contacts.FindIndex(c => c.Jid.Equals(contact.Jid));
+
+                                if (existingContactIndex > 0)
+                                {                                    
+                                    Status.Phonebook.Contacts[existingContactIndex] = contact;
+                                } 
+                                else 
+                                {                                    
+                                    Status.Phonebook.Contacts.Add(contact);
+                                }
+
+                                if(contactsDebounceTimer == null)
+                                {
+                                    contactsDebounceTimer = new CTimer(o => UpdateDirectory(), 2000);
+                                }
+                                else
+                                {
+                                    contactsDebounceTimer.Reset();
+                                }                                
 
 								break;
 							}
@@ -2239,8 +2242,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
         private void UpdateDirectory()
         {
-            var directoryResults =
-                                    zStatus.Phonebook.ConvertZoomContactsToGeneric(Status.Phonebook.Contacts);
+            Debug.Console(2, this, "Updating directory");
+            var directoryResults = zStatus.Phonebook.ConvertZoomContactsToGeneric(Status.Phonebook.Contacts);
 
             if (!PhonebookSyncState.InitialSyncComplete)
             {
@@ -2255,6 +2258,22 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
             DirectoryRoot = directoryResults;
 
             CurrentDirectoryResult = directoryResults;
+
+            //
+            if (contactsDebounceTimer != null)
+            {
+                ClearContactDebounceTimer();
+            }
+        }
+
+        private void ClearContactDebounceTimer()
+        {
+            Debug.Console(2, this, "Clearing Timer");
+            if (!contactsDebounceTimer.Disposed && contactsDebounceTimer != null)
+            {
+                contactsDebounceTimer.Dispose();
+                contactsDebounceTimer = null;
+            }
         }
 
         /// <summary>

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ZoomRoom.cs
@@ -1382,22 +1382,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
 								JsonConvert.PopulateObject(responseObj.ToString(), Status.Phonebook);
 
-								var directoryResults =
-									zStatus.Phonebook.ConvertZoomContactsToGeneric(Status.Phonebook.Contacts);
-
-								if (!PhonebookSyncState.InitialSyncComplete)
-								{
-									PhonebookSyncState.InitialPhonebookFoldersReceived();
-									PhonebookSyncState.PhonebookRootEntriesReceived();
-									PhonebookSyncState.SetPhonebookHasFolders(true);
-									PhonebookSyncState.SetNumberOfContacts(Status.Phonebook.Contacts.Count);
-								}
-
-								directoryResults.ResultsFolderId = "root";
-
-								DirectoryRoot = directoryResults;
-
-								CurrentDirectoryResult = directoryResults;
+                                UpdateDirectory();
 
 								break;
 							}
@@ -2250,6 +2235,26 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
                 Debug.Console(2, this, "{0}", e.StackTrace);
                 return sharingState;
             }
+        }
+
+        private void UpdateDirectory()
+        {
+            var directoryResults =
+                                    zStatus.Phonebook.ConvertZoomContactsToGeneric(Status.Phonebook.Contacts);
+
+            if (!PhonebookSyncState.InitialSyncComplete)
+            {
+                PhonebookSyncState.InitialPhonebookFoldersReceived();
+                PhonebookSyncState.PhonebookRootEntriesReceived();
+                PhonebookSyncState.SetPhonebookHasFolders(true);
+                PhonebookSyncState.SetNumberOfContacts(Status.Phonebook.Contacts.Count);
+            }
+
+            directoryResults.ResultsFolderId = "root";
+
+            DirectoryRoot = directoryResults;
+
+            CurrentDirectoryResult = directoryResults;
         }
 
         /// <summary>


### PR DESCRIPTION
When a Zoom Room reboots and Essentials doesn't, the directory request Essentials makes could come back empty due to timing issues with the Zoom Room and the cloud. In order to fix that, Essentials needs to use the `Added Contact` and `Updated Contact` events to populate and update the address book.

In addition, the GenericQueue was printing unnecessary exception messages to the console. 