### PR TITLE
fix: updates to resolve directory issues

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -1004,7 +1004,9 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 		    if (codec.DirectoryRoot != null)
 		    {
-                trilist.SetUshort(joinMap.DirectoryRowCount.JoinNumber, (ushort)codec.DirectoryRoot.CurrentDirectoryResults.Count);
+				var contactsCount = codec.DirectoryRoot.CurrentDirectoryResults.Where(c => c.ParentFolderId.Equals("root")).ToList().Count;				
+                trilist.SetUshort(joinMap.DirectoryRowCount.JoinNumber, (ushort)contactsCount);
+				Debug.Console(2, this, ">>> contactsCount: {0}", contactsCount);
 
                 var clearBytes = XSigHelpers.ClearOutputs();
 
@@ -1020,7 +1022,13 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 			codec.DirectoryResultReturned += (sender, args) =>
 			{
-				trilist.SetUshort(joinMap.DirectoryRowCount.JoinNumber, (ushort)args.Directory.CurrentDirectoryResults.Count);
+				var isRoot = codec.CurrentDirectoryResultIsNotDirectoryRoot.BoolValue == false;
+				var argsCount = isRoot 
+					? args.Directory.CurrentDirectoryResults.Where(a => a.ParentFolderId.Equals("root")).ToList().Count
+					: args.Directory.CurrentDirectoryResults.Count;
+
+				trilist.SetUshort(joinMap.DirectoryRowCount.JoinNumber, (ushort)argsCount);
+				Debug.Console(2, this, ">>> argsCount: {0}", argsCount);
 
 				var clearBytes = XSigHelpers.ClearOutputs();
 
@@ -1184,46 +1192,47 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
             return GetXSigString(tokenArray);
         }
 
-	    private string UpdateDirectoryXSig(CodecDirectory directory, bool isRoot)
-	    {
-	        var xSigMaxIndex = 1023;
-	        var tokenArray = new XSigToken[directory.CurrentDirectoryResults.Count > xSigMaxIndex
-	            ? xSigMaxIndex
-	            : directory.CurrentDirectoryResults.Count];
+		private string UpdateDirectoryXSig(CodecDirectory directory, bool isRoot)
+		{
+			var xSigMaxIndex = 1023;
+			var tokenArray = new XSigToken[directory.CurrentDirectoryResults.Count > xSigMaxIndex
+				? xSigMaxIndex
+				: directory.CurrentDirectoryResults.Count];
 
-	        Debug.Console(2, this, "IsRoot: {0}, Directory Count: {1}, TokenArray.Length: {2}", isRoot,
-	            directory.CurrentDirectoryResults.Count, tokenArray.Length);
+			Debug.Console(2, this, "IsRoot: {0}, Directory Count: {1}, TokenArray.Length: {2}", isRoot, directory.CurrentDirectoryResults.Count, tokenArray.Length);
 
-	        var contacts = directory.CurrentDirectoryResults.Count > xSigMaxIndex
-	            ? directory.CurrentDirectoryResults.Take(xSigMaxIndex)
-	            : directory.CurrentDirectoryResults;
+			var contacts = directory.CurrentDirectoryResults.Count > xSigMaxIndex
+				? directory.CurrentDirectoryResults.Take(xSigMaxIndex)
+				: directory.CurrentDirectoryResults;
 
-	        var counterIndex = 1;
-	        foreach (var entry in contacts)
-	        {
-	            var arrayIndex = counterIndex - 1;
-	            var entryIndex = counterIndex;
+			var contactsToDisplay = isRoot
+				? contacts.Where(c => c.ParentFolderId == "root")
+				: contacts.Where(c => c.ParentFolderId != "root");
 
-	            Debug.Console(2, this, "Entry{2:0000} Name: {0}, Folder ID: {1}", entry.Name, entry.FolderId, entryIndex);
+			var counterIndex = 1;
+			foreach (var entry in contactsToDisplay)
+			{
+				var arrayIndex = counterIndex - 1;
+				var entryIndex = counterIndex;
 
-	            if (entry is DirectoryFolder && entry.ParentFolderId == "root")
-	            {
-	                tokenArray[arrayIndex] = new XSigSerialToken(entryIndex, String.Format("[+] {0}", entry.Name));
+				Debug.Console(2, this, "Entry{2:0000} Name: {0}, Folder ID: {1}, Type: {3}, ParentFolderId: {4}",
+					entry.Name, entry.FolderId, entryIndex, entry.GetType().GetCType().FullName, entry.ParentFolderId);
 
-	                counterIndex++;
-	                counterIndex++;
+				if (entry is DirectoryFolder)
+				{
+					tokenArray[arrayIndex] = new XSigSerialToken(entryIndex, String.Format("[+] {0}", entry.Name));
 
-	                continue;
-	            }
+					counterIndex++;
 
-	            tokenArray[arrayIndex] = new XSigSerialToken(entryIndex, entry.Name);
+					continue;
+				}
 
-	            counterIndex++;
-	        }
+				tokenArray[arrayIndex] = new XSigSerialToken(entryIndex, entry.Name);
 
-	        return GetXSigString(tokenArray);
+				counterIndex++;
+			}
 
-
+			return GetXSigString(tokenArray);
 		}
 
 	    private void LinkVideoCodecCallControlsToApi(BasicTriList trilist, VideoCodecControllerJoinMap joinMap)

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ResponseObjects.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ResponseObjects.cs
@@ -303,11 +303,19 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 					{
 						var contact = new InvitableDirectoryContact { Name = c.ScreenName, ContactId = c.Jid };
 
-                        contact.ContactMethods.Add(new ContactMethod() { Number = c.Jid, Device = eContactMethodDevice.Video, CallType = eContactMethodCallType.Video, ContactMethodId = c.Jid });
+                        contact.ContactMethods.Add(new ContactMethod()
+                        {
+	                        Number = c.Jid, 
+							Device = eContactMethodDevice.Video, 
+							CallType = eContactMethodCallType.Video, 
+							ContactMethodId = c.Jid
+                        });
 
 						if (folders.Count > 0)
 						{
-							contact.ParentFolderId = c.IsZoomRoom ? "rooms" : "contacts";
+							contact.ParentFolderId = c.IsZoomRoom
+								? roomFolder.FolderId // "rooms" 
+								: contactFolder.FolderId; // "contacts"
 						}
 
 						contacts.Add(contact);


### PR DESCRIPTION
updateDirectoryXsig logic to resolve showing contacts in root when folders are in use (ZoomRooms).

LinkVideoCodecDirectoryToApi to resolve analog value driving total number of contacts when folders are in use (ZoomRooms).

ConvertZoomContactsToGeneric to reference roomFolder.FolderId and contactFolder.FolderId in foreach loops.