### PR TITLE
Feature/dmps dm fixes

### DIFF
--- a/PepperDashEssentials/Audio/EssentialsVolumeLevelConfig.cs
+++ b/PepperDashEssentials/Audio/EssentialsVolumeLevelConfig.cs
@@ -55,7 +55,7 @@ namespace PepperDash.Essentials
                 return null;
             }
 
-            // DSP format: deviceKey--levelName, biampTesira-1--master
+            // DSP/DMPS format: deviceKey--levelName, biampTesira-1--master
             match = Regex.Match(DeviceKey, @"([-_\w]+)--(.+)");
             if (match.Success)
             {
@@ -66,6 +66,27 @@ namespace PepperDash.Essentials
                     var levelTag = match.Groups[2].Value;
                     if (dsp.LevelControlPoints.ContainsKey(levelTag)) // should always...
                         return dsp.LevelControlPoints[levelTag];
+                }
+
+                var dmps = DeviceManager.GetDeviceForKey(devKey) as DmpsAudioOutputController;
+                if (dmps != null)
+                {
+                    var levelTag = match.Groups[2].Value;
+                    switch (levelTag)
+                    {
+                        case "master":
+                            return dmps.MasterVolumeLevel;
+                        case "source":
+                            return dmps.SourceVolumeLevel;
+                        case "micsmaster":
+                            return dmps.MicsMasterVolumeLevel;
+                        case "codec1":
+                            return dmps.Codec1VolumeLevel;
+                        case "codec2":
+                            return dmps.Codec2VolumeLevel;
+                        default:
+                            return dmps.MasterVolumeLevel;
+                    }
                 }
                 // No volume for some reason. We have failed as developers
                 return null;

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
@@ -126,6 +126,7 @@ namespace PepperDash.Essentials.DM
             var parentDev = DeviceManager.GetDeviceForKey(pKey);
             DMInput dmInput;
             BasicDmTxControllerBase tx;
+            bool useChassisForOfflineFeedback = false;
 
 		    if (parentDev is DmChassisController)
             {
@@ -155,15 +156,23 @@ namespace PepperDash.Essentials.DM
                         chassis is DmMd128x128 || chassis is DmMd64x64)
                     {
                         tx = GetDmTxForChassisWithoutIpId(key, name, typeName, dmInput);
-                        Debug.Console(0, "DM endpoint output {0} is for Cpu3, changing online feedback to chassis", num);
-                        tx.IsOnline.SetValueFunc(() => switchDev.InputEndpointOnlineFeedbacks[num].BoolValue);
-                        switchDev.InputEndpointOnlineFeedbacks[num].OutputChange += (o, a) => tx.IsOnline.FireUpdate();
-                        return tx;
+                        useChassisForOfflineFeedback = true;
                     }
                     else
                     {
-                        return GetDmTxForChassisWithIpId(key, name, typeName, ipid, dmInput);
+                        tx = GetDmTxForChassisWithIpId(key, name, typeName, ipid, dmInput);
+                        if (typeName == "hdbasettx" || typeName == "dmtx4k100c1g")
+                        {
+                            useChassisForOfflineFeedback = true;
+                        }                        
                     }
+                    if (useChassisForOfflineFeedback)
+                    {
+                        Debug.Console(0, "DM endpoint output {0} does not have direct online feedback, changing online feedback to chassis", num);
+                        tx.IsOnline.SetValueFunc(() => switchDev.InputEndpointOnlineFeedbacks[num].BoolValue);
+                        switchDev.InputEndpointOnlineFeedbacks[num].OutputChange += (o, a) => tx.IsOnline.FireUpdate();
+                    }
+                    return tx;
                 }
                 catch (Exception e)
                 {
@@ -203,15 +212,23 @@ namespace PepperDash.Essentials.DM
                     if(Global.ControlSystemIsDmps4kType)
                     {
                         tx = GetDmTxForChassisWithoutIpId(key, name, typeName, dmInput);
-                        Debug.Console(0, "DM endpoint output {0} is for DMPS3-4K, changing online feedback to chassis", num);
-                        tx.IsOnline.SetValueFunc(() => dmpsDev.InputEndpointOnlineFeedbacks[num].BoolValue);
-                        dmpsDev.InputEndpointOnlineFeedbacks[num].OutputChange += (o, a) => tx.IsOnline.FireUpdate();
-                        return tx;
+                        useChassisForOfflineFeedback = true;
                     }
                     else
                     {
-                        return GetDmTxForChassisWithIpId(key, name, typeName, ipid, dmInput);
+                        tx = GetDmTxForChassisWithIpId(key, name, typeName, ipid, dmInput);
+                        if (typeName == "hdbasettx" || typeName == "dmtx4k100c1g")
+                        {
+                            useChassisForOfflineFeedback = true;
+                        }                        
                     }
+                    if (useChassisForOfflineFeedback)
+                    {
+                        Debug.Console(0, "DM endpoint output {0} does not have direct online feedback, changing online feedback to chassis", num);
+                        tx.IsOnline.SetValueFunc(() => dmpsDev.InputEndpointOnlineFeedbacks[num].BoolValue);
+                        dmpsDev.InputEndpointOnlineFeedbacks[num].OutputChange += (o, a) => tx.IsOnline.FireUpdate();
+                    }
+                    return tx;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This pr fixes a few issues with DMPS chassis

1) Changes were made to ControlSystem.cs to properly prevent initialization until DM endpoints have had time to register. This was tested using a DM-RX-4K-100-C-1G on a DMPS3-300-C. The device now registers properly and is able to work due to these changes.

2) Additions were made to allow DMPS volume controls to be used in an Essentials room. This follows the model set by DSP objects by using "--" followed by a modifier to access fader objects on each DMPS audio output device.

3) This also cleans up some of the methods for detecting if an endpoint does not support offline feedback at the device itself, and instead relies on pulling that data from the parent chassis outputs.