### PR TITLE
Update PD Core to 1.2.1

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-	<package id="PepperDashCore" version="1.2.0" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+	<package id="PepperDashCore" version="1.2.1" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>


### PR DESCRIPTION
SSH issues were found in PD Core 1.2.0 that were causing issues with manual disconnection/reconnection instead of using the autoreconnect timer. The fix for this issue was added in PD Core 1.2.1