### PR TITLE
Add Interfaces for Battery Status Tracking

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PduInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PduInterfaces.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Crestron.SimplSharp;
 using PepperDash.Core;
 using PepperDash.Essentials.Core;
@@ -8,6 +9,7 @@ namespace PepperDash_Essentials_Core.Devices
     /// <summary>
     /// Interface for any device that is able to control it'spower and has a configurable reboot time
     /// </summary>
+    [Obsolete("PepperDash_Essentials_Core.Devices is Deprecated - use PepperDash.Essentials.Core")]
     public interface IHasPowerCycle : IKeyName, IHasPowerControlWithFeedback
     {
         /// <summary>
@@ -24,6 +26,7 @@ namespace PepperDash_Essentials_Core.Devices
     /// <summary>
     /// Interface for any device that contains a collection of IHasPowerReboot Devices
     /// </summary>
+    [Obsolete("PepperDash_Essentials_Core.Devices is Deprecated - use PepperDash.Essentials.Core")]
     public interface IHasControlledPowerOutlets : IKeyName
     {
         /// <summary>

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
@@ -1,0 +1,87 @@
+﻿using Crestron.SimplSharp;
+using PepperDash.Core;
+
+namespace PepperDash.Essentials.Core
+{
+    /// <summary>
+    /// Interface for any device that has a battery that can be monitored
+    /// </summary>
+    public interface IHasBatteryStats : IKeyName
+    {
+        int BatteryPercentage { get; }
+        int BatteryCautionThresholdPercentage { get;  }
+        int BatteryWarningThresholdPercentage { get; }
+        BoolFeedback BatteryIsWarningFeedback { get; }
+        BoolFeedback BatteryIsCautionFeedback { get; }
+        BoolFeedback BatteryIsOkFeedback { get; }
+        IntFeedback BatteryPercentageFeedback { get; }
+    }
+
+    /// <summary>
+    /// Interface for any device that has a battery that can be monitored and the ability to charge and discharge
+    /// </summary>
+    public interface IHasBatteryCharging : IHasBatteryStats
+    {
+        BoolFeedback BatteryIsCharging { get; }
+    }
+
+    /// <summary>
+    /// Interface for any device that has multiple batteries that can be monitored
+    /// </summary>
+    public interface IHasBatteries : IKeyName
+    {
+        ReadOnlyDictionary<string, IHasBatteryStats> Batteries { get; }   
+    }
+
+    public interface IHasBatteryStatsExtended : IHasBatteryStats
+    {
+        int InputVoltage { get; }
+        int OutputVoltage { get; }
+        int InptuCurrent { get; }
+        int OutputCurrent { get; }
+
+        IntFeedback InputVoltageFeedback { get; }
+        IntFeedback OutputVoltageFeedback { get; }
+        IntFeedback InputCurrentFeedback { get; }
+        IntFeedback OutputCurrentFeedback { get; }
+    }
+
+    /// <summary>
+    /// Interface for any device that is able to control its power, has a configurable reboot time, and has batteries that can be monitored
+    /// </summary>
+    public interface IHasPowerCycleWithBatteries : IHasPowerCycle
+    {
+        
+    }
+
+    /// <summary>
+    /// Interface for any device that is able to control it's power and has a configurable reboot time
+    /// </summary>
+    public interface IHasPowerCycle : IKeyName, IHasPowerControlWithFeedback
+    {
+        /// <summary>
+        /// Delay between power off and power on for reboot
+        /// </summary>
+        int PowerCycleTimeMs { get; }
+
+        /// <summary>
+        /// Reboot outlet
+        /// </summary>
+        void PowerCycle();
+    }
+
+    /// <summary>
+    /// Interface for any device that contains a collection of IHasPowerReboot Devices
+    /// </summary>
+    public interface IHasControlledPowerOutlets : IKeyName
+    {
+        /// <summary>
+        /// Collection of IPduOutlets
+        /// </summary>
+        ReadOnlyDictionary<int, IHasPowerCycle> PduOutlets { get; }
+
+    }
+
+
+
+}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
@@ -49,7 +49,7 @@ namespace PepperDash.Essentials.Core
     /// <summary>
     /// Interface for any device that is able to control its power, has a configurable reboot time, and has batteries that can be monitored
     /// </summary>
-    public interface IHasPowerCycleWithBatteries : IHasPowerCycle
+    public interface IHasPowerCycleWithBatteries : IHasPowerCycle, IHasBatteryStats
     {
         
     }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/PowerInterfaces.cs
@@ -49,7 +49,7 @@ namespace PepperDash.Essentials.Core
     /// <summary>
     /// Interface for any device that is able to control its power, has a configurable reboot time, and has batteries that can be monitored
     /// </summary>
-    public interface IHasPowerCycleWithBatteries : IHasPowerCycle, IHasBatteryStats
+    public interface IHasPowerCycleWithBattery : IHasPowerCycle, IHasBatteryStats
     {
         
     }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Crestron IO\Relay\GenericRelayDevice.cs" />
     <Compile Include="Crestron IO\Relay\ISwitchedOutput.cs" />
     <Compile Include="Crestron IO\StatusSign\StatusSignController.cs" />
+    <Compile Include="Devices\PowerInterfaces.cs" />
     <Compile Include="Web\RequestHandlers\AppDebugRequestHandler.cs" />
     <Compile Include="Web\RequestHandlers\GetFeedbacksForDeviceRequestHandler.cs" />
     <Compile Include="Web\EssentialsWebApiHelpers.cs" />


### PR DESCRIPTION
Additional Refactoring was done for PDU interfaces to move them into the correct namespace.  Original interfaces are intact but are marked with Obsolete attribute.