### PR TITLE
Enable DM TX/RX builds for blade chassis

### DIFF
--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmBladeChassisController.cs
@@ -22,7 +22,7 @@ namespace PepperDash.Essentials.DM
     /// Builds a controller for basic DM-RMCs with Com and IR ports and no control functions
     /// 
     /// </summary>
-    public class DmBladeChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitch, IRoutingNumericWithFeedback
+	public class DmBladeChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitchWithEndpointOnlineFeedback, IRoutingNumericWithFeedback
     {
         private const string NonePortKey = "inputCard0--None";
 

--- a/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Chassis/DmChassisController.cs
@@ -23,7 +23,7 @@ namespace PepperDash.Essentials.DM
     /// 
     /// </summary>
     [Description("Wrapper class for all DM-MD chassis variants from 8x8 to 32x32")]
-    public class DmChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitch, IRoutingNumericWithFeedback
+    public class DmChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitchWithEndpointOnlineFeedback, IRoutingNumericWithFeedback
     {
         private const string NonePortKey = "inputCard0--None";
         public DMChassisPropertiesConfig PropertiesConfig { get; set; }

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Receivers/DmRmcHelper.cs
@@ -436,9 +436,9 @@ namespace PepperDash.Essentials.DM
                 }
                 return rx;
             }
-            else if (parentDev is DmChassisController)
+            else if (parentDev is IDmSwitchWithEndpointOnlineFeedback)
             {
-                var controller = parentDev as DmChassisController;
+                var controller = parentDev as IDmSwitchWithEndpointOnlineFeedback;
                 var chassis = controller.Chassis;
                 var num = props.ParentOutputNumber;
                 Debug.Console(1, "Creating DM Chassis device '{0}'. Output number '{1}'.", key, num);

--- a/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/Endpoints/Transmitters/DmTxHelpers.cs
@@ -127,10 +127,10 @@ namespace PepperDash.Essentials.DM
             BasicDmTxControllerBase tx;
             bool useChassisForOfflineFeedback = false;
 
-            if (parentDev is DmChassisController)
+            if (parentDev is IDmSwitchWithEndpointOnlineFeedback)
             {
                 // Get the Crestron chassis and link stuff up
-                var switchDev = (parentDev as DmChassisController);
+                var switchDev = (parentDev as IDmSwitchWithEndpointOnlineFeedback);
                 var chassis = switchDev.Chassis;
 
                 //Check that the input is within range of this chassis' possible inputs
@@ -179,6 +179,7 @@ namespace PepperDash.Essentials.DM
                     return null;
                 }
             }
+
             if (parentDev is DmpsRoutingController)
             {
                 // Get the DMPS chassis and link stuff up

--- a/essentials-framework/Essentials DM/Essentials_DM/IDmSwitch.cs
+++ b/essentials-framework/Essentials DM/Essentials_DM/IDmSwitch.cs
@@ -16,10 +16,17 @@ using PepperDash.Essentials.Core;
 using PepperDash.Essentials.DM.Config;
 
 namespace PepperDash.Essentials.DM {
-    public interface IDmSwitch {
+    public interface IDmSwitch
+	{
         Switch Chassis { get; }
 
         Dictionary<uint, string> TxDictionary { get; }
         Dictionary<uint, string> RxDictionary { get; }
     }
+
+	public interface IDmSwitchWithEndpointOnlineFeedback : IDmSwitch
+	{
+		Dictionary<uint, BoolFeedback> InputEndpointOnlineFeedbacks { get; }
+		Dictionary<uint, BoolFeedback> OutputEndpointOnlineFeedbacks { get; }
+	}
 }


### PR DESCRIPTION
The DM Rmc/Tx helper classes don't allow for a endpoint parent device to be a DmBladeChassisController, so devices aren't getting built correctly.