### PR TITLE
DevEasy Command to make DevJson easier to use quickly

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/DeviceManager.cs
@@ -39,8 +39,13 @@ namespace PepperDash.Essentials.Core
 				ConsoleAccessLevelEnum.AccessOperator);
 			CrestronConsole.AddNewConsoleCommand(ListDevices, "devlist", "Lists current managed devices", 
 				ConsoleAccessLevelEnum.AccessOperator);
+		    CrestronConsole.AddNewConsoleCommand(DeviceJsonApi.BuildJsonForDeviceAction, "deveasy",
+		        "Easier way to build devjson commands",
+		        ConsoleAccessLevelEnum.AccessOperator);
+
 			CrestronConsole.AddNewConsoleCommand(DeviceJsonApi.DoDeviceActionWithJson, "devjson", "", 
 				ConsoleAccessLevelEnum.AccessOperator);
+
 			CrestronConsole.AddNewConsoleCommand(s => CrestronConsole.ConsoleCommandResponse(DeviceJsonApi.GetProperties(s)), "devprops", "", ConsoleAccessLevelEnum.AccessOperator);
 			CrestronConsole.AddNewConsoleCommand(s => CrestronConsole.ConsoleCommandResponse(DeviceJsonApi.GetMethods(s)), "devmethods", "", ConsoleAccessLevelEnum.AccessOperator);
 			CrestronConsole.AddNewConsoleCommand(s => CrestronConsole.ConsoleCommandResponse(DeviceJsonApi.GetApiMethods(s)), "apimethods", "", ConsoleAccessLevelEnum.AccessOperator);


### PR DESCRIPTION
Nothing really changed majorly, just a new console command that digests the data to build a DeviceActionWrapper and execute it. 

Should handle even edge cases where keys have a space in them using parenthesis to surround keys with spaces - methods shouldn't have spaces, and the params kind of handle that already by requiring you to wrap string parameters.