### PR TITLE
Hotfix/vtc room activation deactivation changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,3 +389,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 essentials-framework/Essentials Interfaces/PepperDash_Essentials_Interfaces/PepperDash_Essentials_Interfaces.csproj
+.DS_Store

--- a/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
@@ -375,7 +375,7 @@ namespace PepperDash.Essentials
                 SetSourceListKey(Key);
             }
 
-            SetCodecExternalSources();
+            SetUpVideoCodec();
         }
 
         protected override void CustomSetConfig(DeviceConfig config)
@@ -923,6 +923,8 @@ namespace PepperDash.Essentials
                         videoCodecWithExternalSwitching.SetExternalSourceState(kvp.Key, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceMode.Ready);
                     }
                 }
+
+                Debug.Console(1, this, "Successfully set up codec external sources for room: {0}", Name);
             }
             catch (Exception e)
             {

--- a/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
@@ -226,7 +226,177 @@ namespace PepperDash.Essentials
             }
         }
 
-        void Initialize()
+        public override void Initialize()
+        {
+            try
+            {
+                //if (DefaultAudioDevice is IBasicVolumeControls)
+                //    DefaultVolumeControls = DefaultAudioDevice as IBasicVolumeControls;
+                //else if (DefaultAudioDevice is IHasVolumeDevice)
+                //    DefaultVolumeControls = (DefaultAudioDevice as IHasVolumeDevice).VolumeDevice;
+                //CurrentVolumeControls = DefaultVolumeControls;
+
+
+                //// Combines call feedback from both codecs if available
+                //InCallFeedback = new BoolFeedback(() =>
+                //{
+                //    bool inAudioCall = false;
+                //    bool inVideoCall = false;
+
+                //    if (AudioCodec != null)
+                //        inAudioCall = AudioCodec.IsInCall;
+
+                //    if (VideoCodec != null)
+                //        inVideoCall = VideoCodec.IsInCall;
+
+                //    if (inAudioCall || inVideoCall)
+                //        return true;
+                //    else
+                //        return false;
+                //});
+
+                //SetupDisplays();
+
+                //// Get Microphone Privacy object, if any  MUST HAPPEN AFTER setting InCallFeedback
+                //this.MicrophonePrivacy = EssentialsRoomConfigHelper.GetMicrophonePrivacy(PropertiesConfig, this);
+
+                //Debug.Console(2, this, "Microphone Privacy Config evaluated.");
+
+                //// Get emergency object, if any
+                //this.Emergency = EssentialsRoomConfigHelper.GetEmergency(PropertiesConfig, this);
+
+                //Debug.Console(2, this, "Emergency Config evaluated.");
+
+
+                //VideoCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();
+                //VideoCodec.IsReadyChange += (o, a) => { this.SetCodecExternalSources(); SetCodecBranding(); };
+
+                //if (AudioCodec != null)
+                //    AudioCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();
+
+                //IsSharingFeedback = new BoolFeedback(() => VideoCodec.SharingContentIsOnFeedback.BoolValue);
+                //VideoCodec.SharingContentIsOnFeedback.OutputChange += (o, a) => this.IsSharingFeedback.FireUpdate();
+
+                //// link privacy to VC (for now?)
+                //PrivacyModeIsOnFeedback = new BoolFeedback(() => VideoCodec.PrivacyModeIsOnFeedback.BoolValue);
+                //VideoCodec.PrivacyModeIsOnFeedback.OutputChange += (o, a) => this.PrivacyModeIsOnFeedback.FireUpdate();
+
+                //CallTypeFeedback = new IntFeedback(() => 0);
+
+                SetSourceListKey();
+
+                //EnablePowerOnToLastSource = true;
+            }
+            catch (Exception e)
+            {
+                Debug.Console(0, this, "Error Initializing Room: {0}", e);
+            }
+        }
+
+        private void SetupDisplays()
+        {
+            //DefaultDisplay = DeviceManager.GetDeviceForKey(PropertiesConfig.DefaultDisplayKey) as IRoutingSinkWithSwitching;
+
+            var destinationList = ConfigReader.ConfigObject.DestinationLists[PropertiesConfig.DestinationListKey];
+
+            Displays.Clear();
+
+            foreach (var destination in destinationList)
+            {
+                var dest = destination.Value.SinkDevice as IRoutingSinkWithSwitching;
+
+                if (dest != null)
+                {
+                    Displays.Add(dest);
+                }
+
+                var display = dest as DisplayBase;
+                if (display != null)
+                {
+                    // Link power, warming, cooling to display
+                    var dispTwoWay = display as IHasPowerControlWithFeedback;
+                    if (dispTwoWay != null)
+                    {
+                        dispTwoWay.PowerIsOnFeedback.OutputChange -= PowerIsOnFeedback_OutputChange;
+                        dispTwoWay.PowerIsOnFeedback.OutputChange += PowerIsOnFeedback_OutputChange;
+
+                        if (dispTwoWay.PowerIsOnFeedback.BoolValue)
+                        {
+                            SetDefaultLevels();
+                        }
+                    }
+
+                    display.IsWarmingUpFeedback.OutputChange -= IsWarmingUpFeedback_OutputChange;
+                    display.IsWarmingUpFeedback.OutputChange += IsWarmingUpFeedback_OutputChange;
+
+                    display.IsCoolingDownFeedback.OutputChange -= IsCoolingDownFeedback_OutputChange;
+                    display.IsCoolingDownFeedback.OutputChange += IsCoolingDownFeedback_OutputChange;
+
+                }
+            }
+        }
+
+        void IsCoolingDownFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            IsCoolingDownFeedback.FireUpdate();
+        }
+
+        void IsWarmingUpFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            IsWarmingUpFeedback.FireUpdate();
+            if (!IsWarmingUpFeedback.BoolValue)
+                (CurrentVolumeControls as IBasicVolumeWithFeedback).SetVolume(DefaultVolume);
+        }
+
+        void PowerIsOnFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            var dispTwoWay = sender as IHasPowerControlWithFeedback;
+            
+            if (dispTwoWay != null && dispTwoWay.PowerIsOnFeedback.BoolValue != OnFeedback.BoolValue)
+            {
+                //if (!dispTwoWay.PowerIsOnFeedback.BoolValue)
+                //    CurrentSourceInfo = null;
+                OnFeedback.FireUpdate();
+            }
+        }
+
+
+
+
+
+        private void SetSourceListKey()
+        {
+            if (!string.IsNullOrEmpty(PropertiesConfig.SourceListKey))
+            {
+                SetSourceListKey(PropertiesConfig.SourceListKey);
+            }
+            else
+            {
+                SetSourceListKey(Key);
+            }
+
+            SetCodecExternalSources();
+        }
+
+        protected override void CustomSetConfig(DeviceConfig config)
+        {
+            var newPropertiesConfig = JsonConvert.DeserializeObject<EssentialsHuddleVtc1PropertiesConfig>(config.Properties.ToString());
+
+            if (newPropertiesConfig != null)
+                PropertiesConfig = newPropertiesConfig;
+
+            ConfigWriter.UpdateRoomConfig(config);
+        }
+
+        public override bool Deactivate()
+        {
+            // Stop listining to this event when room deactivated
+            VideoCodec.IsReadyChange -= VideoCodec_IsReadyChange;
+
+            return base.Deactivate();
+        }
+
+        public override bool CustomActivate()
         {
             try
             {
@@ -267,126 +437,92 @@ namespace PepperDash.Essentials
 
                 Debug.Console(2, this, "Emergency Config evaluated.");
 
-
-                VideoCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();
-                VideoCodec.IsReadyChange += (o, a) => { this.SetCodecExternalSources(); SetCodecBranding(); };
-
                 if (AudioCodec != null)
-                    AudioCodec.CallStatusChange += (o, a) => this.InCallFeedback.FireUpdate();
+                {
+                    AudioCodec.CallStatusChange -= AudioCodec_CallStatusChange;
+                    AudioCodec.CallStatusChange += AudioCodec_CallStatusChange;
+                }
+
+                VideoCodec.CallStatusChange -= VideoCodec_CallStatusChange;
+                VideoCodec.CallStatusChange += VideoCodec_CallStatusChange;
+
+                VideoCodec.IsReadyChange -= VideoCodec_IsReadyChange;
+                VideoCodec.IsReadyChange += VideoCodec_IsReadyChange;
+
+                VideoCodec.SharingContentIsOnFeedback.OutputChange -= SharingContentIsOnFeedback_OutputChange;
+                VideoCodec.SharingContentIsOnFeedback.OutputChange += SharingContentIsOnFeedback_OutputChange;
+
 
                 IsSharingFeedback = new BoolFeedback(() => VideoCodec.SharingContentIsOnFeedback.BoolValue);
-                VideoCodec.SharingContentIsOnFeedback.OutputChange += (o, a) => this.IsSharingFeedback.FireUpdate();
 
                 // link privacy to VC (for now?)
                 PrivacyModeIsOnFeedback = new BoolFeedback(() => VideoCodec.PrivacyModeIsOnFeedback.BoolValue);
-                VideoCodec.PrivacyModeIsOnFeedback.OutputChange += (o, a) => this.PrivacyModeIsOnFeedback.FireUpdate();
+
+                VideoCodec.PrivacyModeIsOnFeedback.OutputChange -= PrivacyModeIsOnFeedback_OutputChange;
+                VideoCodec.PrivacyModeIsOnFeedback.OutputChange += PrivacyModeIsOnFeedback_OutputChange;
 
                 CallTypeFeedback = new IntFeedback(() => 0);
 
                 SetSourceListKey();
 
                 EnablePowerOnToLastSource = true;
+
+
+                // Add Occupancy object from config
+                if (PropertiesConfig.Occupancy != null)
+                {
+                    Debug.Console(0, this, Debug.ErrorLogLevel.Notice, "Setting Occupancy Provider for room");
+                    this.SetRoomOccupancy(DeviceManager.GetDeviceForKey(PropertiesConfig.Occupancy.DeviceKey) as
+                        IOccupancyStatusProvider, PropertiesConfig.Occupancy.TimeoutMinutes);
+                }
+
+                this.LogoUrlLightBkgnd = PropertiesConfig.LogoLight.GetLogoUrlLight();
+                this.LogoUrlDarkBkgnd = PropertiesConfig.LogoDark.GetLogoUrlDark();
+
+                this.DefaultSourceItem = PropertiesConfig.DefaultSourceItem;
+                this.DefaultVolume = (ushort)(PropertiesConfig.Volumes.Master.Level * 65535 / 100);
+
             }
             catch (Exception e)
             {
-                Debug.Console(0, this, "Error Initializing Room: {0}", e);
+                Debug.Console(0, this, "Error Activiating Room: {0}", e);
             }
-        }
-
-        private void SetupDisplays()
-        {
-            //DefaultDisplay = DeviceManager.GetDeviceForKey(PropertiesConfig.DefaultDisplayKey) as IRoutingSinkWithSwitching;
-
-            var destinationList = ConfigReader.ConfigObject.DestinationLists[PropertiesConfig.DestinationListKey];
-
-            foreach (var destination in destinationList)
-            {
-                var dest = destination.Value.SinkDevice as IRoutingSinkWithSwitching;
-
-                if (dest != null)
-                {
-                    Displays.Add(dest);
-                }
-
-                var display = dest as DisplayBase;
-                if (display != null)
-                {
-                    // Link power, warming, cooling to display
-                    var dispTwoWay = display as IHasPowerControlWithFeedback;
-                    if (dispTwoWay != null)
-                    {
-                        dispTwoWay.PowerIsOnFeedback.OutputChange += (o, a) =>
-                        {
-                            if (dispTwoWay.PowerIsOnFeedback.BoolValue != OnFeedback.BoolValue)
-                            {
-                                //if (!dispTwoWay.PowerIsOnFeedback.BoolValue)
-                                //    CurrentSourceInfo = null;
-                                OnFeedback.FireUpdate();
-                            }
-                            if (dispTwoWay.PowerIsOnFeedback.BoolValue)
-                            {
-                                SetDefaultLevels();
-                            }
-                        };
-                    }
-
-                    display.IsWarmingUpFeedback.OutputChange += (o, a) =>
-                    {
-                        IsWarmingUpFeedback.FireUpdate();
-                        if (!IsWarmingUpFeedback.BoolValue)
-                            (CurrentVolumeControls as IBasicVolumeWithFeedback).SetVolume(DefaultVolume);
-                    };
-                    display.IsCoolingDownFeedback.OutputChange += (o, a) =>
-                    {
-                        IsCoolingDownFeedback.FireUpdate();
-                    };
-
-                }
-            }
-        }
-
-        private void SetSourceListKey()
-        {
-            if (!string.IsNullOrEmpty(PropertiesConfig.SourceListKey))
-            {
-                SetSourceListKey(PropertiesConfig.SourceListKey);
-            }
-            else
-            {
-                SetSourceListKey(Key);
-            }
-
-            SetCodecExternalSources();
-        }
-
-        protected override void CustomSetConfig(DeviceConfig config)
-        {
-            var newPropertiesConfig = JsonConvert.DeserializeObject<EssentialsHuddleVtc1PropertiesConfig>(config.Properties.ToString());
-
-            if (newPropertiesConfig != null)
-                PropertiesConfig = newPropertiesConfig;
-
-            ConfigWriter.UpdateRoomConfig(config);
-        }
-
-        public override bool CustomActivate()
-        {
-            // Add Occupancy object from config
-            if (PropertiesConfig.Occupancy != null)
-            {
-                Debug.Console(0, this, Debug.ErrorLogLevel.Notice, "Setting Occupancy Provider for room");
-                this.SetRoomOccupancy(DeviceManager.GetDeviceForKey(PropertiesConfig.Occupancy.DeviceKey) as
-                    IOccupancyStatusProvider, PropertiesConfig.Occupancy.TimeoutMinutes);
-            }
-
-            this.LogoUrlLightBkgnd = PropertiesConfig.LogoLight.GetLogoUrlLight();
-            this.LogoUrlDarkBkgnd = PropertiesConfig.LogoDark.GetLogoUrlDark();
-
-            this.DefaultSourceItem = PropertiesConfig.DefaultSourceItem;
-            this.DefaultVolume = (ushort)(PropertiesConfig.Volumes.Master.Level * 65535 / 100);
 
             return base.CustomActivate();
         }
+
+        void AudioCodec_CallStatusChange(object sender, CodecCallStatusItemChangeEventArgs e)
+        {
+            InCallFeedback.FireUpdate();
+        }
+
+        void PrivacyModeIsOnFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            PrivacyModeIsOnFeedback.FireUpdate();
+        }
+
+        void VideoCodec_IsReadyChange(object sender, EventArgs e)
+        {
+            SetUpVideoCodec();
+        }
+
+        void SetUpVideoCodec()
+        {
+            SetCodecExternalSources();
+            SetCodecBranding();
+        }
+
+        void VideoCodec_CallStatusChange(object sender, CodecCallStatusItemChangeEventArgs e)
+        {
+            InCallFeedback.FireUpdate();
+        }
+
+        void SharingContentIsOnFeedback_OutputChange(object sender, FeedbackEventArgs e)
+        {
+            IsSharingFeedback.FireUpdate();
+        }
+
+
 
         /// <summary>
         /// 

--- a/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsCombinedHuddleVtc1Room.cs
@@ -393,6 +393,11 @@ namespace PepperDash.Essentials
             // Stop listining to this event when room deactivated
             VideoCodec.IsReadyChange -= VideoCodec_IsReadyChange;
 
+            // Clear occupancy 
+            RoomOccupancy = null;
+
+            Debug.Console(0, this, "Room '{0}' Deactivated", Name);
+
             return base.Deactivate();
         }
 
@@ -488,6 +493,8 @@ namespace PepperDash.Essentials
                 Debug.Console(0, this, "Error Activiating Room: {0}", e);
             }
 
+
+            Debug.Console(0, this, "Room '{0}' Activated", Name);
             return base.CustomActivate();
         }
 

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -274,7 +274,7 @@ namespace PepperDash.Essentials
                 SetSourceListKey(Key);
             }
 
-			SetCodecExternalSources();
+            SetUpVideoCodec();
         }
 
         protected override void CustomSetConfig(DeviceConfig config)
@@ -904,6 +904,8 @@ namespace PepperDash.Essentials
                         videoCodecWithExternalSwitching.SetExternalSourceState(kvp.Key, PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceMode.Ready);
                     }
                 }
+                Debug.Console(1, this, "Successfully set up codec external sources for room: {0}", Name);
+
             }
             catch (Exception e)
             {

--- a/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/EssentialsHuddleVtc1Room.cs
@@ -293,6 +293,11 @@ namespace PepperDash.Essentials
             // Stop listining to this event when room deactivated
             VideoCodec.IsReadyChange -= VideoCodec_IsReadyChange;
 
+            // Clear occupancy 
+            RoomOccupancy = null;
+
+            Debug.Console(0, this, "Room '{0}' Deactivated", Name);
+
             return base.Deactivate();
         }
 
@@ -406,7 +411,8 @@ namespace PepperDash.Essentials
             {
                 Debug.Console(0, this, "Error Activiating Room: {0}", e);
             }
-			
+
+            Debug.Console(0, this, "Room '{0}' Activated", Name);
             return base.CustomActivate();
         }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PartitionSensor/GlsPartitionSensorController.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PartitionSensor/GlsPartitionSensorController.cs
@@ -85,18 +85,32 @@ namespace PepperDash.Essentials.Core
 	    {
 	        if (_partitionSensor.IsOnline == false) return;
 
-	        Debug.Console(1, this, "Attempting to apply settings to sensor from config");            
+            // Default to enable
+            _partitionSensor.Enable.BoolValue = true;
 
-	        if (PropertiesConfig.Sensitivity != null)
-	        {
-	            Debug.Console(1, this, "Sensitivity found, attempting to set value '{0}' from config",
-	                PropertiesConfig.Sensitivity);
-                _partitionSensor.Sensitivity.UShortValue = (ushort) PropertiesConfig.Sensitivity;
-	        }	        
-	        else
-	        {
-	            Debug.Console(1, this, "Sensitivity null, no value specified in config");
-	        }
+	        Debug.Console(1, this, "Attempting to apply settings to sensor from config");
+
+            if (PropertiesConfig.Sensitivity != null)
+            {
+                Debug.Console(1, this, "Sensitivity found, attempting to set value '{0}' from config",
+                    PropertiesConfig.Sensitivity);
+                _partitionSensor.Sensitivity.UShortValue = (ushort)PropertiesConfig.Sensitivity;
+            }
+            else
+            {
+                Debug.Console(1, this, "Sensitivity null, no value specified in config");
+            }
+
+            if (PropertiesConfig.Enable != null)
+            {
+                Debug.Console(1, this, "Enable found, attempting to set value '{0}' from config",
+                    PropertiesConfig.Enable);
+                _partitionSensor.Enable.BoolValue = (bool)PropertiesConfig.Enable;
+            }
+            else
+            {
+                Debug.Console(1, this, "Enable null, no value specified in config");
+            }
 
 	    }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/PartitionSensor/GlsPartitionSensorPropertiesConfig.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/PartitionSensor/GlsPartitionSensorPropertiesConfig.cs
@@ -17,5 +17,8 @@ namespace PepperDash_Essentials_Core.PartitionSensor
         /// </remarks>
         [JsonProperty("sensitivity")]
         public ushort? Sensitivity { get; set; }
+
+        [JsonProperty("enable")]
+        public bool? Enable { get; set; }
     }
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/EssentialsRoomBase.cs
@@ -35,7 +35,7 @@ namespace PepperDash.Essentials.Core
         public BoolFeedback IsWarmingUpFeedback { get; private set; }
         public BoolFeedback IsCoolingDownFeedback { get; private set; }
 
-        public IOccupancyStatusProvider RoomOccupancy { get; private set; }
+        public IOccupancyStatusProvider RoomOccupancy { get; protected set; }
 
         public bool OccupancyStatusProviderIsRemote { get; private set; }
 


### PR DESCRIPTION
- Updates Vtc1 and Vtc1 Combined room types to use Deactivate/Activate methods to manage subscriptions to video codec external source change events and also occupancy sensor changes when the room is not active.  
- Updates GlsPartitionSensorController to enable the sensor by default with optional config property to disable/enable

closes #1119 