### PR TITLE
Custom Join Map Improvements

### DIFF
--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/PduJoinMapBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Bridges/JoinMaps/PduJoinMapBase.cs
@@ -10,7 +10,7 @@ namespace PepperDash.Essentials.Core.Bridges
 
         [JoinName("Online")]
         public JoinDataComplete Online = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },
-            new JoinMetadata { Description = "PDU Name", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });
+            new JoinMetadata { Description = "Online", JoinCapabilities = eJoinCapabilities.ToSIMPL, JoinType = eJoinType.Digital });
 
         [JoinName("OutletCount")]
         public JoinDataComplete OutletCount = new JoinDataComplete(new JoinData { JoinNumber = 1, JoinSpan = 1 },

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/JoinMaps/JoinMapBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/JoinMaps/JoinMapBase.cs
@@ -356,15 +356,17 @@ namespace PepperDash.Essentials.Core
         {
             foreach (var customJoinData in joinData)
             {
-                var join = Joins[customJoinData.Key];
+                JoinDataComplete join;
+
+                if (!Joins.TryGetValue(customJoinData.Key, out join))
+                {
+                    Debug.Console(2, "No matching key found in join map for: '{0}'", customJoinData.Key);
+                    continue;
+                }
 
                 if (join != null)
                 {
                     join.SetCustomJoinData(customJoinData.Value);
-                }
-                else
-                {
-                    Debug.Console(2, "No matching key found in join map for: '{0}'", customJoinData.Key);
                 }
             }
 


### PR DESCRIPTION
Using a join map configuration in the configuration file could cause an exception if a join in the configuration file doesn't match the name in the join map dictionary, causing the post-activation method for the bridge to fail, and possibly leaving devices unlinked. This change solves that problem by using the `TryGetValue` method instead of trying to blindly retrieve the join from the Joins dictionary.

In addition, the PDU Join map had an improperly named join.