### PR TITLE
fix: add `Dialable` property to Meeting class

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/Codec/iHasScheduleAwareness.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/Codec/iHasScheduleAwareness.cs
@@ -216,6 +216,10 @@ namespace PepperDash.Essentials.Devices.Common.Codec
                 return joinable;
             }
         }
+
+		[JsonProperty("dialable")]
+		public bool Dialable { get; set; }
+
         //public string ConferenceNumberToDial { get; set; }
         [JsonProperty("conferencePassword")]
         public string ConferencePassword { get; set; }

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/BookingsDataClasses.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/BookingsDataClasses.cs
@@ -348,6 +348,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
                     if (b.DialInfo.ConnectMode.Value.ToLower() == "obtp" || b.DialInfo.ConnectMode.Value.ToLower() == "manual")
                         meeting.IsOneButtonToPushMeeting = true;
 
+				meeting.Dialable = b.DialInfo.Calls.Call.Count > 0;
+
                 if (b.DialInfo.Calls.Call != null)
                 {
                     foreach (Call c in b.DialInfo.Calls.Call)

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/VideoCodecBase.cs
@@ -940,7 +940,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 
 		        //digitals
 		        tokenArray[digitalIndex] = new XSigDigitalToken(digitalIndex + 1, meeting.Joinable);
-		        tokenArray[digitalIndex + 1] = new XSigDigitalToken(digitalIndex + 2, meeting.Id != "0");
+		        tokenArray[digitalIndex + 1] = new XSigDigitalToken(digitalIndex + 2, meeting.Dialable);
 
 		        //serials
 		        tokenArray[stringIndex] = new XSigSerialToken(stringIndex + 1, meeting.Organizer);

--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ResponseObjects.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/ZoomRoom/ResponseObjects.cs
@@ -1510,6 +1510,8 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.ZoomRoom
 
 				meeting.Privacy = b.IsPrivate ? eMeetingPrivacy.Private : eMeetingPrivacy.Public;
 
+				meeting.Dialable = meeting.Id != "0";
+
 				// No meeting.Calls data exists for Zoom Rooms.  Leaving out for now.
 				var now = DateTime.Now;
 				if (meeting.StartTime < now && meeting.EndTime < now)


### PR DESCRIPTION
Previously, the meeting class was determining Dialable based on a meeting ID being "0". This is a Zoom-specific thing, but it has recently become a thing for Cisco codecs to have meetings that aren't necessarily dialable. Adding this property to the `Meeting` class allows the specific codec type to set it correctly based on that codec's needs.