### PR TITLE
Break IEssentialsRoom down further

### DIFF
--- a/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleSpaceRoom.cs
+++ b/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleSpaceRoom.cs
@@ -7,7 +7,8 @@ using PepperDash.Essentials.Room.Config;
 
 namespace PepperDash.Essentials
 {
-    public interface IEssentialsHuddleSpaceRoom : IEssentialsRoom, IHasCurrentSourceInfoChange, IRunRouteAction, IRunDefaultPresentRoute, IHasDefaultDisplay, IHasCurrentVolumeControls
+    public interface IEssentialsHuddleSpaceRoom : IEssentialsRoom, IHasCurrentSourceInfoChange, IRunRouteAction, IRunDefaultPresentRoute, IHasDefaultDisplay, IHasCurrentVolumeControls, IRoomOccupancy,
+        IEmergency, IMicrophonePrivacy
     {
         bool ExcludeFromGlobalFunctions { get; }
 

--- a/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleVtc1Room.cs
+++ b/PepperDashEssentials/Room/Types/Interfaces/IEssentialsHuddleVtc1Room.cs
@@ -8,7 +8,8 @@ using PepperDash.Essentials.Devices.Common.AudioCodec;
 namespace PepperDash.Essentials
 {
     public interface IEssentialsHuddleVtc1Room : IEssentialsRoom, IHasCurrentSourceInfoChange,
-         IPrivacy, IHasCurrentVolumeControls, IRunRouteAction, IRunDefaultCallRoute, IHasVideoCodec, IHasAudioCodec, IHasDefaultDisplay, IHasInCallFeedback
+         IPrivacy, IHasCurrentVolumeControls, IRunRouteAction, IRunDefaultCallRoute, IHasVideoCodec, IHasAudioCodec, IHasDefaultDisplay, IHasInCallFeedback,
+        IRoomOccupancy, IEmergency, IMicrophonePrivacy
     {
         EssentialsHuddleVtc1PropertiesConfig PropertiesConfig { get; }
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IVolumeAndAudioInterfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Devices/IVolumeAndAudioInterfaces.cs
@@ -72,6 +72,10 @@ namespace PepperDash.Essentials.Core
     {
         IBasicVolumeControls CurrentVolumeControls { get; }
 		event EventHandler<VolumeDeviceChangeEventArgs> CurrentVolumeDeviceChange;
+
+        void SetDefaultLevels();
+
+        bool ZeroVolumeWhenSwtichingVolumeDevices { get; }
 	}
 
 

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Fusion/EssentialsHuddleSpaceFusionSystemControllerBase.cs
@@ -148,15 +148,20 @@ namespace PepperDash.Essentials.Core.Fusion
                     ReadGuidFile(guidFilePath);
                 }
 
-                if (Room.RoomOccupancy != null)
+                var occupancyRoom = Room as IRoomOccupancy;
+
+                if (occupancyRoom != null)
                 {
-                    if (Room.OccupancyStatusProviderIsRemote)
+                    if (occupancyRoom.RoomOccupancy != null)
                     {
-                        SetUpRemoteOccupancy();
-                    }
-                    else
-                    {
-                        SetUpLocalOccupancy();
+                        if (occupancyRoom.OccupancyStatusProviderIsRemote)
+                        {
+                            SetUpRemoteOccupancy();
+                        }
+                        else
+                        {
+                            SetUpLocalOccupancy();
+                        }
                     }
                 }
 
@@ -1523,10 +1528,15 @@ namespace PepperDash.Essentials.Core.Fusion
             // Tie to method on occupancy object
             //occSensorShutdownMinutes.OutputSig.UserObject(new Action(ushort)(b => Room.OccupancyObj.SetShutdownMinutes(b));
 
+            var occRoom = Room as IRoomOccupancy;
 
+            if (occRoom != null)
+            {
+                occRoom.RoomOccupancy.RoomIsOccupiedFeedback.LinkInputSig(occSensorAsset.RoomOccupied.InputSig);
+                occRoom.RoomOccupancy.RoomIsOccupiedFeedback.OutputChange += RoomIsOccupiedFeedback_OutputChange;
+            }
             RoomOccupancyRemoteStringFeedback = new StringFeedback(() => _roomOccupancyRemoteString);
-            Room.RoomOccupancy.RoomIsOccupiedFeedback.LinkInputSig(occSensorAsset.RoomOccupied.InputSig);
-            Room.RoomOccupancy.RoomIsOccupiedFeedback.OutputChange += RoomIsOccupiedFeedback_OutputChange;
+            
             RoomOccupancyRemoteStringFeedback.LinkInputSig(occSensorAsset.RoomOccupancyInfo.InputSig);
 
             //}

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/Behaviours/RoomOnToDefaultSourceWhenOccupied.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/Behaviours/RoomOnToDefaultSourceWhenOccupied.cs
@@ -38,7 +38,7 @@ namespace PepperDash.Essentials.Core
 
         ScheduledEventGroup FeatureEventGroup;
 
-        public IEssentialsRoom Room { get; private set; }
+        public IRoomOccupancy Room { get; private set; }
 
         private Fusion.EssentialsHuddleSpaceFusionSystemControllerBase FusionRoom;
 
@@ -84,7 +84,7 @@ namespace PepperDash.Essentials.Core
         /// </summary>
         void SetUpDevice()
         {
-            Room = DeviceManager.GetDeviceForKey(PropertiesConfig.RoomKey) as IEssentialsRoom;
+            Room = DeviceManager.GetDeviceForKey(PropertiesConfig.RoomKey) as IRoomOccupancy;
 
             if (Room != null)
             {
@@ -235,12 +235,23 @@ namespace PepperDash.Essentials.Core
 
                 if (FeatureEnabled)
                 {
-                    // Check room power state first
-                    if (!Room.OnFeedback.BoolValue)
-                    {
-                        Debug.Console(1, this, "Powering Room on to default source");
-                        Room.RunDefaultPresentRoute();
+                    var essentialsRoom = Room as IEssentialsRoom;
+
+                    if (essentialsRoom != null) {
+                        if (!essentialsRoom.OnFeedback.BoolValue)
+                        {
+                            Debug.Console(1, this, "Powering Room on to default source");
+
+                            var defaultRouteRoom = Room as IRunDefaultPresentRoute;
+
+                            if (defaultRouteRoom != null)
+                            {
+                                defaultRouteRoom.RunDefaultPresentRoute();
+                            }
+                        }
                     }
+                    // Check room power state first
+                    
                 }
             }
         }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/IEssentialsRoom.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/IEssentialsRoom.cs
@@ -17,15 +17,10 @@ namespace PepperDash.Essentials.Core
     /// </summary>
     public interface IEssentialsRoom : IKeyName, IReconfigurableDevice, IRunDefaultPresentRoute, IEnvironmentalControls
     {
-        BoolFeedback OnFeedback { get; }
-
-        event EventHandler<EventArgs> RoomOccupancyIsSet;
+        BoolFeedback OnFeedback { get; }        
 
         BoolFeedback IsWarmingUpFeedback { get; }
-        BoolFeedback IsCoolingDownFeedback { get; }
-
-        IOccupancyStatusProvider RoomOccupancy { get; }
-        bool OccupancyStatusProviderIsRemote { get; }
+        BoolFeedback IsCoolingDownFeedback { get; }        
 
         bool IsMobileControlEnabled { get; }
         IMobileControlRoomBridge MobileControlRoomBridge { get; }
@@ -35,31 +30,16 @@ namespace PepperDash.Essentials.Core
         SecondsCountdownTimer ShutdownPromptTimer { get; }
         int ShutdownPromptSeconds { get; }
         int ShutdownVacancySeconds { get; }
-        eShutdownType ShutdownType { get; }
-
-        EssentialsRoomEmergencyBase Emergency { get; }
-
-        Core.Privacy.MicrophonePrivacyController MicrophonePrivacy { get; }
+        eShutdownType ShutdownType { get; }      
 
         string LogoUrlLightBkgnd { get; }
         string LogoUrlDarkBkgnd { get; }
 
-        eVacancyMode VacancyMode { get; }
+        void StartShutdown(eShutdownType type);        
 
-        bool ZeroVolumeWhenSwtichingVolumeDevices { get; }
+        void Shutdown();        
 
-        void StartShutdown(eShutdownType type);
-        void StartRoomVacancyTimer(eVacancyMode mode);
-
-        void Shutdown();
-
-        void SetRoomOccupancy(IOccupancyStatusProvider statusProvider, int timeoutMinutes);
-
-        void PowerOnToDefaultOrLastSource();
-
-        void SetDefaultLevels();
-
-        void RoomVacatedForTimeoutPeriod(object o);
+        void PowerOnToDefaultOrLastSource();               
     }
 
 }

--- a/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/Interfaces.cs
+++ b/essentials-framework/Essentials Core/PepperDashEssentialsBase/Room/Interfaces.cs
@@ -41,7 +41,6 @@ namespace PepperDash.Essentials.Core
         void RunRouteAction(string routeKey, string sourceListKey);
 
         void RunRouteAction(string routeKey, string sourceListKey, Action successCallback);
-
     }
 
     /// <summary>
@@ -76,6 +75,32 @@ namespace PepperDash.Essentials.Core
         List<EssentialsDevice> EnvironmentalControlDevices { get; }
 
         bool HasEnvironmentalControlDevices { get; }
+    }
+
+    public interface IRoomOccupancy:IKeyed
+    {
+        IOccupancyStatusProvider RoomOccupancy { get; }
+        bool OccupancyStatusProviderIsRemote { get; }
+
+        void SetRoomOccupancy(IOccupancyStatusProvider statusProvider, int timeoutMinutes);
+
+        void RoomVacatedForTimeoutPeriod(object o);
+
+        void StartRoomVacancyTimer(eVacancyMode mode);
+
+        eVacancyMode VacancyMode { get; }
+
+        event EventHandler<EventArgs> RoomOccupancyIsSet;
+    }
+
+    public interface IEmergency
+    {
+        EssentialsRoomEmergencyBase Emergency { get; }
+    }
+
+    public interface IMicrophonePrivacy
+    {
+        Core.Privacy.MicrophonePrivacyController MicrophonePrivacy { get; }
     }
 
 }


### PR DESCRIPTION
In order to allow for easier composition of interfaces for room plugins, the IEssentialsRoom interface needed to be broken down further to the simplest components a room would need to function. The interfaces are composited in the huddle space and the Huddle VTC interfaces.