### PR TITLE
Add JSON Props & Control Config

### DIFF
--- a/src/PepperDash.Essentials.Core/Comm and IR/ComSpecJsonConverter.cs
+++ b/src/PepperDash.Essentials.Core/Comm and IR/ComSpecJsonConverter.cs
@@ -23,12 +23,12 @@ namespace PepperDash.Essentials.Core
     {
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            if (objectType == typeof(ComPort.ComPortSpec))
+            if (objectType == typeof(ComPort.ComPortSpec?))
             {
                 var newSer = new JsonSerializer();
                 newSer.Converters.Add(new ComSpecPropsJsonConverter());
                 newSer.ObjectCreationHandling = ObjectCreationHandling.Replace;
-                return newSer.Deserialize<ComPort.ComPortSpec>(reader);
+                return newSer.Deserialize<ComPort.ComPortSpec?>(reader);
             }
             return null;
         }
@@ -38,7 +38,7 @@ namespace PepperDash.Essentials.Core
         /// </summary>
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(ComPort.ComPortSpec);
+            return objectType == typeof(ComPort.ComPortSpec?);
         }
 
         public override bool CanRead { get { return true; } }

--- a/src/PepperDash.Essentials.Core/Comm and IR/CommFactory.cs
+++ b/src/PepperDash.Essentials.Core/Comm and IR/CommFactory.cs
@@ -51,7 +51,7 @@ namespace PepperDash.Essentials.Core
 				switch (controlConfig.Method)
 				{
 					case eControlMethod.Com:
-						comm = new ComPortController(deviceConfig.Key + "-com", GetComPort, controlConfig.ComParams, controlConfig);
+						comm = new ComPortController(deviceConfig.Key + "-com", GetComPort, controlConfig.ComParams.Value, controlConfig);
 						break;
                     case eControlMethod.Cec:
                         comm = new CecPortController(deviceConfig.Key + "-cec", GetCecPort, controlConfig);
@@ -115,7 +115,7 @@ namespace PepperDash.Essentials.Core
 			var comPar = config.ComParams;
 			var dev = GetIComPortsDeviceFromManagedDevice(config.ControlPortDevKey);
 			if (dev != null && config.ControlPortNumber <= dev.NumberOfComPorts)
-				return dev.ComPorts[config.ControlPortNumber];
+				return dev.ComPorts[config.ControlPortNumber.Value];
 			Debug.LogMessage(LogEventLevel.Information, "GetComPort: Device '{0}' does not have com port {1}", config.ControlPortDevKey, config.ControlPortNumber);
 			return null;
 		}
@@ -205,11 +205,11 @@ namespace PepperDash.Essentials.Core
         ControlPropertiesConfig
     {
 
-        [JsonProperty("comParams")]
+        [JsonProperty("comParams", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(ComSpecJsonConverter))]
-        public ComPort.ComPortSpec ComParams { get; set; }
+        public ComPort.ComPortSpec? ComParams { get; set; }
 
-        [JsonProperty("cresnetId")]
+        [JsonProperty("cresnetId", NullValueHandling = NullValueHandling.Ignore)]
         public string CresnetId { get; set; }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace PepperDash.Essentials.Core
             }
         }
 
-        [JsonProperty("infinetId")]
+        [JsonProperty("infinetId", NullValueHandling = NullValueHandling.Ignore)]
         public string InfinetId { get; set; }
 
         /// <summary>

--- a/src/PepperDash.Essentials.Core/Comm and IR/CommFactory.cs
+++ b/src/PepperDash.Essentials.Core/Comm and IR/CommFactory.cs
@@ -201,23 +201,26 @@ namespace PepperDash.Essentials.Core
     /// <summary>
     /// 
     /// </summary>
-    public class EssentialsControlPropertiesConfig : 
-        PepperDash.Core.ControlPropertiesConfig
+    public class EssentialsControlPropertiesConfig :
+        ControlPropertiesConfig
     {
 
+        [JsonProperty("comParams")]
         [JsonConverter(typeof(ComSpecJsonConverter))]
-        public ComPort.ComPortSpec ComParams { get; set; }		
+        public ComPort.ComPortSpec ComParams { get; set; }
 
-		public string CresnetId { get; set; }
+        [JsonProperty("cresnetId")]
+        public string CresnetId { get; set; }
 
         /// <summary>
         /// Attempts to provide uint conversion of string CresnetId
         /// </summary>
+        [JsonIgnore]
         public uint CresnetIdInt
         {
             get
             {
-                try 
+                try
                 {
                     return Convert.ToUInt32(CresnetId, 16);
                 }
@@ -228,11 +231,13 @@ namespace PepperDash.Essentials.Core
             }
         }
 
+        [JsonProperty("infinetId")]
         public string InfinetId { get; set; }
 
         /// <summary>
         /// Attepmts to provide uiont conversion of string InifinetId
         /// </summary>
+        [JsonIgnore]
         public uint InfinetIdInt
         {
             get

--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-423" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-418" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
+++ b/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
@@ -23,16 +23,16 @@ namespace PepperDash.Essentials.Core
         public string ProjectName { get; set; }
 
         [JsonProperty("showVolumeGauge", NullValueHandling = NullValueHandling.Ignore)]
-        public bool ShowVolumeGauge { get; set; }
+        public bool? ShowVolumeGauge { get; set; }
 
         [JsonProperty("usesSplashPage", NullValueHandling = NullValueHandling.Ignore)]
-        public bool UsesSplashPage { get; set; }
+        public bool? UsesSplashPage { get; set; }
 
         [JsonProperty("showDate", NullValueHandling = NullValueHandling.Ignore)]
-        public bool ShowDate { get; set; }
+        public bool? ShowDate { get; set; }
 
         [JsonProperty("showTime", NullValueHandling = NullValueHandling.Ignore)]
-        public bool ShowTime { get; set; }
+        public bool? ShowTime { get; set; }
 
         [JsonProperty("setup", NullValueHandling = NullValueHandling.Ignore)]
         public UiSetupPropertiesConfig Setup { get; set; }
@@ -41,13 +41,13 @@ namespace PepperDash.Essentials.Core
         public string HeaderStyle { get; set; }
 
         [JsonProperty("includeInFusionRoomHealth", NullValueHandling = NullValueHandling.Ignore)]
-        public bool IncludeInFusionRoomHealth { get; set; }
+        public bool? IncludeInFusionRoomHealth { get; set; }
 
         [JsonProperty("screenSaverTimeoutMin", NullValueHandling = NullValueHandling.Ignore)]
-        public uint ScreenSaverTimeoutMin { get; set; }
+        public uint? ScreenSaverTimeoutMin { get; set; }
 
         [JsonProperty("screenSaverMovePositionIntervalMs", NullValueHandling = NullValueHandling.Ignore)]
-        public uint ScreenSaverMovePositionIntervalMs { get; set; }
+        public uint? ScreenSaverMovePositionIntervalMs { get; set; }
 
 
         /// <summary>
@@ -55,17 +55,20 @@ namespace PepperDash.Essentials.Core
         /// Defaults to 5
         /// </summary>
         [JsonProperty("sourcesOverflowCount", NullValueHandling = NullValueHandling.Ignore)]
-        public int SourcesOverflowCount { get; set; }
+        public int? SourcesOverflowCount { get; set; }
 
-        public CrestronTouchpanelPropertiesConfig()
+        public CrestronTouchpanelPropertiesConfig() : this(false) { }        
+
+        public CrestronTouchpanelPropertiesConfig(bool setDefaultValues = false)
         {
+            if(!setDefaultValues) { return; }
             SourcesOverflowCount = 5;
-            HeaderStyle = CrestronTouchpanelPropertiesConfig.Habanero;
+            HeaderStyle = Habanero;
 
             // Default values
             ScreenSaverTimeoutMin = 5;
             ScreenSaverMovePositionIntervalMs = 15000;
-        }
+        }        
 
         /// <summary>
         /// "habanero"

--- a/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
+++ b/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
@@ -1,20 +1,49 @@
-﻿namespace PepperDash.Essentials.Core
+﻿using Newtonsoft.Json;
+
+namespace PepperDash.Essentials.Core
 {
     public class CrestronTouchpanelPropertiesConfig
     {
+        [JsonProperty("ipId")]
         public string IpId { get; set; }
+
+        [JsonProperty("defaultRoomKey")]
         public string DefaultRoomKey { get; set; }
+        
+        [JsonProperty("roomListKey")]
         public string RoomListKey { get; set; }
+
+        [JsonProperty("sgdFile")]
         public string SgdFile { get; set; }
+
+        [JsonProperty("projectName")]
         public string ProjectName { get; set; }
+
+        [JsonProperty("showVolumeGauge")]
         public bool ShowVolumeGauge { get; set; }
+
+        [JsonProperty("usesSplashPage")]
         public bool UsesSplashPage { get; set; }
+
+        [JsonProperty("showDate")]
         public bool ShowDate { get; set; }
+
+        [JsonProperty("showTime")]
         public bool ShowTime { get; set; }
+
+        [JsonProperty("setup")]
         public UiSetupPropertiesConfig Setup { get; set; }
+
+        [JsonProperty("headerStyle")]
         public string HeaderStyle { get; set; }
+
+        [JsonProperty("includeInFusionRoomHealth")]
         public bool IncludeInFusionRoomHealth { get; set; }
+
+        [JsonProperty("screenSaverTimeoutMin")]
         public uint ScreenSaverTimeoutMin { get; set; }
+
+        [JsonProperty("screenSaverMovePositionIntervalMs")]
         public uint ScreenSaverMovePositionIntervalMs { get; set; }
 
 
@@ -22,6 +51,7 @@
         /// The count of sources that will trigger the "additional" arrows to show on the SRL.
         /// Defaults to 5
         /// </summary>
+        [JsonProperty("sourcesOverflowCount")]
         public int SourcesOverflowCount { get; set; }
 
         public CrestronTouchpanelPropertiesConfig()
@@ -49,6 +79,7 @@
     /// </summary>
     public class UiSetupPropertiesConfig
     {
+        [JsonProperty("isVisible")]
         public bool IsVisible { get; set; }
     }
 }

--- a/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
+++ b/src/PepperDash.Essentials.Core/Touchpanels/CrestronTouchpanelPropertiesConfig.cs
@@ -4,46 +4,49 @@ namespace PepperDash.Essentials.Core
 {
     public class CrestronTouchpanelPropertiesConfig
     {
-        [JsonProperty("ipId")]
+        [JsonProperty("control")]
+        public EssentialsControlPropertiesConfig ControlProperties { get; set; }
+
+        [JsonProperty("ipId", NullValueHandling = NullValueHandling.Ignore)]
         public string IpId { get; set; }
 
-        [JsonProperty("defaultRoomKey")]
+        [JsonProperty("defaultRoomKey", NullValueHandling = NullValueHandling.Ignore)]
         public string DefaultRoomKey { get; set; }
         
-        [JsonProperty("roomListKey")]
+        [JsonProperty("roomListKey", NullValueHandling = NullValueHandling.Ignore)]
         public string RoomListKey { get; set; }
 
-        [JsonProperty("sgdFile")]
+        [JsonProperty("sgdFile", NullValueHandling = NullValueHandling.Ignore)]
         public string SgdFile { get; set; }
 
-        [JsonProperty("projectName")]
+        [JsonProperty("projectName", NullValueHandling = NullValueHandling.Ignore)]
         public string ProjectName { get; set; }
 
-        [JsonProperty("showVolumeGauge")]
+        [JsonProperty("showVolumeGauge", NullValueHandling = NullValueHandling.Ignore)]
         public bool ShowVolumeGauge { get; set; }
 
-        [JsonProperty("usesSplashPage")]
+        [JsonProperty("usesSplashPage", NullValueHandling = NullValueHandling.Ignore)]
         public bool UsesSplashPage { get; set; }
 
-        [JsonProperty("showDate")]
+        [JsonProperty("showDate", NullValueHandling = NullValueHandling.Ignore)]
         public bool ShowDate { get; set; }
 
-        [JsonProperty("showTime")]
+        [JsonProperty("showTime", NullValueHandling = NullValueHandling.Ignore)]
         public bool ShowTime { get; set; }
 
-        [JsonProperty("setup")]
+        [JsonProperty("setup", NullValueHandling = NullValueHandling.Ignore)]
         public UiSetupPropertiesConfig Setup { get; set; }
 
-        [JsonProperty("headerStyle")]
+        [JsonProperty("headerStyle", NullValueHandling = NullValueHandling.Ignore)]
         public string HeaderStyle { get; set; }
 
-        [JsonProperty("includeInFusionRoomHealth")]
+        [JsonProperty("includeInFusionRoomHealth", NullValueHandling = NullValueHandling.Ignore)]
         public bool IncludeInFusionRoomHealth { get; set; }
 
-        [JsonProperty("screenSaverTimeoutMin")]
+        [JsonProperty("screenSaverTimeoutMin", NullValueHandling = NullValueHandling.Ignore)]
         public uint ScreenSaverTimeoutMin { get; set; }
 
-        [JsonProperty("screenSaverMovePositionIntervalMs")]
+        [JsonProperty("screenSaverMovePositionIntervalMs", NullValueHandling = NullValueHandling.Ignore)]
         public uint ScreenSaverMovePositionIntervalMs { get; set; }
 
 
@@ -51,7 +54,7 @@ namespace PepperDash.Essentials.Core
         /// The count of sources that will trigger the "additional" arrows to show on the SRL.
         /// Defaults to 5
         /// </summary>
-        [JsonProperty("sourcesOverflowCount")]
+        [JsonProperty("sourcesOverflowCount", NullValueHandling = NullValueHandling.Ignore)]
         public int SourcesOverflowCount { get; set; }
 
         public CrestronTouchpanelPropertiesConfig()
@@ -79,7 +82,7 @@ namespace PepperDash.Essentials.Core
     /// </summary>
     public class UiSetupPropertiesConfig
     {
-        [JsonProperty("isVisible")]
+        [JsonProperty("isVisible", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsVisible { get; set; }
     }
 }

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -28,6 +28,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-423" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -28,6 +28,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-418" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -28,6 +28,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-418" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-421" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-422" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-beta-423" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />


### PR DESCRIPTION
In order to reconfigure devices that have a control properties config, that config needs to be part of the properties that are saved, and then serialized correctly to the local configuration file.