### PR TITLE
Update xStatus.cs ConvertCodecPreset Debug Console formatting

### DIFF
--- a/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/xStatus.cs
+++ b/essentials-framework/Essentials Devices Common/Essentials Devices Common/VideoCodec/CiscoCodec/xStatus.cs
@@ -2206,7 +2206,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec.Cisco
                     {
                         var preset =  new CodecRoomPreset(UInt16.Parse(id), Description.Value, Defined.BoolValue, true);
 
-                        Debug.Console(2, "Preset ID {0} Converted from Cisco Codec Preset to Essentials Preset");
+                        Debug.Console(2, "Preset ID {0} Converted from Cisco Codec Preset to Essentials Preset, id");
 
                         return preset;
                     }


### PR DESCRIPTION
The Debug.Console statement within ConvertCodecPreset uses a variable placeholder in the formatted text but does not include the variable in the console statement call.