### PR TITLE
Set CurrentSourceKey correctly & in the correct order

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/RoutingFeedbackManager.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RoutingFeedbackManager.cs
@@ -187,8 +187,8 @@ namespace PepperDash.Essentials.Core.Routing
                     Name = sourceTieLine.SourcePort.Key,
                 };
 
-                destination.CurrentSourceInfo = tempSourceListItem; ;
                 destination.CurrentSourceInfoKey = "$transient";
+                destination.CurrentSourceInfo = tempSourceListItem;                
                 return;
             }
 


### PR DESCRIPTION
Most devices that implement `IHasCurrentSourceInfo` trigger an event when the `CurrentSourceInfo` property is set. In order to have all the information available for the event, the source key should be set prior to setting the `CurrentSourceInfo` property.