### PR TITLE
fix: joins in join maps get added correctly to a bridge

### DIFF
--- a/src/PepperDash.Essentials.Core/Bridges/BridgeBase.cs
+++ b/src/PepperDash.Essentials.Core/Bridges/BridgeBase.cs
@@ -19,81 +19,6 @@ using Serilog.Events;
 namespace PepperDash.Essentials.Core.Bridges
 {
     /// <summary>
-    /// Helper methods for bridges
-    /// </summary>
-    public static class BridgeHelper
-    {
-        public static void PrintJoinMap(string command)
-        {
-            var targets = command.Split(' ');
-
-            var bridgeKey = targets[0].Trim();
-
-            var bridge = DeviceManager.GetDeviceForKey(bridgeKey) as EiscApiAdvanced;
-
-            if (bridge == null)
-            {
-                Debug.LogMessage(LogEventLevel.Information, "Unable to find advanced bridge with key: '{0}'", bridgeKey);
-                return;
-            }
-
-            if (targets.Length > 1)
-            {
-                var deviceKey = targets[1].Trim();
-
-                if (string.IsNullOrEmpty(deviceKey)) return;
-                bridge.PrintJoinMapForDevice(deviceKey);
-            }
-            else
-            {
-                bridge.PrintJoinMaps();
-            }
-        }
-        public static void JoinmapMarkdown(string command)
-        {
-            var targets = command.Split(' ');
-
-            var bridgeKey = targets[0].Trim();
-
-            var bridge = DeviceManager.GetDeviceForKey(bridgeKey) as EiscApiAdvanced;
-
-            if (bridge == null)
-            {
-                Debug.LogMessage(LogEventLevel.Information, "Unable to find advanced bridge with key: '{0}'", bridgeKey);
-                return;
-            }
-
-            if (targets.Length > 1)
-            {
-                var deviceKey = targets[1].Trim();
-
-                if (string.IsNullOrEmpty(deviceKey)) return;
-                bridge.MarkdownJoinMapForDevice(deviceKey, bridgeKey);
-            }
-            else
-            {
-                bridge.MarkdownForBridge(bridgeKey);
-
-            }
-        }
-    }
-
-
-    /// <summary>
-    /// Base class for all bridge class variants
-    /// </summary>
-    public class BridgeBase : EssentialsDevice
-    {
-        public BridgeApi Api { get; protected set; }
-
-        public BridgeBase(string key) :
-            base(key)
-        {
-
-        }
-    }
-
-    /// <summary>
     /// Base class for bridge API variants
     /// </summary>
     public abstract class BridgeApi : EssentialsDevice
@@ -168,19 +93,15 @@ namespace PepperDash.Essentials.Core.Bridges
 
                 Debug.LogMessage(LogEventLevel.Debug, this, "Linking Device: '{0}'", device.Key);
 
-                if (!typeof(IBridgeAdvanced).IsAssignableFrom(device.GetType().GetType()))
+                if (device is IBridgeAdvanced bridge)
                 {
-                    Debug.LogMessage(LogEventLevel.Information, this,
-                        "{0} is not compatible with this bridge type. Please use 'eiscapi' instead, or updae the device.",
-                        device.Key);
+                    bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
                     continue;
                 }
 
-                var bridge = device as IBridgeAdvanced;
-                if (bridge != null)
-                {
-                    bridge.LinkToApi(Eisc, d.JoinStart, d.JoinMapKey, this);
-                }
+                Debug.LogMessage(LogEventLevel.Information, this,
+                        "{0} is not compatible with this bridge type. Please use 'eiscapi' instead, or updae the device.",
+                        device.Key);
             }
         }
 
@@ -249,11 +170,11 @@ namespace PepperDash.Essentials.Core.Bridges
         /// </summary>
         public virtual void PrintJoinMaps()
         {
-            Debug.LogMessage(LogEventLevel.Information, this, "Join Maps for EISC IPID: {0}", Eisc.ID.ToString("X"));
+            CrestronConsole.ConsoleCommandResponse("Join Maps for EISC IPID: {0}\r\n", Eisc.ID.ToString("X"));
 
             foreach (var joinMap in JoinMaps)
             {
-                Debug.LogMessage(LogEventLevel.Information, "Join map for device '{0}':", joinMap.Key);
+                CrestronConsole.ConsoleCommandResponse("Join map for device '{0}':", joinMap.Key);
                 joinMap.Value.PrintJoinMapInfo();
             }
         }

--- a/src/PepperDash.Essentials.Core/Bridges/BridgeHelper.cs
+++ b/src/PepperDash.Essentials.Core/Bridges/BridgeHelper.cs
@@ -1,0 +1,66 @@
+﻿using PepperDash.Core;
+using Serilog.Events;
+
+//using PepperDash.Essentials.Devices.Common.Cameras;
+
+namespace PepperDash.Essentials.Core.Bridges
+{
+    /// <summary>
+    /// Helper methods for bridges
+    /// </summary>
+    public static class BridgeHelper
+    {
+        public static void PrintJoinMap(string command)
+        {
+            var targets = command.Split(' ');
+
+            var bridgeKey = targets[0].Trim();
+
+            if (!(DeviceManager.GetDeviceForKey(bridgeKey) is EiscApiAdvanced bridge))
+            {
+                Debug.LogMessage(LogEventLevel.Information, "Unable to find advanced bridge with key: '{0}'", bridgeKey);
+                return;
+            }
+
+            if (targets.Length > 1)
+            {
+                var deviceKey = targets[1].Trim();
+
+                if (string.IsNullOrEmpty(deviceKey)) return;
+                bridge.PrintJoinMapForDevice(deviceKey);
+            }
+            else
+            {
+                bridge.PrintJoinMaps();
+            }
+        }
+        public static void JoinmapMarkdown(string command)
+        {
+            var targets = command.Split(' ');
+
+            var bridgeKey = targets[0].Trim();
+
+            var bridge = DeviceManager.GetDeviceForKey(bridgeKey) as EiscApiAdvanced;
+
+            if (bridge == null)
+            {
+                Debug.LogMessage(LogEventLevel.Information, "Unable to find advanced bridge with key: '{0}'", bridgeKey);
+                return;
+            }
+
+            if (targets.Length > 1)
+            {
+                var deviceKey = targets[1].Trim();
+
+                if (string.IsNullOrEmpty(deviceKey)) return;
+                bridge.MarkdownJoinMapForDevice(deviceKey, bridgeKey);
+            }
+            else
+            {
+                bridge.MarkdownForBridge(bridgeKey);
+
+            }
+        }
+    }
+
+}

--- a/src/PepperDash.Essentials.Core/Devices/DeviceJsonApi.cs
+++ b/src/PepperDash.Essentials.Core/Devices/DeviceJsonApi.cs
@@ -206,7 +206,7 @@ namespace PepperDash.Essentials.Core
             if (dev == null)
                 return "{ \"error\":\"No Device\"}";
 
-            object prop = dev.GetType().GetType().GetProperty(propertyName).GetValue(dev, null);
+            object prop = dev.GetType().GetProperty(propertyName).GetValue(dev, null);
 
             // var prop = t.GetProperty(propertyName);
             if (prop != null)

--- a/src/PepperDash.Essentials.Core/JoinMaps/JoinMapBase.cs
+++ b/src/PepperDash.Essentials.Core/JoinMaps/JoinMapBase.cs
@@ -107,8 +107,7 @@ namespace PepperDash.Essentials.Core
         }
 
         protected void AddJoins(Type type)
-        {
-            type.GetType();
+        {            
             var fields =
                 type.GetFields(BindingFlags.Public | BindingFlags.Instance)
                     .Where(f => f.IsDefined(typeof (JoinNameAttribute), true)).ToList();

--- a/src/PepperDash.Essentials.Devices.Common/Streaming/AppleTV.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Streaming/AppleTV.cs
@@ -42,7 +42,7 @@ namespace PepperDash.Essentials.Devices.Common
 
         public void PrintExpectedIrCommands()
         {
-            var cmds = typeof (AppleTvIrCommands).GetType().GetFields(BindingFlags.Public | BindingFlags.Static);
+            var cmds = typeof (AppleTvIrCommands).GetFields(BindingFlags.Public | BindingFlags.Static);
 
             foreach (var value in cmds.Select(cmd => cmd.GetValue(null)).OfType<string>())
             {

--- a/src/PepperDash.Essentials.Devices.Common/VideoCodec/VideoCodecBase.cs
+++ b/src/PepperDash.Essentials.Devices.Common/VideoCodec/VideoCodecBase.cs
@@ -1214,7 +1214,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 				var entryIndex = counterIndex;
 
 				Debug.LogMessage(LogEventLevel.Verbose, this, "Entry{2:0000} Name: {0}, Folder ID: {1}, Type: {3}, ParentFolderId: {4}",
-					entry.Name, entry.FolderId, entryIndex, entry.GetType().GetType().FullName, entry.ParentFolderId);
+					entry.Name, entry.FolderId, entryIndex, entry.GetType().FullName, entry.ParentFolderId);
 
 				if (entry is DirectoryFolder)
 				{


### PR DESCRIPTION
When Essentials moved to using `System.Reflection` instead of the Crestron classes, there were some leftover `GetType` calls that were no longer necessary. These extra calls were preventing things from getting the correct type.

Join Map printing was also fixed to print out in an actual readable fashion.