### PR TITLE
fix: remove event sub for route request

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -61,12 +61,13 @@ namespace PepperDash.Essentials.Core
                 SignalType = signalType
             };
 
-            var coolingDevice = destination as IWarmingCooling;
+            
 
+            var coolingDevice = destination as IWarmingCooling;
 
             //We already have a route request for this device, and it's a cooling device and is cooling
             if (RouteRequests.TryGetValue(destination.Key, out RouteRequest existingRouteRequest) && coolingDevice != null && coolingDevice.IsCoolingDownFeedback.BoolValue == true)
-            {
+            {                
                 coolingDevice.IsCoolingDownFeedback.OutputChange -= existingRouteRequest.HandleCooldown;
 
                 coolingDevice.IsCoolingDownFeedback.OutputChange += routeRequest.HandleCooldown;
@@ -80,20 +81,23 @@ namespace PepperDash.Essentials.Core
 
             //New Request
             if (coolingDevice != null && coolingDevice.IsCoolingDownFeedback.BoolValue == true)
-            {
-                coolingDevice.IsCoolingDownFeedback.OutputChange -= routeRequest.HandleCooldown;
-
+            {               
                 coolingDevice.IsCoolingDownFeedback.OutputChange += routeRequest.HandleCooldown;
 
                 RouteRequests.Add(destination.Key, routeRequest);
 
-                Debug.LogMessage(LogEventLevel.Information, "Device: {destination} is cooling down.  Storing route request to route to source key: {sourceKey}", null, destination.Key, routeRequest.Source.Key);
+                Debug.LogMessage(LogEventLevel.Information, "Device: {destination} is cooling down. Storing route request to route to source key: {sourceKey}", null, destination.Key, routeRequest.Source.Key);
                 return;
             }
 
             if (RouteRequests.ContainsKey(destination.Key) && coolingDevice != null && coolingDevice.IsCoolingDownFeedback.BoolValue == false)
             {
+                var handledRequest = RouteRequests[destination.Key];
+
+                coolingDevice.IsCoolingDownFeedback.OutputChange -= handledRequest.HandleCooldown;
+
                 RouteRequests.Remove(destination.Key);
+
                 Debug.LogMessage(LogEventLevel.Information, "Device: {destination} is NOT cooling down.  Removing stored route request and routing to source key: {sourceKey}", null, destination.Key, routeRequest.Source.Key);
             }
 


### PR DESCRIPTION
When route requests made during a destination's cooldown cycle were handled, the event subscription was *NOT* being removed, resulting in the request being run on *EVERY* subsequent cooldown complete event.
