### PR TITLE
Fix issues with concurrent routing actions

### DIFF
--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-451" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-424" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Core/Room/Combining/RoomCombinationScenario.cs
+++ b/src/PepperDash.Essentials.Core/Room/Combining/RoomCombinationScenario.cs
@@ -81,11 +81,9 @@ namespace PepperDash.Essentials.Core
                 foreach (var action in activationActions)
                 {
                     this.LogInformation("Running Activation action {@action}", action);
-                    tasks.Add(DeviceJsonApi.DoDeviceActionAsync(action));
+                    await DeviceJsonApi.DoDeviceActionAsync(action);
                 }
             }
-
-            await Task.WhenAll(tasks);
 
             IsActive = true;
         }
@@ -101,11 +99,9 @@ namespace PepperDash.Essentials.Core
                 foreach (var action in deactivationActions)
                 {
                     this.LogInformation("Running deactivation action {actionDeviceKey}:{actionMethod}", action.DeviceKey, action.MethodName);
-                    tasks.Add( DeviceJsonApi.DoDeviceActionAsync(action));
+                    await DeviceJsonApi.DoDeviceActionAsync(action);
                 }
             }
-
-            await Task.WhenAll(tasks);
 
             IsActive = false;
         }

--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -131,7 +131,7 @@ namespace PepperDash.Essentials.Core
                 videoRoute?.ExecuteRoutes();
             } catch(Exception ex)
             {
-                Debug.LogMessage(ex,"Exception Running Route Request", null, )
+                Debug.LogMessage(ex, "Exception Running Route Request {request}", null, request);
             }
         }
 

--- a/src/PepperDash.Essentials.Core/Routing/RouteRequest.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RouteRequest.cs
@@ -38,5 +38,10 @@ namespace PepperDash.Essentials.Core
                 Debug.LogMessage(ex, "Exception handling cooldown", Destination);
             }
         }
+
+        public override string ToString()
+        {
+            return $"Route {Source?.Key ?? "No Source Device"}:{SourcePort?.Key ?? "auto"} to {Destination?.Key ?? "No Destination Device"}:{DestinationPort?.Key ?? "auto"}";
+        }
     }
 }

--- a/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
@@ -20,7 +20,7 @@ namespace PepperDash.Essentials.Core.Routing
         }
     }
 
-    public class ReleaseRouteQueueItem: IQueueMessage
+    public class ReleaseRouteQueueItem : IQueueMessage
     {
         private readonly Action<IRoutingInputs, string> action;
         private readonly IRoutingInputs destination;
@@ -33,7 +33,9 @@ namespace PepperDash.Essentials.Core.Routing
             this.inputPortKey = inputPortKey;
         }
 
-        public void Dispatch() {
+        public void Dispatch()
+        {
             action(destination, inputPortKey);
         }
+    }
 }

--- a/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
@@ -1,5 +1,7 @@
-﻿using PepperDash.Essentials.Core.Queues;
+﻿using PepperDash.Core;
+using PepperDash.Essentials.Core.Queues;
 using System;
+using Serilog.Events;
 
 namespace PepperDash.Essentials.Core.Routing
 {
@@ -16,6 +18,7 @@ namespace PepperDash.Essentials.Core.Routing
 
         public void Dispatch()
         {
+            Debug.LogMessage(LogEventLevel.Information, "Dispatching route request {routeRequest}", null, routeRequest);
             action(routeRequest);
         }
     }
@@ -35,6 +38,7 @@ namespace PepperDash.Essentials.Core.Routing
 
         public void Dispatch()
         {
+            Debug.LogMessage(LogEventLevel.Information, "Dispatching release route request for {destination}:{inputPortKey}", null, destination?.Key ?? "no destination", string.IsNullOrEmpty(inputPortKey) ? "auto" : inputPortKey);
             action(destination, inputPortKey);
         }
     }

--- a/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RouteRequestQueueItem.cs
@@ -1,0 +1,39 @@
+﻿using PepperDash.Essentials.Core.Queues;
+using System;
+
+namespace PepperDash.Essentials.Core.Routing
+{
+    public class RouteRequestQueueItem : IQueueMessage
+    {
+        private readonly Action<RouteRequest> action;
+        private readonly RouteRequest routeRequest;
+
+        public RouteRequestQueueItem(Action<RouteRequest> routeAction, RouteRequest request)
+        {
+            action = routeAction;
+            routeRequest = request;
+        }
+
+        public void Dispatch()
+        {
+            action(routeRequest);
+        }
+    }
+
+    public class ReleaseRouteQueueItem: IQueueMessage
+    {
+        private readonly Action<IRoutingInputs, string> action;
+        private readonly IRoutingInputs destination;
+        private readonly string inputPortKey;
+
+        public ReleaseRouteQueueItem(Action<IRoutingInputs, string> action, IRoutingInputs destination, string inputPortKey)
+        {
+            this.action = action;
+            this.destination = destination;
+            this.inputPortKey = inputPortKey;
+        }
+
+        public void Dispatch() {
+            action(destination, inputPortKey);
+        }
+}

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -30,6 +30,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-451" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -30,6 +30,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-424" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.Devices.Common/SoftCodec/GenericSoftCodec.cs
+++ b/src/PepperDash.Essentials.Devices.Common/SoftCodec/GenericSoftCodec.cs
@@ -28,14 +28,14 @@ namespace PepperDash.Essentials.Devices.Common.SoftCodec
 
             for(var i = 1; i <= props.OutputCount; i++)
             {
-                var outputPort = new RoutingOutputPort($"{Key}-output{i}", eRoutingSignalType.AudioVideo, eRoutingPortConnectionType.Hdmi, null, this);
+                var outputPort = new RoutingOutputPort($"output{i}", eRoutingSignalType.AudioVideo, eRoutingPortConnectionType.Hdmi, null, this);
 
                 OutputPorts.Add(outputPort);
             }
 
             for(var i = 1; i<= props.ContentInputCount; i++)
             {
-                var inputPort = new RoutingInputPort($"{Key}-contentInput{i}", eRoutingSignalType.AudioVideo, eRoutingPortConnectionType.Hdmi, $"contentInput{i}", this);
+                var inputPort = new RoutingInputPort($"contentInput{i}", eRoutingSignalType.AudioVideo, eRoutingPortConnectionType.Hdmi, $"contentInput{i}", this);
 
                 InputPorts.Add(inputPort);
             }
@@ -47,7 +47,7 @@ namespace PepperDash.Essentials.Devices.Common.SoftCodec
 
             for(var i = 1; i <=props.CameraInputCount; i++)
             {
-                var cameraPort = new RoutingInputPort($"{Key}-cameraInput{i}", eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, $"cameraInput{i}", this);
+                var cameraPort = new RoutingInputPort($"cameraInput{i}", eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, $"cameraInput{i}", this);
 
                 InputPorts.Add(cameraPort);
             }

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-424" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.20.66" />
-    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-450" />
+    <PackageReference Include="PepperDashCore" Version="2.0.0-alpha-451" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />


### PR DESCRIPTION
* In order to allow multiple threads to make routes using the Essentials Routing mechanism, a queue for routing actions was added.
* PD Core updated to 2.0.0-alpha-451
  *  Updated the GenericSshClient to use Renci.Ssh instead of the Crestron SSH classes
* closed #1213 