### PR TITLE
fix: correct event subscription logic in GenericCommunicationMonitor and poll inclusively.

### DIFF
--- a/src/PepperDash.Essentials.Core/Monitoring/GenericCommunicationMonitor.cs
+++ b/src/PepperDash.Essentials.Core/Monitoring/GenericCommunicationMonitor.cs
@@ -151,17 +151,16 @@ namespace PepperDash.Essentials.Core
 		{
             if (MonitorBytesReceived) 
             {
-			    Client.BytesReceived += Client_BytesReceived;
+			    Client.BytesReceived -= Client_BytesReceived;
+		        Client.BytesReceived += Client_BytesReceived;
             }
             else
             {
+                Client.TextReceived -= Client_TextReceived;
                 Client.TextReceived += Client_TextReceived;
             }
 
-            if (!IsSocket)
-            {
-                BeginPolling();
-            }
+            BeginPolling();
 		}
 
         void  socket_ConnectionChange(object sender, GenericSocketStatusChageEventArgs e)


### PR DESCRIPTION
deregister client.BytesReceived and client.TextReceived events before registering preventing multiple event registrations and trigger poll independant of iSocket condition.