### PR TITLE
fix: update lighting interfaces & messenger

### DIFF
--- a/src/PepperDash.Essentials.Core/Lighting/Lighting Interfaces.cs
+++ b/src/PepperDash.Essentials.Core/Lighting/Lighting Interfaces.cs
@@ -1,10 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Crestron.SimplSharp;
-
-using PepperDash.Core;
 
 namespace PepperDash.Essentials.Core.Lighting
 {
@@ -21,6 +16,11 @@ namespace PepperDash.Essentials.Core.Lighting
 
         LightingScene CurrentLightingScene { get; }
 
+    }
+
+    public interface ILightingScenesDynamic
+    {
+        event EventHandler LightingScenesUpdated;
     }
 
     /// <summary>

--- a/src/PepperDash.Essentials.Core/Lighting/LightingScene.cs
+++ b/src/PepperDash.Essentials.Core/Lighting/LightingScene.cs
@@ -26,6 +26,9 @@ namespace PepperDash.Essentials.Core.Lighting
             }
         }
 
+        [JsonProperty("sortOrder", NullValueHandling = NullValueHandling.Ignore)]
+        public int SortOrder { get; set; }
+
         [JsonIgnore]
         public BoolFeedback IsActiveFeedback { get; set; }
 

--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/LightingBaseMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/LightingBaseMessenger.cs
@@ -15,8 +15,6 @@ namespace PepperDash.Essentials.AppServer.Messengers
         {
             Device = device ?? throw new ArgumentNullException("device");
             Device.LightingSceneChange += new EventHandler<LightingSceneChangeEventArgs>(LightingDevice_LightingSceneChange);
-
-
         }
 
         private void LightingDevice_LightingSceneChange(object sender, LightingSceneChangeEventArgs e)
@@ -40,6 +38,11 @@ namespace PepperDash.Essentials.AppServer.Messengers
                 var s = content.ToObject<LightingScene>();
                 Device.SelectScene(s);
             });
+
+            if(!(Device is ILightingScenesDynamic lightingScenesDynamic))
+                return;
+
+            lightingScenesDynamic.LightingScenesUpdated += (s, e) => SendFullStatus();
         }
 
 

--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/LightingBaseMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/LightingBaseMessenger.cs
@@ -8,13 +8,14 @@ namespace PepperDash.Essentials.AppServer.Messengers
 {
     public class ILightingScenesMessenger : MessengerBase
     {
-        protected ILightingScenes Device { get; private set; }
+        private ILightingScenes lightingScenesDevice;
 
         public ILightingScenesMessenger(string key, ILightingScenes device, string messagePath)
             : base(key, messagePath, device as IKeyName)
         {
-            Device = device ?? throw new ArgumentNullException("device");
-            Device.LightingSceneChange += new EventHandler<LightingSceneChangeEventArgs>(LightingDevice_LightingSceneChange);
+            lightingScenesDevice = device ?? throw new ArgumentNullException("device");
+
+            lightingScenesDevice.LightingSceneChange += new EventHandler<LightingSceneChangeEventArgs>(LightingDevice_LightingSceneChange);
         }
 
         private void LightingDevice_LightingSceneChange(object sender, LightingSceneChangeEventArgs e)
@@ -36,10 +37,10 @@ namespace PepperDash.Essentials.AppServer.Messengers
             AddAction("/selectScene", (id, content) =>
             {
                 var s = content.ToObject<LightingScene>();
-                Device.SelectScene(s);
+                lightingScenesDevice.SelectScene(s);
             });
 
-            if(!(Device is ILightingScenesDynamic lightingScenesDynamic))
+            if(!(lightingScenesDevice is ILightingScenesDynamic lightingScenesDynamic))
                 return;
 
             lightingScenesDynamic.LightingScenesUpdated += (s, e) => SendFullStatus();
@@ -50,8 +51,8 @@ namespace PepperDash.Essentials.AppServer.Messengers
         {
             var state = new LightingBaseStateMessage
             {
-                Scenes = Device.LightingScenes,
-                CurrentLightingScene = Device.CurrentLightingScene
+                Scenes = lightingScenesDevice.LightingScenes,
+                CurrentLightingScene = lightingScenesDevice.CurrentLightingScene
             };
 
             PostStatusMessage(state);


### PR DESCRIPTION
Added the `ILightingScenesDynamic` interface to add an event for devices that support retrieving scene data from the lighting system at runtime. Also added the `sortOrder` property for the `LightingScene` type to allow for control over the sort order of scenes on the UI
