### PR TITLE
fix: check for `SecondaryAudio | Video`

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -69,7 +69,8 @@ namespace PepperDash.Essentials.Core
         public static (RouteDescriptor, RouteDescriptor) GetRouteToSource(this IRoutingInputs destination, IRoutingOutputs source, eRoutingSignalType signalType, RoutingInputPort destinationPort, RoutingOutputPort sourcePort)
         {
             // if it's a single signal type, find the route
-            if (!signalType.HasFlag(eRoutingSignalType.AudioVideo) && !signalType.HasFlag(eRoutingSignalType.Video | eRoutingSignalType.SecondaryAudio))
+            if (!signalType.HasFlag(eRoutingSignalType.AudioVideo) && 
+                !(signalType.HasFlag(eRoutingSignalType.Video) && signalType.HasFlag(eRoutingSignalType.SecondaryAudio)))
             {
                 var singleTypeRouteDescriptor = new RouteDescriptor(source, destination, destinationPort, signalType);
                 Debug.LogMessage(LogEventLevel.Debug, "Attempting to build source route from {sourceKey} of type {type}", destination, source.Key, signalType);

--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -69,7 +69,7 @@ namespace PepperDash.Essentials.Core
         public static (RouteDescriptor, RouteDescriptor) GetRouteToSource(this IRoutingInputs destination, IRoutingOutputs source, eRoutingSignalType signalType, RoutingInputPort destinationPort, RoutingOutputPort sourcePort)
         {
             // if it's a single signal type, find the route
-            if (!signalType.HasFlag(eRoutingSignalType.AudioVideo))
+            if (!signalType.HasFlag(eRoutingSignalType.AudioVideo) && !signalType.HasFlag(eRoutingSignalType.Video | eRoutingSignalType.SecondaryAudio))
             {
                 var singleTypeRouteDescriptor = new RouteDescriptor(source, destination, destinationPort, signalType);
                 Debug.LogMessage(LogEventLevel.Debug, "Attempting to build source route from {sourceKey} of type {type}", destination, source.Key, signalType);


### PR DESCRIPTION
In some scenarios when working with NVX, a route is intended to use the
secondary audio (NAX) path instead of the primary audio path. A route
that's both `Video` and `SecondaryAudio` should be considered a
dual-path route instead of a single path.
