### PR TITLE
feat: add support for mcdge1000 type in MobileControlTouchpanelContro…

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -491,7 +491,7 @@ namespace PepperDash.Essentials.Touchpanel
     {
         public MobileControlTouchpanelControllerFactory()
         {
-            TypeNames = new List<string>() { "mccrestronapp", "mctsw550", "mctsw750", "mctsw1050", "mctsw560", "mctsw760", "mctsw1060", "mctsw570", "mctsw770", "mcts770", "mctsw1070", "mcts1070", "mcxpanel" };
+            TypeNames = new List<string>() { "mccrestronapp", "mctsw550", "mctsw750", "mctsw1050", "mctsw560", "mctsw760", "mctsw1060", "mctsw570", "mctsw770", "mcts770", "mctsw1070", "mcts1070", "mcxpanel", "mcdge1000" };
             MinimumEssentialsFrameworkVersion = "2.0.0";
         }
 
@@ -555,7 +555,10 @@ namespace PepperDash.Essentials.Touchpanel
                     return new Tsw1070(id, Global.ControlSystem);
                 else if (type == "ts1070")
                     return new Ts1070(id, Global.ControlSystem);
-                else
+                else if (type == "dge1000")
+                    return new Dge1000(id, Global.ControlSystem);
+                else 
+
                 {
                     Debug.LogMessage(Serilog.Events.LogEventLevel.Warning, "WARNING: Cannot create TSW controller with type '{0}'", type);
                     return null;


### PR DESCRIPTION
This pull request updates the `MobileControlTouchpanelController` to add support for a new touch panel type, `dge1000`. The changes include adding the type to the list of recognized types and implementing its creation logic. Tested locally.

### Support for `dge1000` touch panel:

* [`src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs`](diffhunk://#diff-4cb19370765efca7aa474d6976e3dc93c54a7f79a935ea720c55626f02431069L494-R494): Added `"mcdge1000"` to the `TypeNames` list in the `MobileControlTouchpanelControllerFactory` constructor to recognize the new touch panel type.
* [`src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs`](diffhunk://#diff-4cb19370765efca7aa474d6976e3dc93c54a7f79a935ea720c55626f02431069R558-R561): Added a conditional branch in the `GetPanelForType` method to create a `Dge1000` instance when the type is `"dge1000"`.