### PR TITLE
Feature/add interfaces

### DIFF
--- a/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
+++ b/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
@@ -56,7 +56,7 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
     public class LayoutInfo
     {
         /// <summary>
-        /// The display name for the layout
+        /// The name of the layout.
         /// </summary>
         [JsonProperty("layoutName")]
         public string LayoutName { get; set; }
@@ -66,5 +66,35 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
         /// </summary>
         [JsonProperty("layoutIndex")]
         public int LayoutIndex { get; set; }
+
+        /// <summary>
+        /// The type of the layout, which can be "single", "double", "triple", or "quad".
+        /// </summary>
+        [JsonProperty("layoutType")]
+        public string LayoutType { get; set; }
+
+        /// <summary>
+        /// A dictionary of window configurations for the layout, keyed by window ID.
+        /// </summary>
+        [JsonProperty("windows")]
+        public Dictionary<uint, WindowConfig> Windows { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the configuration of a window within a layout on a screen.
+    /// </summary>
+    public class WindowConfig
+    {
+        /// <summary>
+        /// The display label for the window
+        /// </summary>
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        /// <summary>
+        /// The input for the window
+        /// </summary>
+        [JsonProperty("input")]
+        public string Input { get; set; }
     }
 }

--- a/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
+++ b/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
@@ -17,6 +17,13 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
         /// A dictionary of screens, keyed by screen ID, that contains information about each screen and its layouts.
         /// </summary>
         Dictionary<uint, ScreenInfo> Screens { get; }
+
+        /// <summary>
+        /// Applies a specific layout to a screen based on the provided screen ID and layout index.
+        /// </summary>
+        /// <param name="screenId"></param>
+        /// <param name="layoutIndex"></param>
+        void ApplyLayout(uint screenId, uint layoutIndex);
     }
 
     /// <summary>

--- a/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
+++ b/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs
@@ -1,0 +1,70 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
+{
+    /// <summary>
+    /// This defines a device that has screens with layouts
+    /// Simply decorative
+    /// </summary>
+    public interface IHasScreensWithLayouts
+    {
+        /// <summary>
+        /// A dictionary of screens, keyed by screen ID, that contains information about each screen and its layouts.
+        /// </summary>
+        Dictionary<uint, ScreenInfo> Screens { get; }
+    }
+
+    /// <summary>
+    /// Represents information about a screen and its layouts.
+    /// </summary>
+    public class ScreenInfo
+    {
+
+        /// <summary>
+        /// Indicates whether the screen is enabled or not.
+        /// </summary>
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// The name of the screen.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The index of the screen.
+        /// </summary>
+        [JsonProperty("screenIndex")]
+        public int ScreenIndex { get; set; }
+
+        /// <summary>
+        /// A dictionary of layout information for the screen, keyed by layout ID.
+        /// </summary>
+        [JsonProperty("layouts")]
+        public Dictionary<uint, LayoutInfo> Layouts { get; set; }
+    }
+
+    /// <summary>
+    /// Represents information about a layout on a screen.
+    /// </summary>
+    public class LayoutInfo
+    {
+        /// <summary>
+        /// The display name for the layout
+        /// </summary>
+        [JsonProperty("layoutName")]
+        public string LayoutName { get; set; }
+
+        /// <summary>
+        /// The index of the layout.
+        /// </summary>
+        [JsonProperty("layoutIndex")]
+        public int LayoutIndex { get; set; }
+    }
+}

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
@@ -1,0 +1,32 @@
+﻿using PepperDash.Core;
+using PepperDash.Essentials.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
+{
+    /// <summary>
+    /// Describes the Presenter Track controls for a Cisco codec.
+    /// </summary>
+    public interface IPresenterTrack : IKeyed
+    {
+        bool PresenterTrackAvailability { get; }
+
+        BoolFeedback PresenterTrackAvailableFeedback { get; }
+
+        BoolFeedback PresenterTrackStatusOffFeedback { get; }
+        BoolFeedback PresenterTrackStatusFollowFeedback { get; }
+        BoolFeedback PresenterTrackStatusBackgroundFeedback { get; }
+        BoolFeedback PresenterTrackStatusPersistentFeedback { get; }
+
+        bool PresenterTrackStatus { get; }
+
+        void PresenterTrackOff();
+        void PresenterTrackFollow();
+        void PresenterTrackBackground();
+        void PresenterTrackPersistent();
+    }
+}

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
@@ -13,20 +13,59 @@ namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
     /// </summary>
     public interface IPresenterTrack : IKeyed
     {
+        /// <summary>
+        /// 
+        /// </summary>
         bool PresenterTrackAvailability { get; }
 
+        /// <summary>
+        /// Feedback indicating whether Presenter Track is available.
+        /// </summary>
         BoolFeedback PresenterTrackAvailableFeedback { get; }
 
+        /// <summary>
+        /// Feedback indicateing the current status of Presenter Track is off
+        /// </summary>
         BoolFeedback PresenterTrackStatusOffFeedback { get; }
+
+        /// <summary>
+        /// Feedback indicating the current status of Presenter Track is follow
+        /// </summary>
         BoolFeedback PresenterTrackStatusFollowFeedback { get; }
+
+        /// <summary>
+        /// Feedback indicating the current status of Presenter Track is background
+        /// </summary>
         BoolFeedback PresenterTrackStatusBackgroundFeedback { get; }
+
+        /// <summary>
+        /// Feedback indicating the current status of Presenter Track is persistent
+        /// </summary>
         BoolFeedback PresenterTrackStatusPersistentFeedback { get; }
 
+        /// <summary>
+        /// Indicates the current status of Presenter Track.
+        /// </summary>
         bool PresenterTrackStatus { get; }
 
+        /// <summary>
+        /// Turns off Presenter Track.
+        /// </summary>
         void PresenterTrackOff();
+
+        /// <summary>
+        /// Turns on Presenter Track in follow mode.
+        /// </summary>
         void PresenterTrackFollow();
+
+        /// <summary>
+        /// Turns on Presenter Track in background mode.
+        /// </summary>
         void PresenterTrackBackground();
+
+        /// <summary>
+        /// Turns on Presenter Track in persistent mode.
+        /// </summary>
         void PresenterTrackPersistent();
     }
 }

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
@@ -9,6 +9,30 @@ using System.Threading.Tasks;
 namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
 {
     /// <summary>
+    /// Describes the available tracking modes for a Cisco codec's Presenter Track feature.
+    /// </summary>
+    public enum PresenterTrackMode
+    {
+        /// <summary>
+        /// Presenter Track is turned off.
+        /// </summary>
+        Off,
+        /// <summary>
+        /// Presenter Track follows the speaker's movements.
+        /// </summary>
+        Follow,
+        /// <summary>
+        /// Presenter Track is set to background mode, where it tracks the speaker but does not actively follow.
+        /// </summary>
+        Background,
+        /// <summary>
+        /// Presenter Track is set to persistent mode, where it maintains a fixed position or focus on the speaker.
+        /// </summary>
+        Persistent
+    }
+
+
+    /// <summary>
     /// Describes the Presenter Track controls for a Cisco codec.
     /// </summary>
     public interface IPresenterTrack : IKeyed

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs
@@ -11,7 +11,7 @@ namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
     /// <summary>
     /// Describes the available tracking modes for a Cisco codec's Presenter Track feature.
     /// </summary>
-    public enum PresenterTrackMode
+    public enum ePresenterTrackMode
     {
         /// <summary>
         /// Presenter Track is turned off.

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/ISpeakerTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/ISpeakerTrack.cs
@@ -1,0 +1,25 @@
+﻿using PepperDash.Core;
+using PepperDash.Essentials.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
+{
+    /// <summary>
+    /// Describes the available tracking modes for a Cisco codec
+    /// </summary>
+    public interface ISpeakerTrack : IKeyed
+    {
+        bool SpeakerTrackAvailability { get; }
+
+        BoolFeedback SpeakerTrackAvailableFeedback { get; }
+
+        bool SpeakerTrackStatus { get; }
+
+        void SpeakerTrackOff();
+        void SpeakerTrackOn();
+    }
+}

--- a/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/ISpeakerTrack.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Codec/Cisco/ISpeakerTrack.cs
@@ -13,13 +13,28 @@ namespace PepperDash.Essentials.Devices.Common.Codec.Cisco
     /// </summary>
     public interface ISpeakerTrack : IKeyed
     {
+        /// <summary>
+        /// Indicates whether Speaker Track is available on the codec.
+        /// </summary>
         bool SpeakerTrackAvailability { get; }
 
+        /// <summary>
+        /// 
+        /// </summary>
         BoolFeedback SpeakerTrackAvailableFeedback { get; }
 
+        /// <summary>
+        /// Feedback indicating the current status of Speaker Track is off
+        /// </summary>
         bool SpeakerTrackStatus { get; }
 
+        /// <summary>
+        /// Turns Speaker Track off
+        /// </summary>
         void SpeakerTrackOff();
+        /// <summary>
+        /// Turns Speaker Track on
+        /// </summary>
         void SpeakerTrackOn();
     }
 }

--- a/src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs
+++ b/src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs
@@ -12,20 +12,45 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
     /// </summary>
     public interface IHasCodecRoomPresets
     {
+        /// <summary>
+        /// Event that is raised when the list of room presets has changed.
+        /// </summary>
         event EventHandler<EventArgs> CodecRoomPresetsListHasChanged;
 
+        /// <summary>
+        /// List of near end presets that can be recalled.
+        /// </summary>
         List<CodecRoomPreset> NearEndPresets { get; }
 
+        /// <summary>
+        /// List of far end presets that can be recalled.
+        /// </summary>
         List<CodecRoomPreset> FarEndRoomPresets { get; }
 
+        /// <summary>
+        /// Selects a near end preset by its ID.
+        /// </summary>
+        /// <param name="preset"></param>
         void CodecRoomPresetSelect(int preset);
 
+        /// <summary>
+        /// Stores a near end preset with the given ID and description.
+        /// </summary>
+        /// <param name="preset"></param>
+        /// <param name="description"></param>
         void CodecRoomPresetStore(int preset, string description);
 
+        /// <summary>
+        /// Selects a far end preset by its ID. This is typically used to recall a preset that has been defined on the far end codec.
+        /// </summary>
+        /// <param name="preset"></param>
         void SelectFarEndPreset(int preset);        
     }
 
-    public static class RoomPresets
+    /// <summary>
+    /// Static class for converting non-generic RoomPresets to generic CameraPresets.
+    /// </summary>
+    public static class RoomPresets 
     {
         /// <summary>
         /// Converts non-generic RoomPresets to generic CameraPresets
@@ -47,6 +72,13 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
     /// </summary>
     public class CodecRoomPreset : PresetBase
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="description"></param>
+        /// <param name="def"></param>
+        /// <param name="isDef"></param>
         public CodecRoomPreset(int id, string description, bool def, bool isDef)
             : base(id, description, def, isDef)
         {

--- a/src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs
+++ b/src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs
@@ -38,7 +38,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
         /// </summary>
         /// <param name="preset"></param>
         /// <param name="description"></param>
-        void CodecRoomPresetStore(int preset, string description);
+        void CodecRoomPresetStore(int preset, string description);  
 
         /// <summary>
         /// Selects a far end preset by its ID. This is typically used to recall a preset that has been defined on the far end codec.


### PR DESCRIPTION
This pull request introduces several new interfaces and classes to enhance functionality for devices with screens, layouts, and tracking capabilities, as well as for managing room presets in video codecs. Below is a summary of the most important changes grouped by theme.

### Interfaces for Screen and Layout Management:
* Added `IHasScreensWithLayouts` interface to define devices with screens and layouts, including methods for applying layouts and a `Screens` dictionary containing `ScreenInfo` objects. (`src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs`)
* Introduced `ScreenInfo`, `LayoutInfo`, and `WindowConfig` classes to represent screens, layouts, and window configurations, respectively. These classes include properties like `Enabled`, `LayoutName`, and `Input`, with JSON serialization attributes. (`src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasScreensWithLayouts.cs`)

### Presenter and Speaker Tracking for Cisco Codecs:
* Added `ePresenterTrackMode` enum to describe tracking modes (Off, Follow, Background, Persistent) for Cisco codec Presenter Track. (`src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs`)
* Created `IPresenterTrack` interface for managing Presenter Track functionality, including feedback properties and methods to toggle tracking modes. (`src/PepperDash.Essentials.Devices.Common/Codec/Cisco/IPresenterTrack.cs`)
* Introduced `ISpeakerTrack` interface for Cisco codec Speaker Track, with methods to enable/disable tracking and feedback on availability and status. (`src/PepperDash.Essentials.Devices.Common/Codec/Cisco/ISpeakerTrack.cs`)

### Enhancements to Room Presets:
* Extended `IHasCodecRoomPresets` interface to include events for changes in room presets, lists for near and far-end presets, and methods to select/store presets. (`src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs`)
* Updated the `CodecRoomPreset` class constructor to include documentation for its parameters. (`src/PepperDash.Essentials.Devices.Common/VideoCodec/CiscoCodec/RoomPresets.cs`)