### PR TITLE
Fix/remove unsued method in cs

### DIFF
--- a/src/PepperDash.Essentials/ControlSystem.cs
+++ b/src/PepperDash.Essentials/ControlSystem.cs
@@ -41,29 +41,6 @@ namespace PepperDash.Essentials
             SystemMonitor.ProgramInitialization.ProgramInitializationUnderUserControl = true;
 
             Debug.SetErrorLogMinimumDebugLevel(CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance ? LogEventLevel.Warning : LogEventLevel.Verbose);
-
-            // AppDomain.CurrentDomain.AssemblyResolve += CurrentDomainOnAssemblyResolve;
-        }
-
-        private Assembly CurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args)
-        {
-            var assemblyName = new AssemblyName(args.Name).Name;
-            if (assemblyName == "PepperDash_Core")
-            {
-                return Assembly.LoadFrom("PepperDashCore.dll");
-            }
-
-            if (assemblyName == "PepperDash_Essentials_Core")
-            {
-                return Assembly.LoadFrom("PepperDash.Essentials.Core.dll");
-            }
-
-            if (assemblyName == "Essentials Devices Common")
-            {
-                return Assembly.LoadFrom("PepperDash.Essentials.Devices.Common.dll");
-            }
-
-            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
pretty sure I had this method in there early in the 2.0 refactor when we were trying to work with the old assembly names; its unused