### PR TITLE
fix: add StreamUrl to baseStreamingDeviceProperties

### DIFF
--- a/src/PepperDash.Essentials.Core/Config/BaseStreamingDeviceProperties.cs
+++ b/src/PepperDash.Essentials.Core/Config/BaseStreamingDeviceProperties.cs
@@ -19,5 +19,11 @@ namespace PepperDash.Essentials.Core.Config
     /// </summary>
     [JsonProperty("multicastAudioAddress", NullValueHandling = NullValueHandling.Ignore)]
     public string MulticastAudioAddress { get; set; }
+
+    /// <summary>
+    /// The URL for the streaming device's media stream.
+    /// </summary>
+    [JsonProperty("streamUrl", NullValueHandling = NullValueHandling.Ignore)]
+    public string StreamUrl { get; set; }
   }
 }


### PR DESCRIPTION
This pull request adds a new property to the `BaseStreamingDeviceProperties` class to support configuration of a streaming device's media stream URL.

Streaming device configuration:

* Added a `StreamUrl` property to the `BaseStreamingDeviceProperties` class, allowing the media stream URL to be specified in configuration.