### PR TITLE
fix: add version to dll name for Essentials & PD Core

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
   <ItemGroup>    
-    <None Include="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).clz" Condition="$(ProjectType) == 'Library'">
+    <None Include="$(TargetDir)$(TargetName).$(TargetFramework).clz" Condition="$(ProjectType) == 'Library'">
       <Pack>true</Pack>
       <PackagePath>build;</PackagePath>
     </None>
-    <None Include="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cpz" Condition="$(ProjectType) == 'Program'">
+    <None Include="$(TargetDir)$(TargetName).$(TargetFramework).cpz" Condition="$(ProjectType) == 'Program'">
       <Pack>true</Pack>
       <PackagePath>build;</PackagePath>
     </None>
@@ -14,29 +14,29 @@
     </None>
   </ItemGroup>
   <PropertyGroup Condition="$(ProjectType) == 'Library'">
-    <FileName>$(TargetDir)$(TargetName).$(Version).$(TargetFramework).clz</FileName>
+    <FileName>$(TargetDir)$(TargetName).$(TargetFramework).clz</FileName>
   </PropertyGroup>
   <PropertyGroup Condition="$(ProjectType) == 'ProgramLibrary'">
     <FileName>$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cplz</FileName>
   </PropertyGroup>
   <PropertyGroup Condition="$(ProjectType) == 'Program'">
-    <FileName>$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cpz</FileName>
+    <FileName>$(TargetDir)$(TargetName).$(TargetFramework).cpz</FileName>
   </PropertyGroup>
 
   <Target Name="DeleteCLZ" BeforeTargets="PreBuildEvent" Condition="$(ProjectType) == 'Library' And $(TargetDir) != '' And Exists($(FileName))">
-    <Delete Files="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).clz">
+    <Delete Files="$(TargetDir)$(TargetName).$(TargetFramework).clz">
       <Output TaskParameter="DeletedFiles" ItemName="DeletedList"/>
     </Delete>
     <Message Text="Deleted files: '@(DeletedList)'" />
   </Target>
   <Target Name="DeleteCPZ" BeforeTargets="PreBuildEvent" Condition="$(ProjectType) == 'Program' And $(TargetDir) != '' And Exists($(FileName))">
-    <Delete Files="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cpz">
+    <Delete Files="$(TargetDir)$(TargetName).$(TargetFramework).cpz">
       <Output TaskParameter="DeletedFiles" ItemName="DeletedList"/>
     </Delete>
     <Message Text="Deleted files: '@(DeletedList)'" />
   </Target>
   <Target Name="DeleteCPLZ" BeforeTargets="PreBuildEvent" Condition="$(ProjectType) == 'ProgramLibrary' And $(TargetDir) != '' And Exists($(FileName))">
-    <Delete Files="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cplz">
+    <Delete Files="$(TargetDir)$(TargetName).$(TargetFramework).cplz">
       <Output TaskParameter="DeletedFiles" ItemName="DeletedList"/>
     </Delete>
     <Message Text="Deleted files: '@(DeletedList)'" />
@@ -50,12 +50,12 @@
   </Target>  
   <Target Name="Copy CLZ" AfterTargets="SimplSharpPostProcess" Condition="($(ProjectType) == 'Library')">
     <Message Text="Copying CLZ"></Message>
-    <Move SourceFiles="$(TargetDir)\$(TargetName).clz" DestinationFiles="$(TargetDir)\$(TargetName).$(Version).$(TargetFramework).clz"/>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).$(Version).$(TargetFramework).clz" DestinationFiles="$(PackageOutputPath)\$(TargetName).$(Version).$(TargetFramework).clz"/>
+    <Move SourceFiles="$(TargetDir)\$(TargetName).clz" DestinationFiles="$(TargetDir)\$(TargetName).$(TargetFramework).clz"/>
+    <Copy SourceFiles="$(TargetDir)\$(TargetName).$(TargetFramework).clz" DestinationFiles="$(PackageOutputPath)\$(TargetName).$(TargetFramework).clz"/>
   </Target>
   <Target Name="Copy CPZ" AfterTargets="SimplSharpPostProcess" Condition="($(ProjectType) == 'Program' And ( '$(TargetFramework)' != 'net6.0' ) And ( '$(TargetFramework)' != 'net8.0' ))">
     <Message Text="Copying CPZ"></Message>
-    <Move SourceFiles="$(TargetDir)$(TargetName).cpz" DestinationFiles="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cpz" />
-    <Copy SourceFiles="$(TargetDir)$(TargetName).$(Version).$(TargetFramework).cpz" DestinationFiles="$(PackageOutputPath)\$(TargetName).$(Version).$(TargetFramework).cpz" />
+    <Move SourceFiles="$(TargetDir)$(TargetName).cpz" DestinationFiles="$(TargetDir)$(TargetName).$(TargetFramework).cpz" />
+    <Copy SourceFiles="$(TargetDir)$(TargetName).$(TargetFramework).cpz" DestinationFiles="$(PackageOutputPath)\$(TargetName).$(TargetFramework).cpz" />
   </Target>
 </Project>

--- a/src/PepperDash.Core/PepperDash.Core.csproj
+++ b/src/PepperDash.Core/PepperDash.Core.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>PepperDash.Core</RootNamespace>
-    <AssemblyName>PepperDashCore</AssemblyName>
+    <AssemblyName>PepperDashCore-$(Version)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <Deterministic>true</Deterministic>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>PepperDash.Essentials</RootNamespace>
-    <AssemblyName>PepperDashEssentials</AssemblyName>
+    <AssemblyName>PepperDashEssentials-$(Version)</AssemblyName>
     <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <OutputPath>bin\$(Configuration)\</OutputPath>


### PR DESCRIPTION
This pull request updates the build and packaging logic to remove the use of the `$(Version)` variable from file names for build artifacts, simplifying file naming conventions and ensuring consistency. Additionally, it updates the assembly names in project files to include the version, making it easier to identify builds.

**Build and packaging logic simplification:**

* Removed the `$(Version)` variable from artifact file names in `Directory.Build.targets` for `.clz`, `.cpz`, and `.cplz` files, affecting both creation and deletion logic. [[1]](diffhunk://#diff-4da790e243fabc7a08eef8f04f251cff1a708fd1aa498a6508da5ecb2bce1564L3-R7) [[2]](diffhunk://#diff-4da790e243fabc7a08eef8f04f251cff1a708fd1aa498a6508da5ecb2bce1564L17-R39) [[3]](diffhunk://#diff-4da790e243fabc7a08eef8f04f251cff1a708fd1aa498a6508da5ecb2bce1564L53-R59)

**Project configuration updates:**

* Updated the `AssemblyName` property in `PepperDash.Core.csproj` to include the version, changing it from `PepperDashCore` to `PepperDashCore-$(Version)`.
* Updated the `AssemblyName` property in `PepperDash.Essentials.csproj` to include the version, changing it from `PepperDashEssentials` to `PepperDashEssentials-$(Version)`.

Progcomments output below:

<img width="538" height="244" alt="Screenshot 2025-08-26 at 2 02 05 PM" src="https://github.com/user-attachments/assets/b10a2167-9f4b-4a7b-8c68-0ebeb8293ffc" />
