### PR TITLE
feat: Add HideInUi property to room combiner classes

### DIFF
--- a/src/PepperDash.Essentials.Core/Room/Combining/EssentialsRoomCombinerPropertiesConfig.cs
+++ b/src/PepperDash.Essentials.Core/Room/Combining/EssentialsRoomCombinerPropertiesConfig.cs
@@ -104,6 +104,12 @@ namespace PepperDash.Essentials.Core
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to hide this scenario in the UI.
+        /// </summary>
+        [JsonProperty("hideInUi", NullValueHandling = NullValueHandling.Ignore)]
+        public bool HideInUi { get; set; }
+
+        /// <summary>
         /// Gets or sets the collection of partition states.
         /// </summary>
         [JsonProperty("partitionStates")]

--- a/src/PepperDash.Essentials.Core/Room/Combining/IEssentialsRoomCombiner.cs
+++ b/src/PepperDash.Essentials.Core/Room/Combining/IEssentialsRoomCombiner.cs
@@ -110,7 +110,7 @@ namespace PepperDash.Essentials.Core
         bool IsActive { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the entity is active.
+        /// Gets a value indicating whether this scenario should be hidden in the UI.
         /// </summary>
         [JsonProperty("hideInUi")]
         bool HideInUi { get; }

--- a/src/PepperDash.Essentials.Core/Room/Combining/IEssentialsRoomCombiner.cs
+++ b/src/PepperDash.Essentials.Core/Room/Combining/IEssentialsRoomCombiner.cs
@@ -110,6 +110,12 @@ namespace PepperDash.Essentials.Core
         bool IsActive { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the entity is active.
+        /// </summary>
+        [JsonProperty("hideInUi")]
+        bool HideInUi { get; }
+
+        /// <summary>
         /// Activates this room combination scenario
         /// </summary>
         Task Activate();

--- a/src/PepperDash.Essentials.Core/Room/Combining/RoomCombinationScenario.cs
+++ b/src/PepperDash.Essentials.Core/Room/Combining/RoomCombinationScenario.cs
@@ -14,18 +14,40 @@ namespace PepperDash.Essentials.Core
     {
         private RoomCombinationScenarioConfig _config;
 
+        /// <summary>
+        /// Gets or sets the key associated with the object.
+        /// </summary>
         [JsonProperty("key")]
         public string Key { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name associated with the object.
+        /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("partitionStates")]
+        /// <summary>
+        /// Gets a value indicating whether to hide this scenario in the UI.
+        /// </summary>
+        ///        
+        [JsonProperty("hideInUi")]
+
+        public bool HideInUi
+        {
+            get { return _config.HideInUi; }
+        }
+
         /// <summary>
         /// Gets or sets the PartitionStates
         /// </summary>
+        ///
+        [JsonProperty("partitionStates")]
+
         public List<PartitionState> PartitionStates { get; private set; }
 
+        /// <summary>
+        /// Determines which UI devices get mapped to which room in this scenario.  The Key should be the key of the UI device and the Value should be the key of the room to map to
+        /// </summary>
         [JsonProperty("uiMap")]
         public Dictionary<string, string> UiMap { get; set; }
 


### PR DESCRIPTION
This pull request introduces support for hiding room combination scenarios from the UI by adding a new `hideInUi` property to the relevant configuration and model classes. The property is now available in the configuration, interface, and implementation, ensuring it can be set in configuration files and accessed throughout the codebase.

**UI visibility control additions:**

* Added a `HideInUi` property to `RoomCombinationScenarioConfig` to allow scenarios to be hidden from the UI via configuration, with support for JSON serialization.
* Added a `HideInUi` property to the `IRoomCombinationScenario` interface to expose UI visibility control in the contract.
* Implemented the `HideInUi` property in the `RoomCombinationScenario` class, retrieving its value from the configuration.- Introduced `HideInUi` property in `EssentialsRoomCombinerPropertiesConfig` to control UI visibility.
- Added `HideInUi` interface property in `IEssentialsRoomCombiner`.
- Implemented `HideInUi` in `RoomCombinationScenario`, along with new `Key` and `Name` properties for improved data representation.