### PR TITLE
Hotfix/check for cs lan on mctp

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -200,9 +200,17 @@ namespace PepperDash.Essentials.Touchpanel
                 this.csSubnetMask = System.Net.IPAddress.Parse(csSubnetMask);
                 this.csIpAddress = System.Net.IPAddress.Parse(csIpAddress);
             }
-            catch
+            catch (ArgumentException)
             {
                 Debug.LogInformation("This processor does not have a CS LAN", this);
+            }
+            catch (InvalidOperationException)
+            {
+                Debug.LogInformation("This processor does not have a CS LAN", this);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Unexpected exception when checking CS LAN: {ex}", this);
             }
         }
 


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging in the `MobileControlTouchpanelController` class. The most important changes focus on making the code more robust against missing network adapters and providing clearer log messages for easier debugging.

Error handling improvements:
* Wrapped the retrieval of CS LAN adapter information in a `try-catch` block to prevent exceptions when the processor does not have a CS LAN, logging an informational message instead.

Logging enhancements:
* Updated the log message for app URL changes to include the new URL value, making it easier to trace changes.
* Added a missing `Serilog.Events` import to support structured logging.