### PR TITLE
fix: add InfinetEx to eControlMethods enum

### DIFF
--- a/src/PepperDash.Core/Comm/eControlMethods.cs
+++ b/src/PepperDash.Core/Comm/eControlMethods.cs
@@ -78,6 +78,10 @@ namespace PepperDash.Core
         /// <summary>
         /// Used when comms needs to be handled in SIMPL and bridged opposite the normal direction
         /// </summary>
-        ComBridge
+        ComBridge,
+        /// <summary>
+        /// InfinetEX control
+        /// </summary>
+        InfinetEx
     }
 }


### PR DESCRIPTION
This pull request makes a small update to the `eControlMethod` enum by adding a new value for InfinetEX control. This allows the codebase to explicitly support devices or communication handled via InfinetEX.

* Added `InfinetEx` as a new control method in the `eControlMethod` enum to support InfinetEX control scenarios.