### PR TITLE
Com102 comspec

### DIFF
--- a/src/PepperDash.Essentials.Core/Comm and IR/ComPortController.cs
+++ b/src/PepperDash.Essentials.Core/Comm and IR/ComPortController.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Crestron.SimplSharp;
 using Crestron.SimplSharpPro;
-
 using PepperDash.Core;
-using Serilog.Events;
 using PepperDash.Core.Logging;
-using Crestron.SimplSharpPro.GeneralIO;
+using Serilog.Events;
 
 
 namespace PepperDash.Essentials.Core


### PR DESCRIPTION
Tested with CEN-IO-COM-102 in Lab, confirmed device required `Port.Register()` to properly set the baud rate.  Web UI does reflect the current baud settings driven by code.