### PR TITLE
fix: use correct overload for PostStatusMessage

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/ThemeMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/ThemeMessenger.cs
@@ -40,7 +40,7 @@ namespace PepperDash.Essentials.Touchpanel
                 this.LogInformation("Setting theme to {theme}", theme.Value);
                 _tpDevice.UpdateTheme(theme.Value);
 
-                PostStatusMessage(JToken.FromObject(new { theme = theme.Value }), id);
+                PostStatusMessage(JToken.FromObject(new { theme = theme.Value }), clientId: id);
             });
         }
     }


### PR DESCRIPTION
This pull request makes a minor update to the `RegisterActions` method in `ThemeMessenger.cs` to clarify parameter usage when posting a status message.

- Changed the call to `PostStatusMessage` to use a named parameter (`clientId`) instead of a positional argument for `id`, improving code readability.