### PR TITLE
fix: make subscriber functionality thread-safe

### DIFF
--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
@@ -31,7 +31,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
         /// <remarks>
         /// Unsoliciited feedback from a device in a messenger will ONLY be sent to devices in this subscription list. When a client disconnects, it's ID will be removed from the collection.
         /// </remarks>
-        protected HashSet<string> SubscriberIds = new HashSet<string>();
+        private readonly HashSet<string> subscriberIds = new HashSet<string>();
 
         /// <summary>
         /// Lock object for thread-safe access to SubscriberIds
@@ -200,13 +200,11 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
             lock (_subscriberLock)
             {
-                if (SubscriberIds.Contains(clientId))
+                if (!subscriberIds.Add(clientId))
                 {
                     this.LogVerbose("Client {clientId} already subscribed", clientId);
                     return;
                 }
-
-                SubscriberIds.Add(clientId);
             }
 
             this.LogDebug("Client {clientId} subscribed", clientId);
@@ -227,10 +225,10 @@ namespace PepperDash.Essentials.AppServer.Messengers
             bool wasSubscribed;
             lock (_subscriberLock)
             {
-                wasSubscribed = SubscriberIds.Contains(clientId);
+                wasSubscribed = subscriberIds.Contains(clientId);
                 if (wasSubscribed)
                 {
-                    SubscriberIds.Remove(clientId);
+                    subscriberIds.Remove(clientId);
                 }
             }
 
@@ -332,7 +330,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
                     List<string> subscriberSnapshot;
                     lock (_subscriberLock)
                     {
-                        subscriberSnapshot = new List<string>(SubscriberIds);
+                        subscriberSnapshot = new List<string>(subscriberIds);
                     }
 
                     foreach (var client in subscriberSnapshot)


### PR DESCRIPTION
This pull request improves thread safety in the `MessengerBase` class by introducing locking around access to the `SubscriberIds` collection. This prevents potential issues when multiple threads subscribe, unsubscribe, or broadcast messages simultaneously. The main changes are focused on ensuring that all operations on `SubscriberIds` are performed in a thread-safe manner.

**Thread safety improvements:**

* Added a private lock object `_subscriberLock` to the `MessengerBase` class for synchronizing access to the `SubscriberIds` collection.
* Wrapped the addition of new subscribers in `SubscribeClient` with a lock to prevent race conditions and ensure a client is not added multiple times concurrently.
* Updated `UnsubscribeClient` to use locking when checking and removing a subscriber, ensuring consistency and preventing concurrent modification issues.
* In `PostStatusMessage`, created a snapshot of the `SubscriberIds` collection under a lock before iterating, preventing errors if the collection is modified during broadcasting.