### PR TITLE
fix: check for multiple URL patterns for both template & system URLS

### DIFF
--- a/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
@@ -36,21 +36,29 @@ namespace PepperDash.Essentials.Core.Config
         {
             get
             {
-                if (string.IsNullOrEmpty(SystemUrl))
-                    return "missing url";
+                string uuid;
 
-                if (SystemUrl.Contains("#"))
+                if (string.IsNullOrEmpty(SystemUrl))
+                {
+                    uuid = "missing url";
+                }
+                else if (SystemUrl.Contains("#"))
                 {
                     var result = Regex.Match(SystemUrl, @"https?:\/\/.*\/systems\/(.*)\/#.*");
-                    string uuid = result.Groups[1].Value;
-                    return uuid;
+                    uuid = result.Groups[1].Value;
+                }
+                else if (SystemUrl.Contains("detail"))
+                {
+                    var result = Regex.Match(SystemUrl, @"https?:\/\/.*\/systems\/detail\/(.*)\/.*");
+                    uuid = result.Groups[1].Value;
                 }
                 else
                 {
-                    var result = Regex.Match(SystemUrl, @"https?:\/\/.*\/systems\/detail\/(.*)\/.*");
-                    string uuid = result.Groups[1].Value;
-                    return uuid;
+                    var result = Regex.Match(SystemUrl, @"https?:\/\/.*\/systems\/(.*)\/.*");
+                    uuid = result.Groups[1].Value;
                 }
+
+                return uuid;
             }
         }
 
@@ -62,21 +70,29 @@ namespace PepperDash.Essentials.Core.Config
         {
             get
             {
-                if (string.IsNullOrEmpty(TemplateUrl))
-                    return "missing template url";
+                string uuid;
 
-                if (TemplateUrl.Contains("#"))
+                if (string.IsNullOrEmpty(TemplateUrl))
+                {
+                    uuid = "missing template url";
+                }
+                else if (TemplateUrl.Contains("#"))
                 {
                     var result = Regex.Match(TemplateUrl, @"https?:\/\/.*\/templates\/(.*)\/#.*");
-                    string uuid = result.Groups[1].Value;
-                    return uuid;
+                    uuid = result.Groups[1].Value;
+                }
+                else if (TemplateUrl.Contains("detail"))
+                {
+                    var result = Regex.Match(TemplateUrl, @"https?:\/\/.*\/system-templates\/detail\/(.*)\/system-template-versions\/detail\/(.*)\/.*");
+                    uuid = result.Groups[2].Value;
                 }
                 else
                 {
-                    var result = Regex.Match(TemplateUrl, @"https?:\/\/.*\/system-templates\/detail\/(.*)\/system-template-versions\/detail\/(.*)\/.*");
-                    string uuid = result.Groups[2].Value;
-                    return uuid;
+                    var result = Regex.Match(TemplateUrl, @"https?:\/\/.*\/system-templates\/(.*)\/system-template-versions\/(.*)\/.*");
+                    uuid = result.Groups[2].Value;
                 }
+
+                return uuid;
             }
         }
 


### PR DESCRIPTION
This pull request refactors the logic for extracting UUIDs from URLs in the `SystemUuid` and `TemplateUuid` properties in `EssentialsConfig.cs`. The updates improve readability and maintainability by consolidating repeated code and clarifying the extraction process.

**URL UUID extraction logic improvements:**

* Refactored the getter for `SystemUuid` to use a single `uuid` variable and consolidated the URL pattern matching logic, improving clarity and reducing code duplication.
* Refactored the getter for `TemplateUuid` in a similar fashion, using a single `uuid` variable and streamlining the regular expression matching for different URL formats.