### PR TITLE
feat: add help request timeout functionality to IEssentialsRoomFusion…

### DIFF
--- a/src/PepperDash.Essentials.Core/Fusion/IEssentialsRoomFusionController.cs
+++ b/src/PepperDash.Essentials.Core/Fusion/IEssentialsRoomFusionController.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Timers;
 
 namespace PepperDash.Essentials.Core.Fusion
 {
@@ -87,15 +88,17 @@ namespace PepperDash.Essentials.Core.Fusion
         /// <inheritdoc />
         public StringFeedback HelpRequestStatusFeedback { get; private set; }
 
+        private Timer _helpRequestTimeoutTimer;
 
-        #region System Info Sigs
+        /// <summary>
+        /// Gets the DefaultHelpRequestTimeoutMs
+        /// </summary>
+        public int HelpRequestTimeoutMs => _config.HelpRequestTimeoutMs;
 
-        //StringSigData SystemName;
-        //StringSigData Model;
-        //StringSigData SerialNumber;
-        //StringSigData Uptime;
-
-        #endregion
+        /// <summary>
+        /// Gets whether to use a timer for help requests
+        /// </summary>
+        public bool UseHelpRequestTimer => _config.UseTimeoutForHelpRequests;
 
         #region Processor Info Sigs
 
@@ -1805,7 +1808,7 @@ namespace PepperDash.Essentials.Core.Fusion
                             break;
                         case "Please call the helpdesk.":
                             // this.LogInformation("Please call the helpdesk.");
-                            // _helpRequestStatus = eFusionHelpResponse.CallHelpDesk;
+                            _helpRequestStatus = eFusionHelpResponse.CallHelpDesk;
                             break;
                         case "Please wait, I will reschedule your meeting to a different room.":
                             // this.LogInformation("Please wait, I will reschedule your meeting to a different room.",
@@ -1839,6 +1842,13 @@ namespace PepperDash.Essentials.Core.Fusion
                 }
 
                 HelpRequestStatusFeedback.FireUpdate();
+
+                if (_helpRequestTimeoutTimer != null)
+                {
+                    _helpRequestTimeoutTimer.Stop();
+                    _helpRequestTimeoutTimer.Dispose();
+                    _helpRequestTimeoutTimer = null;
+                }
             }
 
 
@@ -1909,8 +1919,37 @@ namespace PepperDash.Essentials.Core.Fusion
             _helpRequestSent = true;
             HelpRequestSentFeedback.FireUpdate();
 
+            if (UseHelpRequestTimer)
+            {
+                if (_helpRequestTimeoutTimer == null)
+                {
+                    _helpRequestTimeoutTimer = new Timer(HelpRequestTimeoutMs);
+                    _helpRequestTimeoutTimer.AutoReset = false;
+                    _helpRequestTimeoutTimer.Enabled = true;
+
+                    _helpRequestTimeoutTimer.Elapsed += OnTimedEvent;
+                }
+
+                _helpRequestTimeoutTimer.Interval = HelpRequestTimeoutMs;
+                _helpRequestTimeoutTimer.Start();
+
+                this.LogDebug("Help request timeout timer started for room '{0}' with timeout of {1} ms.",
+    Room.Name, HelpRequestTimeoutMs);
+            }
+
             _helpRequestStatus = eFusionHelpResponse.HelpRequested;
             HelpRequestStatusFeedback.FireUpdate();
+        }
+
+        private void OnTimedEvent(object source, ElapsedEventArgs e)
+        {
+            this.LogInformation("Help request timeout reached for room '{0}'. Cancelling help request.",
+    Room.Name);
+
+            CancelHelpRequest();
+            _helpRequestTimeoutTimer.Stop();
+            _helpRequestTimeoutTimer.Dispose();
+            _helpRequestTimeoutTimer = null;
         }
 
         /// <inheritdoc />
@@ -1923,7 +1962,7 @@ namespace PepperDash.Essentials.Core.Fusion
                 HelpRequestSentFeedback.FireUpdate();
                 _helpRequestStatus = eFusionHelpResponse.None;
                 HelpRequestStatusFeedback.FireUpdate();
-                Debug.LogMessage(LogEventLevel.Information, this, "Help request cancelled in Fusion for room '{0}'", Room.Name);
+                Debug.LogMessage(LogEventLevel.Information, this, "Help request cancelled for room '{0}'", Room.Name);
             }
         }
 

--- a/src/PepperDash.Essentials.Core/Fusion/IEssentialsRoomFusionControllerPropertiesConfig.cs
+++ b/src/PepperDash.Essentials.Core/Fusion/IEssentialsRoomFusionControllerPropertiesConfig.cs
@@ -56,4 +56,16 @@ public class IEssentialsRoomFusionControllerPropertiesConfig
     /// </summary>
     [JsonProperty("use24HourTimeFormat")]
     public bool Use24HourTimeFormat { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets whether to use a timeout for help requests
+    /// </summary>
+    [JsonProperty("useTimeoutForHelpRequests")]
+    public bool UseTimeoutForHelpRequests { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the timeout duration for help requests in milliseconds
+    /// </summary>
+    [JsonProperty("helpRequestTimeoutMs")]
+    public int HelpRequestTimeoutMs{ get; set; } = 30000;
 }


### PR DESCRIPTION
This pull request introduces a configurable timeout mechanism for help requests in the `IEssentialsRoomFusionController` class. The changes allow help requests to be automatically cancelled after a specified duration, improving system reliability and user experience. The timeout behavior is controlled via new configuration properties.

**Help Request Timeout Feature**

* Added new configuration properties `UseTimeoutForHelpRequests` and `HelpRequestTimeoutMs` to `IEssentialsRoomFusionControllerPropertiesConfig`, allowing help request timeouts to be enabled and customized via config.
* Implemented a `Timer` in `IEssentialsRoomFusionController` to track help request timeouts. When a help request is sent and the timer is enabled, the timer starts and cancels the request if the timeout is reached. [[1]](diffhunk://#diff-014b0b046aa106dce27881306ffaf88245b320af3f619ebfaf34411167e50e15R91-R101) [[2]](diffhunk://#diff-014b0b046aa106dce27881306ffaf88245b320af3f619ebfaf34411167e50e15R1922-R1954)
* On timeout, the system logs the event, cancels the help request, and disposes of the timer to prevent resource leaks.
* Ensured proper cleanup of the timer when a help request is resolved or cancelled, preventing multiple timers from running.

**Other Improvements**

* Fixed help request status assignment in the Fusion state change handler to ensure correct status updates.
* Minor logging message improvement for help request cancellation to clarify log output.…Controller