### PR TITLE
feat: updates core version with latest updates to genericTcpSocket

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,3 +1,3 @@
 <packages>
-	<package id="PepperDashCore" version="1.4.2" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
+	<package id="PepperDashCore" version="1.4.3" targetFramework="net35" allowedVersions="[1.0,2.0)"/>
 </packages>

--- a/src/PepperDashEssentials/PepperDashEssentials.csproj
+++ b/src/PepperDashEssentials/PepperDashEssentials.csproj
@@ -71,7 +71,7 @@
       <HintPath>..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.UI.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="PepperDash_Core, Version=1.3.3.32940, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="PepperDash_Core, Version=1.4.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>

--- a/src/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
+++ b/src/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj
@@ -83,7 +83,7 @@
       <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.UI.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="PepperDash_Core, Version=1.3.3.32940, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="PepperDash_Core, Version=1.4.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>

--- a/src/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
+++ b/src/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj
@@ -59,7 +59,7 @@
       <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.UI.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="PepperDash_Core, Version=1.3.3.32940, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="PepperDash_Core, Version=1.4.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>

--- a/src/essentials-framework/Essentials Devices Common/Essentials Devices Common/Essentials Devices Common.csproj
+++ b/src/essentials-framework/Essentials Devices Common/Essentials Devices Common/Essentials Devices Common.csproj
@@ -63,7 +63,7 @@
       <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.Lighting.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="PepperDash_Core, Version=1.3.3.32940, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="PepperDash_Core, Version=1.4.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\PepperDashCore\lib\net35\PepperDash_Core.dll</HintPath>
     </Reference>

--- a/src/essentials-framework/Essentials/PepperDashEssentials/PepperDashEssentials.csproj
+++ b/src/essentials-framework/Essentials/PepperDashEssentials/PepperDashEssentials.csproj
@@ -71,7 +71,7 @@
       <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\Crestron\SDK\SSPDevices\Crestron.SimplSharpPro.UI.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="PepperDash_Core, Version=1.0.3.27452, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="PepperDash_Core, Version=1.4.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Release Package\PepperDash_Core.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This pull request updates the dependency on the `PepperDashCore` library across several projects in the solution. All references to `PepperDash_Core` have been upgraded to version 1.4.3 to ensure consistency and to take advantage of any bug fixes or new features in the latest release.

Dependency upgrades:

* Updated the `PepperDashCore` NuGet package version from 1.4.2 to 1.4.3 in `packages.config`.
* Updated the `PepperDash_Core` assembly reference to version 1.4.3 in the following project files:
  - `src/PepperDashEssentials/PepperDashEssentials.csproj`
  - `src/essentials-framework/Essentials Core/PepperDashEssentialsBase/PepperDash_Essentials_Core.csproj`
  - `src/essentials-framework/Essentials DM/Essentials_DM/PepperDash_Essentials_DM.csproj`
  - `src/essentials-framework/Essentials Devices Common/Essentials Devices Common/Essentials Devices Common.csproj`
  - `src/essentials-framework/Essentials/PepperDashEssentials/PepperDashEssentials.csproj`