### PR TITLE
fix: DeviceVolumeMessenger only sends rawValue when device implements it

### DIFF
--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/DeviceVolumeMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/DeviceVolumeMessenger.cs
@@ -130,33 +130,32 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
             feedback.MuteFeedback.OutputChange += (sender, args) =>
             {
-                PostStatusMessage(JToken.FromObject(
-                        new
-                        {
-                            volume = new
-                            {
-                                muted = args.BoolValue
-                            }
-                        })
-                );
+                var message = new VolumeStateMessage
+                {
+                    Volume = new Volume
+                    {
+                        Muted = args.BoolValue
+                    }
+                };
+
+                PostStatusMessage(JToken.FromObject(message));
             };
 
             feedback.VolumeLevelFeedback.OutputChange += (sender, args) =>
             {
-                var rawValue = "";
-                if (feedback is IBasicVolumeWithFeedbackAdvanced volumeAdvanced)
+                var message = new VolumeStateMessage
                 {
-                    rawValue = volumeAdvanced.RawVolumeLevel.ToString();
-                }
-
-                var message = new
-                {
-                    volume = new
+                    Volume = new Volume
                     {
-                        level = args.IntValue,
-                        rawValue
+                        Level = args.IntValue,
                     }
                 };
+
+                if (device is IBasicVolumeWithFeedbackAdvanced volumeAdvanced)
+                {
+                    message.Volume.RawValue = volumeAdvanced.RawVolumeLevel.ToString();
+                    message.Volume.Units = volumeAdvanced.Units;
+                }
 
                 PostStatusMessage(JToken.FromObject(message));
             };


### PR DESCRIPTION
This pull request refactors the way volume state messages are constructed and posted in the `DeviceVolumeMessenger` class. The changes improve code clarity and consistency by using a dedicated `VolumeStateMessage` object instead of anonymous objects when reporting mute and volume level changes.

Refactoring and code clarity improvements:

* Replaced anonymous objects with the strongly-typed `VolumeStateMessage` and `Volume` classes for both mute and volume level feedback, making the message structure more explicit and maintainable.
* Ensured that additional volume properties (`RawValue`, `Units`) are included in the message when available, improving the completeness of the volume state reporting.