### PR TITLE
fix: handle subsequent join calls and clientid/websocket client mismatches

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/WebSocketServer/UiClient.cs
+++ b/src/PepperDash.Essentials.MobileControl/WebSocketServer/UiClient.cs
@@ -27,6 +27,15 @@ namespace PepperDash.Essentials.WebSocketServer
         public string Id { get; private set; }
 
         /// <summary>
+        /// Updates the client ID - only accessible from within the assembly (e.g., by the server)
+        /// </summary>
+        /// <param name="newId">The new client ID</param>
+        internal void UpdateId(string newId)
+        {
+            Id = newId;
+        }
+
+        /// <summary>
         /// Token associated with this client
         /// </summary>
         public string Token { get; private set; }


### PR DESCRIPTION
This pull request updates the handling of legacy client registrations in the `MobileControlWebsocketServer` to improve robustness and support for duplicate join requests, and introduces the ability to update a client's ID after registration. The main changes include replacing the legacy FIFO queue with a timestamped registration bag, updating the client ID management logic, and adding a method to update a client's ID safely.

**Legacy Client Registration Improvements:**

* Replaced `legacyClientIdQueues` (FIFO queue per token) with `legacyClientRegistrations`, a `ConcurrentBag` storing `(clientId, timestamp)` tuples, allowing the server to always use the most recent registration for a given token. [[1]](diffhunk://#diff-6e01bd6c5c4b47efbd65b5be4fb52514db57c785d612b5222e202018fa60799dL72-R76) [[2]](diffhunk://#diff-6e01bd6c5c4b47efbd65b5be4fb52514db57c785d612b5222e202018fa60799dR1197-R1207)
* Updated the legacy client ID assignment logic in `BuildUiClient` to select and remove the most recent client ID for a token, instead of dequeuing the oldest, improving support for duplicate join requests.
* Adjusted cleanup logic to remove empty legacy registration bags instead of empty queues.

**Client ID Management Enhancements:**

* Added a new `UpdateClientId` method to `MobileControlWebsocketServer` to handle situations where a client's ID needs to be updated after registration, with checks for registration validity and safe updating in the `uiClients` collection.
* Added an `UpdateId` internal method to the `UiClient` class to allow the server to update the client ID in a controlled manner.