### PR TITLE
docs: fix capitalization error in toc

### DIFF
--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -4,7 +4,7 @@
 - name: How-to's
   items:
   - name: How to add an article or doc page
-    href: how-to/How-to-add-docs.md
+    href: how-to/how-to-add-docs.md
 - name: Usage
   items:
   - href: usage/Standalone-Use.md    


### PR DESCRIPTION
This pull request makes a minor documentation fix by correcting a link in the table of contents to use the proper filename casing for the "How to add an article or doc page" guide.