### PR TITLE
Feature/add i has web view with pwa mode

### DIFF
--- a/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasWebView.cs
+++ b/src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasWebView.cs
@@ -48,7 +48,7 @@ namespace PepperDash.Essentials.Core.DeviceTypeInterfaces
         bool IsInPwaMode { get; }
 
         /// <summary>
-        /// Indicates whether the webview is currently in PWA mode
+        /// Gets the BoolFeedback indicating whether the webview is currently in PWA mode
         /// </summary>
         BoolFeedback IsInPwaModeFeedback { get; }
 


### PR DESCRIPTION
This pull request introduces a new interface to extend webview functionality with support for Progressive Web App (PWA) mode. The main change is the addition of `IHasWebViewWithPwaMode`, which provides properties and methods to manage PWA mode in devices implementing webview interfaces.

Extension of webview interfaces:

* Added the `IHasWebViewWithPwaMode` interface to `src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasWebView.cs`, extending `IHasWebView` with properties for checking PWA mode status (`IsInPwaMode`, `IsInPwaModeFeedback`) and methods to send navigators to a PWA URL and exit PWA mode.

No functional changes:

* Minor formatting changes and extra newlines at the end of `src/PepperDash.Essentials.Core/DeviceTypeInterfaces/IHasWebView.cs`.