### PR TITLE
feat: implement constructor for BridgeApi with key and name parameters

### DIFF
--- a/src/PepperDash.Essentials.Core/Bridges/BridgeBase.cs
+++ b/src/PepperDash.Essentials.Core/Bridges/BridgeBase.cs
@@ -30,6 +30,17 @@ namespace PepperDash.Essentials.Core.Bridges
         {
 
         }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="name"></param>
+        protected BridgeApi(string key, string name) :
+            base(key, name)
+        {
+
+        }
     }
 
     /// <summary>
@@ -58,7 +69,7 @@ namespace PepperDash.Essentials.Core.Bridges
         /// <param name="dc">Device configuration</param>
         /// <param name="eisc">EISC instance</param>
         public EiscApiAdvanced(DeviceConfig dc, BasicTriList eisc) :
-            base(dc.Key)
+            base(dc.Key, dc.Name)
         {
             JoinMaps = new Dictionary<string, JoinMapBaseAdvanced>();
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the bridge API infrastructure by adding support for passing a `name` parameter to the `BridgeApi` constructor. This allows for more descriptive instantiation of bridge APIs, particularly when creating advanced EISC API objects.

Constructor enhancements:

* Added a new protected constructor to the `BridgeApi` class that accepts both `key` and `name` parameters, enabling derived classes to specify a device name during instantiation.
* Updated the `EiscApiAdvanced` class to use the new `BridgeApi` constructor, passing both `dc.Key` and `dc.Name` for improved clarity and consistency.