### PR TITLE
fix: clean up unused using directives and add firmware version check …

### DIFF
--- a/src/PepperDash.Core/Logging/Debug.cs
+++ b/src/PepperDash.Core/Logging/Debug.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Crestron.SimplSharp;

--- a/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
+++ b/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
@@ -51,8 +51,10 @@ namespace PepperDash.Core
                 if (service == null) return "";
 
                 // Use CSLAN IP if available, otherwise fallback to primary IP. This ensures we provide a reachable URL in dual-stack environments.
-                if (!string.IsNullOrEmpty(CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 1)))
-                    return $"wss://{CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 1)}:{_httpsServer.Port}{service.Path}";
+                var cslanIp = CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 1);
+                if (!string.IsNullOrEmpty(cslanIp) && cslanIp != "Invalid Value")
+                    return $"wss://{cslanIp}:{_httpsServer.Port}{service.Path}";
                 else
                     return $"wss://{CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0)}:{_httpsServer.Port}{service.Path}";
             }

--- a/src/PepperDash.Essentials/ControlSystem.cs
+++ b/src/PepperDash.Essentials/ControlSystem.cs
@@ -27,6 +27,8 @@ namespace PepperDash.Essentials
         private CEvent _initializeEvent;
         private const long StartupTime = 500;
 
+        private const string minimumFirmwareVersion = "2.8006.00110";
+
         /// <summary>
         /// Initializes a new instance of the ControlSystem class
         /// </summary>
@@ -46,6 +48,24 @@ namespace PepperDash.Essentials
         /// <inheritdoc />
         public override void InitializeSystem()
         {
+
+            // Get FW version and stop if it's too low to run this version of Essentials.  Must be greater than v2.8006.00110
+            var fwVersion = InitialParametersClass.FirmwareVersion;
+
+            Debug.LogInformation("Control System Hardware Version: {fwVersion}", fwVersion);
+
+            // split the version into parts and compare against minimumFirmwareVersion
+            var versionParts = fwVersion.Split('.').Select(int.Parse).ToArray();
+            var minParts = minimumFirmwareVersion.Split('.').Select(int.Parse).ToArray();
+            if (versionParts.Length < minParts.Length
+                || versionParts[0] < minParts[0]
+                || (versionParts[0] == minParts[0] && versionParts[1] < minParts[1])
+                || (versionParts[0] == minParts[0] && versionParts[1] == minParts[1] && versionParts[2] <= minParts[2]))
+            {
+                Debug.LogFatal("Firmware version {fwVersion} is too low to run this version of Essentials. Please upgrade to greater than v{minimumFirmwareVersion}.", fwVersion, minimumFirmwareVersion);
+                return;
+            }
+
             // If the control system is a DMPS type, we need to wait to exit this method until all devices have had time to activate
             // to allow any HD-BaseT DM endpoints to register first.
             bool preventInitializationComplete = Global.ControlSystemIsDmpsType;


### PR DESCRIPTION
This pull request introduces a minimum firmware version check to the `ControlSystem` class in `PepperDash.Essentials`, ensuring that the application only runs on supported firmware. Additionally, it improves the logic for determining the WebSocket URL in dual-stack environments and performs a minor cleanup in the `Debug.cs` file.

**Firmware version enforcement:**

* Added a `minimumFirmwareVersion` constant and logic in `ControlSystem.InitializeSystem()` to check the device firmware version at startup. If the firmware is below the required version (`2.8006.00110`), the system logs a fatal error and halts initialization. This prevents the application from running on unsupported hardware. [[1]](diffhunk://#diff-497bfd7d65516cda5fa2ed0ff1f25336f07fed304acd6eb1a733ec8fd8876e22R30-R31) [[2]](diffhunk://#diff-497bfd7d65516cda5fa2ed0ff1f25336f07fed304acd6eb1a733ec8fd8876e22R51-R68)

**Networking improvements:**

* Updated the `Url` property in `DebugWebsocketSink` to ignore invalid CSLAN IP addresses (e.g., "Invalid Value") and reliably select a reachable IP address in dual-stack environments.

**Code cleanup:**

* Removed an unnecessary `using System.Net;` directive from `Debug.cs` to tidy up unused imports.…in ControlSystem