### PR TITLE
feat: mark deprecated classes and methods for future removal

### DIFF
--- a/src/PepperDash.Core/Logging/DebugContext.cs
+++ b/src/PepperDash.Core/Logging/DebugContext.cs
@@ -11,6 +11,7 @@ namespace PepperDash.Core
     /// <summary>
     /// Represents a debugging context
     /// </summary>
+    [Obsolete("DebugContext is no longer supported and will be removed in a future release.")]
     public class DebugContext
     {
         /// <summary>

--- a/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
+++ b/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Crestron.SimplSharp;                          				// For Basic SIMPL# Classes
+using Crestron.SimplSharp;                                          // For Basic SIMPL# Classes
 using Crestron.SimplSharp.CrestronIO;
 using Crestron.SimplSharp.Net.Http;
 using Crestron.SimplSharp.Net.Https;
@@ -10,24 +10,25 @@ using PepperDash.Core.JsonToSimpl;
 
 namespace PepperDash.Core.WebApi.Presets
 {
-    /// <summary>
-    /// Passcode client for the WebApi
-    /// </summary>
+	/// <summary>
+	/// Passcode client for the WebApi
+	/// </summary>
+	[Obsolete("WebApiPasscodeClient is no longer supported and will be removed in a future release.")]
 	public class WebApiPasscodeClient : IKeyed
 	{
-        /// <summary>
-        /// Notifies when user received
-        /// </summary>
+		/// <summary>
+		/// Notifies when user received
+		/// </summary>
 		public event EventHandler<UserReceivedEventArgs> UserReceived;
 
-        /// <summary>
-        /// Notifies when Preset received
-        /// </summary>
+		/// <summary>
+		/// Notifies when Preset received
+		/// </summary>
 		public event EventHandler<PresetReceivedEventArgs> PresetReceived;
 
-  /// <summary>
-  /// Gets or sets the Key
-  /// </summary>
+		/// <summary>
+		/// Gets or sets the Key
+		/// </summary>
 		public string Key { get; private set; }
 
 		//string JsonMasterKey;
@@ -54,13 +55,13 @@ namespace PepperDash.Core.WebApi.Presets
 		{
 		}
 
-        /// <summary>
-        /// Initializes the instance
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="jsonMasterKey"></param>
-        /// <param name="urlBase"></param>
-        /// <param name="defaultPresetJsonFilePath"></param>
+		/// <summary>
+		/// Initializes the instance
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="jsonMasterKey"></param>
+		/// <param name="urlBase"></param>
+		/// <param name="defaultPresetJsonFilePath"></param>
 		public void Initialize(string key, string jsonMasterKey, string urlBase, string defaultPresetJsonFilePath)
 		{
 			Key = key;
@@ -73,44 +74,44 @@ namespace PepperDash.Core.WebApi.Presets
 			J2SMaster.Initialize(jsonMasterKey);
 		}
 
-        /// <summary>
-        /// Gets the user for a passcode
-        /// </summary>
-        /// <param name="passcode"></param>
-  /// <summary>
-  /// GetUserForPasscode method
-  /// </summary>
+		/// <summary>
+		/// Gets the user for a passcode
+		/// </summary>
+		/// <param name="passcode"></param>
+		/// <summary>
+		/// GetUserForPasscode method
+		/// </summary>
 		public void GetUserForPasscode(string passcode)
 		{
-            // Bullshit duplicate code here... These two cases should be the same 
-            // except for https/http and the certificate ignores 
-            if (!UrlBase.StartsWith("https"))
-                return;
-            var req = new HttpsClientRequest();
-            req.Url = new UrlParser(UrlBase + "/api/users/dopin");
-            req.RequestType = Crestron.SimplSharp.Net.Https.RequestType.Post;
-            req.Header.AddHeader(new HttpsHeader("Content-Type", "application/json"));
-            req.Header.AddHeader(new HttpsHeader("Accept", "application/json"));
-            var jo = new JObject();
-            jo.Add("pin", passcode);
-            req.ContentString = jo.ToString();
+			// Bullshit duplicate code here... These two cases should be the same 
+			// except for https/http and the certificate ignores 
+			if (!UrlBase.StartsWith("https"))
+				return;
+			var req = new HttpsClientRequest();
+			req.Url = new UrlParser(UrlBase + "/api/users/dopin");
+			req.RequestType = Crestron.SimplSharp.Net.Https.RequestType.Post;
+			req.Header.AddHeader(new HttpsHeader("Content-Type", "application/json"));
+			req.Header.AddHeader(new HttpsHeader("Accept", "application/json"));
+			var jo = new JObject();
+			jo.Add("pin", passcode);
+			req.ContentString = jo.ToString();
 
-            var client = new HttpsClient();
-            client.HostVerification = false;
-            client.PeerVerification = false;
-            var resp = client.Dispatch(req);
-            var handler = UserReceived;
-            if (resp.Code == 200)
-            {
-                //CrestronConsole.PrintLine("Received: {0}", resp.ContentString);
-                var user = JsonConvert.DeserializeObject<User>(resp.ContentString);
-                CurrentUser = user;
-                if (handler != null)
-                    UserReceived(this, new UserReceivedEventArgs(user, true));
-            }
-            else
-                if (handler != null)
-                    UserReceived(this, new UserReceivedEventArgs(null, false));
+			var client = new HttpsClient();
+			client.HostVerification = false;
+			client.PeerVerification = false;
+			var resp = client.Dispatch(req);
+			var handler = UserReceived;
+			if (resp.Code == 200)
+			{
+				//CrestronConsole.PrintLine("Received: {0}", resp.ContentString);
+				var user = JsonConvert.DeserializeObject<User>(resp.ContentString);
+				CurrentUser = user;
+				if (handler != null)
+					UserReceived(this, new UserReceivedEventArgs(user, true));
+			}
+			else
+				if (handler != null)
+					UserReceived(this, new UserReceivedEventArgs(null, false));
 		}
 
 		/// <summary>
@@ -118,9 +119,9 @@ namespace PepperDash.Core.WebApi.Presets
 		/// </summary>
 		/// <param name="roomTypeId"></param>
 		/// <param name="presetNumber"></param>
-  /// <summary>
-  /// GetPresetForThisUser method
-  /// </summary>
+		/// <summary>
+		/// GetPresetForThisUser method
+		/// </summary>
 		public void GetPresetForThisUser(int roomTypeId, int presetNumber)
 		{
 			if (CurrentUser == null)
@@ -136,57 +137,57 @@ namespace PepperDash.Core.WebApi.Presets
 				PresetNumber = presetNumber
 			};
 
-            var handler = PresetReceived;
+			var handler = PresetReceived;
 			try
 			{
-                if (!UrlBase.StartsWith("https"))
-                    return;
-                var req = new HttpsClientRequest();
-                req.Url = new UrlParser(UrlBase + "/api/presets/userandroom");
-                req.RequestType = Crestron.SimplSharp.Net.Https.RequestType.Post;
-                req.Header.AddHeader(new HttpsHeader("Content-Type", "application/json"));
-                req.Header.AddHeader(new HttpsHeader("Accept", "application/json"));
-                req.ContentString = JsonConvert.SerializeObject(msg);
+				if (!UrlBase.StartsWith("https"))
+					return;
+				var req = new HttpsClientRequest();
+				req.Url = new UrlParser(UrlBase + "/api/presets/userandroom");
+				req.RequestType = Crestron.SimplSharp.Net.Https.RequestType.Post;
+				req.Header.AddHeader(new HttpsHeader("Content-Type", "application/json"));
+				req.Header.AddHeader(new HttpsHeader("Accept", "application/json"));
+				req.ContentString = JsonConvert.SerializeObject(msg);
 
-                var client = new HttpsClient();
-                client.HostVerification = false;
-                client.PeerVerification = false;
+				var client = new HttpsClient();
+				client.HostVerification = false;
+				client.PeerVerification = false;
 
-                // ask for the preset
-                var resp = client.Dispatch(req);
-                if (resp.Code == 200) // got it
-                {
-                    //Debug.Console(1, this, "Received: {0}", resp.ContentString);
-                    var preset = JsonConvert.DeserializeObject<Preset>(resp.ContentString);
-                    CurrentPreset = preset;
+				// ask for the preset
+				var resp = client.Dispatch(req);
+				if (resp.Code == 200) // got it
+				{
+					//Debug.Console(1, this, "Received: {0}", resp.ContentString);
+					var preset = JsonConvert.DeserializeObject<Preset>(resp.ContentString);
+					CurrentPreset = preset;
 
-                    //if there's no preset data, load the template
-                    if (preset.Data == null || preset.Data.Trim() == string.Empty || JObject.Parse(preset.Data).Count == 0)
-                    {
-                        //Debug.Console(1, this, "Loaded preset has no data. Loading default template.");
-                        LoadDefaultPresetData();
-                        return;
-                    }
+					//if there's no preset data, load the template
+					if (preset.Data == null || preset.Data.Trim() == string.Empty || JObject.Parse(preset.Data).Count == 0)
+					{
+						//Debug.Console(1, this, "Loaded preset has no data. Loading default template.");
+						LoadDefaultPresetData();
+						return;
+					}
 
-                    J2SMaster.LoadWithJson(preset.Data);
-                    if (handler != null)
-                        PresetReceived(this, new PresetReceivedEventArgs(preset, true));
-                }
-                else // no existing preset
-                {
-                    CurrentPreset = new Preset();
-                    LoadDefaultPresetData();
-                    if (handler != null)
-                        PresetReceived(this, new PresetReceivedEventArgs(null, false));
-                }
+					J2SMaster.LoadWithJson(preset.Data);
+					if (handler != null)
+						PresetReceived(this, new PresetReceivedEventArgs(preset, true));
+				}
+				else // no existing preset
+				{
+					CurrentPreset = new Preset();
+					LoadDefaultPresetData();
+					if (handler != null)
+						PresetReceived(this, new PresetReceivedEventArgs(null, false));
+				}
 			}
 			catch (HttpException e)
 			{
 				var resp = e.Response;
 				Debug.Console(1, this, "No preset received (code {0}). Loading default template", resp.Code);
 				LoadDefaultPresetData();
-                if (handler != null)
-                    PresetReceived(this, new PresetReceivedEventArgs(null, false));
+				if (handler != null)
+					PresetReceived(this, new PresetReceivedEventArgs(null, false));
 			}
 		}
 
@@ -218,14 +219,14 @@ namespace PepperDash.Core.WebApi.Presets
 		/// </summary>
 		/// <param name="roomTypeId"></param>
 		/// <param name="presetNumber"></param>
-  /// <summary>
-  /// SavePresetForThisUser method
-  /// </summary>
+		/// <summary>
+		/// SavePresetForThisUser method
+		/// </summary>
 		public void SavePresetForThisUser(int roomTypeId, int presetNumber)
 		{
 			if (CurrentPreset == null)
 				LoadDefaultPresetData();
-				//return;
+			//return;
 
 			//// A new preset needs to have its numbers set
 			//if (CurrentPreset.IsNewPreset)
@@ -245,8 +246,8 @@ namespace PepperDash.Core.WebApi.Presets
 		{
 			CurrentPreset.Data = json;
 
-            if (!UrlBase.StartsWith("https"))
-                return;
+			if (!UrlBase.StartsWith("https"))
+				return;
 			var req = new HttpsClientRequest();
 			req.RequestType = Crestron.SimplSharp.Net.Https.RequestType.Post;
 			req.Url = new UrlParser(string.Format("{0}/api/presets/addorchange", UrlBase));
@@ -255,8 +256,8 @@ namespace PepperDash.Core.WebApi.Presets
 			req.ContentString = JsonConvert.SerializeObject(CurrentPreset);
 
 			var client = new HttpsClient();
-            client.HostVerification = false;
-            client.PeerVerification = false;
+			client.HostVerification = false;
+			client.PeerVerification = false;
 			try
 			{
 				var resp = client.Dispatch(req);

--- a/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
+++ b/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
@@ -171,14 +171,14 @@ namespace PepperDash.Core.WebApi.Presets
 
 					J2SMaster.LoadWithJson(preset.Data);
 					if (handler != null)
-						PresetReceived(this, new PresetReceivedEventArgs(preset, true));
+						handler(this, new PresetReceivedEventArgs(preset, true));
 				}
 				else // no existing preset
 				{
 					CurrentPreset = new Preset();
 					LoadDefaultPresetData();
 					if (handler != null)
-						PresetReceived(this, new PresetReceivedEventArgs(null, false));
+						handler(this, new PresetReceivedEventArgs(null, false));
 				}
 			}
 			catch (HttpException e)

--- a/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
+++ b/src/PepperDash.Core/WebApi/Presets/WebApiPasscodeClient.cs
@@ -107,11 +107,11 @@ namespace PepperDash.Core.WebApi.Presets
 				var user = JsonConvert.DeserializeObject<User>(resp.ContentString);
 				CurrentUser = user;
 				if (handler != null)
-					UserReceived(this, new UserReceivedEventArgs(user, true));
+					handler(this, new UserReceivedEventArgs(user, true));
 			}
 			else
 				if (handler != null)
-					UserReceived(this, new UserReceivedEventArgs(null, false));
+					handler(this, new UserReceivedEventArgs(null, false));
 		}
 
 		/// <summary>

--- a/src/PepperDash.Essentials.Core/Config/Essentials/ConfigUpdater.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/ConfigUpdater.cs
@@ -19,6 +19,7 @@ namespace PepperDash.Essentials.Core.Config
     /// <summary>
     /// ConfigUpdater class
     /// </summary>
+    [Obsolete("ConfigUpdater is no longer supported and will be removed in a future release.")]
     public static class ConfigUpdater
     {
         /// <summary>
@@ -81,7 +82,7 @@ namespace PepperDash.Essentials.Core.Config
         {
             var handler = ConfigStatusChanged;
 
-            if(handler != null)
+            if (handler != null)
             {
                 handler(typeof(ConfigUpdater), new ConfigStatusEventArgs(status));
             }
@@ -89,7 +90,7 @@ namespace PepperDash.Essentials.Core.Config
 
         static void WriteConfigToFile(string configData)
         {
-            var filePath = Global.FilePathPrefix+ "configurationFile-updated.json";
+            var filePath = Global.FilePathPrefix + "configurationFile-updated.json";
 
             try
             {
@@ -104,7 +105,7 @@ namespace PepperDash.Essentials.Core.Config
                 Debug.LogMessage(LogEventLevel.Debug, "Error parsing new config: {0}", e);
 
                 OnStatusUpdate(eUpdateStatus.UpdateFailed);
-            }           
+            }
         }
 
         /// <summary>
@@ -149,11 +150,11 @@ namespace PepperDash.Essentials.Core.Config
                 // Directory exists, first clear any contents
                 var archivedConfigFiles = ConfigReader.GetConfigFiles(archiveDirectoryPath + Global.DirectorySeparator + Global.ConfigFileName + ".bak");
 
-                if(archivedConfigFiles != null || archivedConfigFiles.Length > 0)
+                if (archivedConfigFiles != null || archivedConfigFiles.Length > 0)
                 {
                     Debug.LogMessage(LogEventLevel.Information, "{0} Existing files found in archive folder.  Deleting.", archivedConfigFiles.Length);
 
-                    for (int i = 0; i < archivedConfigFiles.Length; i++ )
+                    for (int i = 0; i < archivedConfigFiles.Length; i++)
                     {
                         var file = archivedConfigFiles[i];
                         Debug.LogMessage(LogEventLevel.Information, "Deleting archived file: '{0}'", file.FullName);
@@ -170,9 +171,9 @@ namespace PepperDash.Essentials.Core.Config
 
                 // Moves the file and appends the .bak extension
                 var fileDest = archiveDirectoryPath + "/" + file.Name + ".bak";
-                if(!File.Exists(fileDest))
+                if (!File.Exists(fileDest))
                 {
-                  file.MoveTo(fileDest);
+                    file.MoveTo(fileDest);
                 }
                 else
                     Debug.LogMessage(LogEventLevel.Information, "Cannot move file to archive folder.  Existing file already exists with same name: '{0}'", fileDest);
@@ -207,15 +208,15 @@ namespace PepperDash.Essentials.Core.Config
 
             CrestronConsole.SendControlSystemCommand(string.Format("progreset -p:{0}", InitialParametersClass.ApplicationNumber), ref response);
 
-            Debug.LogMessage(LogEventLevel.Debug, "Console Response: {0}", response);          
+            Debug.LogMessage(LogEventLevel.Debug, "Console Response: {0}", response);
         }
 
     }
 
-        /// <summary>
-        /// Enumeration of eUpdateStatus values
-        /// </summary>
-        public enum eUpdateStatus
+    /// <summary>
+    /// Enumeration of eUpdateStatus values
+    /// </summary>
+    public enum eUpdateStatus
     {
         /// <summary>
         /// UpdateStarted status

--- a/src/PepperDash.Essentials.Core/Config/Essentials/ConfigUpdater.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/ConfigUpdater.cs
@@ -150,7 +150,7 @@ namespace PepperDash.Essentials.Core.Config
                 // Directory exists, first clear any contents
                 var archivedConfigFiles = ConfigReader.GetConfigFiles(archiveDirectoryPath + Global.DirectorySeparator + Global.ConfigFileName + ".bak");
 
-                if (archivedConfigFiles != null || archivedConfigFiles.Length > 0)
+                if (archivedConfigFiles != null && archivedConfigFiles.Length > 0)
                 {
                     Debug.LogMessage(LogEventLevel.Information, "{0} Existing files found in archive folder.  Deleting.", archivedConfigFiles.Length);
 

--- a/src/PepperDash.Essentials.Core/Interfaces/ILogStrings.cs
+++ b/src/PepperDash.Essentials.Core/Interfaces/ILogStrings.cs
@@ -7,9 +7,10 @@ using PepperDash.Core;
 
 namespace PepperDash.Essentials.Core.Interfaces
 {
- /// <summary>
- /// Defines the contract for ILogStrings
- /// </summary>
+	/// <summary>
+	/// Defines the contract for ILogStrings
+	/// </summary>
+	[Obsolete("ILogStrings is no longer supported and will be removed in a future release.")]
 	public interface ILogStrings : IKeyed
 	{
 		/// <summary>

--- a/src/PepperDash.Essentials.Core/Interfaces/ILogStringsWithLevel.cs
+++ b/src/PepperDash.Essentials.Core/Interfaces/ILogStringsWithLevel.cs
@@ -7,15 +7,16 @@ using PepperDash.Core;
 
 namespace PepperDash.Essentials.Core.Interfaces
 {
- /// <summary>
- /// Defines the contract for ILogStringsWithLevel
- /// </summary>
+	/// <summary>
+	/// Defines the contract for ILogStringsWithLevel
+	/// </summary>
+	[Obsolete("ILogStringsWithLevel is no longer supported and will be removed in a future release.")]
 	public interface ILogStringsWithLevel : IKeyed
 	{
 		/// <summary>
 		/// Defines a class that is capable of logging a string with an int level
 		/// </summary>
-		void SendToLog(IKeyed device, Debug.ErrorLogLevel level,string logMessage);
+		void SendToLog(IKeyed device, Debug.ErrorLogLevel level, string logMessage);
 	}
 
 }

--- a/src/PepperDash.Essentials.Core/Routing/eRoutingSignalType.cs
+++ b/src/PepperDash.Essentials.Core/Routing/eRoutingSignalType.cs
@@ -27,16 +27,19 @@ namespace PepperDash.Essentials.Core
         /// <summary>
         /// Control signal type
         /// </summary>
+        [Obsolete("UsbOutput is no longer supported and will be removed in a future release.")]
         UsbOutput = 8,
 
         /// <summary>
         /// Control signal type
         /// </summary>
+        [Obsolete("UsbInput is no longer supported and will be removed in a future release.")]
         UsbInput = 16,
 
         /// <summary>
         /// Secondary audio signal type
         /// </summary>
+        [Obsolete("SecondaryAudio is no longer supported and will be removed in a future release.")]
         SecondaryAudio = 32
 	}
 }

--- a/src/PepperDash.Essentials.Devices.Common/Cameras/CameraVisca.cs
+++ b/src/PepperDash.Essentials.Devices.Common/Cameras/CameraVisca.cs
@@ -17,6 +17,8 @@ namespace PepperDash.Essentials.Devices.Common.Cameras
     /// <summary>
     /// Represents a CameraVisca
     /// </summary>
+    [Obsolete("CameraVisca is no longer supported and will be removed in a future release.  Use the CameraVisca plugin instead.")]
+
     public class CameraVisca : CameraBase, IHasCameraPtzControl, ICommunicationMonitor, IHasCameraPresets, IHasPowerControlWithFeedback, IBridgeAdvanced, IHasCameraFocusControl, IHasAutoFocusMode
     {
         private readonly CameraViscaPropertiesConfig PropertiesConfig;

--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/DeviceStateMessageBase.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/DeviceStateMessageBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -18,6 +19,7 @@ namespace PepperDash.Essentials.AppServer.Messengers
     /// Sets the interfaces implemented by the device sending the message
     /// </summary>
     /// <param name="interfaces"></param>
+    [Obsolete("SetInterfaces is no longer supported and will be removed in a future release.  Interfaces for all devices are now retrieved via the /joinroom endpoint in the MobileControlWebsocketServer")]
     public void SetInterfaces(List<string> interfaces)
     {
       Interfaces = interfaces;

--- a/src/PepperDash.Essentials/ControlSystem.cs
+++ b/src/PepperDash.Essentials/ControlSystem.cs
@@ -801,6 +801,7 @@ namespace PepperDash.Essentials
         /// <summary>
         /// Fires up a logo server if not already running
         /// </summary>
+        [Obsolete("Logo server is no longer supported and will be removed in a future release.")]
         void LoadLogoServer()
         {
             if (ConfigReader.ConfigObject?.Rooms == null)


### PR DESCRIPTION
This pull request adds `[Obsolete]` attributes to several classes, interfaces, methods, and enum members across the codebase. The purpose is to mark these components as deprecated, indicating they are no longer supported and will be removed in a future release. This helps developers avoid using outdated code and prepares the codebase for future clean-up.

**Deprecation of core classes and interfaces:**

* Marked `DebugContext`, `WebApiPasscodeClient`, and the static class `ConfigUpdater` as obsolete, signaling that these classes are no longer supported and will be removed in a future release. [[1]](diffhunk://#diff-9ab0465895e64dc70e43e397f59259ca5baae06be5841cb9f53465a31c463472R14) [[2]](diffhunk://#diff-7448a9d2ebc66549715ebee855ee2b8c4c8cc0ea2ab7f592d15ff6d101382998R16) [[3]](diffhunk://#diff-bf3201f8e51da5663d3fc1f1b1f2acb6f3b0300f261e028e6cd1032e16602a85R22)
* Marked the interfaces `ILogStrings` and `ILogStringsWithLevel` as obsolete. [[1]](diffhunk://#diff-0bed156ea593d4f7d1c92a108fbe8bdf4d433037538f894f3c21260a3314172eR13) [[2]](diffhunk://#diff-d57c629ff3301eccf537726eab5e49edde932a9d3321deda4a379663fe4eebbbR13)

**Deprecation of device and camera-related components:**

* Marked the `CameraVisca` class as obsolete, instructing users to use the CameraVisca plugin instead.

**Deprecation of routing signal types:**

* Marked the `UsbOutput`, `UsbInput`, and `SecondaryAudio` members of the `eRoutingSignalType` enum as obsolete.

**Deprecation of methods:**

* Marked the `SetInterfaces` method in `DeviceStateMessageBase` and the `LoadLogoServer` method as obsolete, providing guidance on alternative approaches. [[1]](diffhunk://#diff-cb19b6480a84f9711b521bbb64d54403d456edcff0e18743cda835a53afa8ecfR22) [[2]](diffhunk://#diff-497bfd7d65516cda5fa2ed0ff1f25336f07fed304acd6eb1a733ec8fd8876e22R804)