### PR TITLE
Fix/devtools fixex

### DIFF
--- a/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
+++ b/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
@@ -15,12 +15,10 @@ using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Operators;
-using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.X509;
-using System.Security.Cryptography;
 using Serilog.Formatting;
 using Serilog.Formatting.Json;
 
@@ -244,9 +242,10 @@ namespace PepperDash.Core
 
         /// <summary>
         /// Loads a PKCS#12 file written by BouncyCastle and returns an <see cref="X509Certificate2"/> with
-        /// private key attached via <see cref="RSACryptoServiceProvider"/>.
-        /// Using BouncyCastle's own reader avoids the .NET/Mono PFX parser, which can reject
-        /// BouncyCastle-generated archives on the Crestron runtime.
+        /// private key attached.
+        /// The PFX is parsed and re-encoded by BouncyCastle (ensuring format compatibility), then passed as
+        /// raw bytes to <see cref="X509Certificate2"/> so neither <c>RSACryptoServiceProvider</c> nor the
+        /// <c>EphemeralKeySet</c> flag (unsupported on the Crestron/Mono runtime) is needed.
         /// </summary>
         private static X509Certificate2 LoadCertFromBouncyCastle(string certPath, string certPassword)
         {
@@ -258,26 +257,12 @@ namespace PepperDash.Core
                     var store = new Pkcs12StoreBuilder().Build();
                     store.Load(stream, passwordChars);
 
-                    foreach (string alias in store.Aliases)
+                    // Re-encode through BouncyCastle to guarantee PKCS#12 format compatibility,
+                    // then hand raw bytes to X509Certificate2 — no RSACryptoServiceProvider needed.
+                    using (var ms = new MemoryStream())
                     {
-                        if (!store.IsKeyEntry(alias)) continue;
-
-                        var keyEntry = store.GetKey(alias);
-                        var certChain = store.GetCertificateChain(alias);
-                        if (certChain == null || certChain.Length == 0) continue;
-
-                        // Build X509Certificate2 from raw DER — no PFX parsing by .NET needed.
-                        var cert = new X509Certificate2(certChain[0].Certificate.GetEncoded());
-
-                        // Attach the private key via RSACryptoServiceProvider (available on all target runtimes).
-                        var rsaParams = DotNetUtilities.ToRSAParameters(
-                            (RsaPrivateCrtKeyParameters)keyEntry.Key);
-                        var rsa = new RSACryptoServiceProvider();
-                        rsa.PersistKeyInCsp = false;
-                        rsa.ImportParameters(rsaParams);
-                        cert.PrivateKey = rsa;
-
-                        return cert;
+                        store.Save(ms, passwordChars, new SecureRandom());
+                        return new X509Certificate2(ms.ToArray(), certPassword);
                     }
                 }
             }
@@ -285,8 +270,6 @@ namespace PepperDash.Core
             {
                 Array.Clear(passwordChars, 0, passwordChars.Length);
             }
-
-            throw new InvalidOperationException("No key entry found in PKCS#12 store: " + certPath);
         }
 
         private void Start(int port, string certPath = "", string certPassword = "")

--- a/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
+++ b/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
@@ -262,7 +262,13 @@ namespace PepperDash.Core
                     using (var ms = new MemoryStream())
                     {
                         store.Save(ms, passwordChars, new SecureRandom());
-                        return new X509Certificate2(ms.ToArray(), certPassword);
+                        var cert = new X509Certificate2(ms.ToArray(), certPassword);
+
+                        if (!cert.HasPrivateKey)
+                            throw new InvalidOperationException(
+                                string.Format("Certificate loaded from '{0}' does not contain a private key and cannot be used as a server certificate.", certPath));
+
+                        return cert;
                     }
                 }
             }

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
@@ -93,15 +93,19 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                 context.Response.ContentType = "application/json";
                 context.Response.ContentEncoding = System.Text.Encoding.UTF8;
                 context.Response.Write(JsonConvert.SerializeObject(
-                    new
-                        {
-                            UserName = token.UserName,
-                            Access = token.Access,
-                            State = token.State,
-                            Groups = token.Groups,
-                            ADConnect = token.ADConnect,
-                            Valid = token.Valid
-                        }, Formatting.Indented), false);
+                     new
+                     {
+                         Token = new LoginResponse
+                         {
+                             UserName = token.UserName,
+                             Password = token.Password,
+                             Access = token.Access,
+                             State = token.State,
+                             Groups = token.Groups,
+                             ADConnect = token.ADConnect,
+                             Valid = token.Valid
+                         }
+                     }, Formatting.Indented), false);
                 context.Response.End();
             }
             catch (System.Exception ex)

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
@@ -98,7 +98,6 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                          Token = new LoginResponse
                          {
                              UserName = token.UserName,
-                             Password = token.Password,
                              Access = token.Access,
                              State = token.State,
                              Groups = token.Groups,
@@ -145,11 +144,6 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
         /// Gets or sets the username.
         /// </summary>
         public string UserName { get; set; }
-
-        /// <summary>
-        /// Gets or sets the password.
-        /// </summary>
-        public string Password { get; set; }
 
         /// <summary>
         /// Gets or sets the access level.

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
@@ -93,14 +93,15 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                 context.Response.ContentType = "application/json";
                 context.Response.ContentEncoding = System.Text.Encoding.UTF8;
                 context.Response.Write(JsonConvert.SerializeObject(
-                    new LoginResponse 
-                        { UserName = token.UserName, 
-                        Password = token.Password, 
-                        Access = token.Access, 
-                        State = token.State, 
-                        Groups = token.Groups, 
-                        ADConnect = token.ADConnect, 
-                        Valid = token.Valid }, Formatting.Indented), false);
+                    new
+                        {
+                            UserName = token.UserName,
+                            Access = token.Access,
+                            State = token.State,
+                            Groups = token.Groups,
+                            ADConnect = token.ADConnect,
+                            Valid = token.Valid
+                        }, Formatting.Indented), false);
                 context.Response.End();
             }
             catch (System.Exception ex)

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/LoginRequestHandler.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Collections.Generic;
 using Crestron.SimplSharp.CrestronAuthentication;
 using Crestron.SimplSharp.WebScripting;
 using Newtonsoft.Json;
@@ -91,7 +92,15 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                 context.Response.StatusDescription = "OK";
                 context.Response.ContentType = "application/json";
                 context.Response.ContentEncoding = System.Text.Encoding.UTF8;
-                context.Response.Write(JsonConvert.SerializeObject(new { Token = token }, Formatting.Indented), false);
+                context.Response.Write(JsonConvert.SerializeObject(
+                    new LoginResponse 
+                        { UserName = token.UserName, 
+                        Password = token.Password, 
+                        Access = token.Access, 
+                        State = token.State, 
+                        Groups = token.Groups, 
+                        ADConnect = token.ADConnect, 
+                        Valid = token.Valid }, Formatting.Indented), false);
                 context.Response.End();
             }
             catch (System.Exception ex)
@@ -120,5 +129,46 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
         /// Gets or sets the password.
         /// </summary>
         public string Password { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a LoginResponse
+    /// </summary>
+    internal class LoginResponse
+    {
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the access level.
+        /// </summary>
+        public Authentication.UserAuthenticationLevelEnum Access { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token authenticated state.
+        /// </summary>
+        public Authentication.eTokenAuthenticatedState State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of groups.
+        /// </summary>
+        public List<string> Groups { get; set; }
+
+        /// <summary>
+        /// Gets or sets the active directory connection flag.
+        /// </summary>
+        public int ADConnect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the valid flag indicating whether the token is valid.
+        /// </summary>
+        public bool Valid { get; set; }
     }
 }


### PR DESCRIPTION
This pull request introduces two main changes: it updates the login response structure to include more detailed user information, and it simplifies the process of loading PKCS#12 certificates for the debug WebSocket sink to improve compatibility and reliability.

Closes PepperDash/essentials-devtools#29 as verified by @jonnyarndt 

**Login Response Enhancements:**

* The login POST handler now returns a detailed `LoginResponse` object, including fields such as `UserName`, `Password`, `Access`, `State`, `Groups`, `ADConnect`, and `Valid`, instead of just a token string. This provides clients with more comprehensive authentication data.
* A new internal `LoginResponse` class is introduced to encapsulate all relevant authentication response fields.

**Certificate Loading Improvements:**

* The `LoadCertFromBouncyCastle` method in `DebugWebsocketSink` has been refactored to re-encode the PKCS#12 archive using BouncyCastle and pass the raw bytes directly to `X509Certificate2`. This removes the need for `RSACryptoServiceProvider` and avoids issues with the `EphemeralKeySet` flag, improving compatibility with the Crestron/Mono runtime. [[1]](diffhunk://#diff-22fca81120edec079b537390f1c43cdcacc76b89e7397d26e5846010eed6a6ccL247-R248) [[2]](diffhunk://#diff-22fca81120edec079b537390f1c43cdcacc76b89e7397d26e5846010eed6a6ccL261-L289)
* Unused or unnecessary using directives related to cryptography have been removed for code cleanliness.