### PR TITLE
Fix/fix e control method enum values

### DIFF
--- a/src/PepperDash.Core/Comm/eControlMethods.cs
+++ b/src/PepperDash.Core/Comm/eControlMethods.cs
@@ -18,74 +18,75 @@ namespace PepperDash.Core
         /// <summary>
         /// RS232/422/485
         /// </summary>
-        Com,
+        Com = 1,
         /// <summary>
         /// Crestron IpId (most Crestron ethernet devices)
         /// </summary>
-        IpId,
+        IpId = 2,
         /// <summary>
         /// Crestron IpIdTcp (HD-MD series, etc.)
         /// </summary>
-        IpidTcp,
+        IpidTcp = 3,
         /// <summary>
         /// Crestron IR control
         /// </summary>
-        IR,
+        IR = 4,
         /// <summary>
         /// SSH client
         /// </summary>
-        Ssh,
+        Ssh = 5,
         /// <summary>
         /// TCP/IP client
         /// </summary>
-        Tcpip,
+        Tcpip = 6,
         /// <summary>
         /// Telnet
         /// </summary>
-        Telnet,
+        Telnet = 7,
         /// <summary>
         /// Crestnet device
         /// </summary>
-        Cresnet,
+        Cresnet = 8,
         /// <summary>
         /// CEC Control, via a DM HDMI port
         /// </summary>
-        Cec,
+        Cec = 9,
         /// <summary>
         /// UDP Server
         /// </summary>
-        Udp,
-        /// <summary>
-        /// UDP client
-        /// </summary>
-        UdpClient,
+        Udp = 10,
+
         /// <summary>
         /// HTTP client
         /// </summary>
-        Http,
+        Http = 11,
         /// <summary>
         /// HTTPS client
         /// </summary>
-        Https,
+        Https = 12,
         /// <summary>
         /// Websocket client
         /// </summary>
-        Ws,
+        Ws = 13,
         /// <summary>
         /// Secure Websocket client 
         /// </summary>
-        Wss,
+        Wss = 14,
         /// <summary>
         /// Secure TCP/IP
         /// </summary>
-        SecureTcpIp,
+        SecureTcpIp = 15,
         /// <summary>
         /// Used when comms needs to be handled in SIMPL and bridged opposite the normal direction
         /// </summary>
-        ComBridge,
+        ComBridge = 16,
         /// <summary>
         /// InfinetEX control
         /// </summary>
-        InfinetEx
+        InfinetEx = 17,
+        /// <summary>
+        /// UDP client
+        /// </summary>
+        UdpClient = 18,
     }
 }


### PR DESCRIPTION
Closes #1421 

This pull request updates the `eControlMethod` enum in `eControlMethods.cs` to explicitly assign integer values to each member and reorders the `UdpClient` entry. This change ensures that the enum values are stable and predictable, which is important for serialization, interoperability, and backward compatibility.

Enum improvements and maintenance:

* Explicitly assigned integer values to all members of the `eControlMethod` enum to ensure stable and predictable values.
* Moved the `UdpClient` entry to the end of the enum and assigned it the next available integer value (`18`), ensuring the order and values are clear and consistent.