### PR TITLE
fix: update routing logic

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -249,7 +249,7 @@ namespace PepperDash.Essentials.Core
             }
             // otherwise, audioVideo needs to be handled as two steps.
 
-            Debug.LogDebug(destination, "Attempting to build source route from {destinationKey} to {sourceKey} of type {type}", source.Key, signalType);
+            Debug.LogDebug(destination, "Attempting to build source route from {destinationKey} to {sourceKey} of type {type}", destination.Key, source.Key, signalType);
 
             RouteDescriptor audioRouteDescriptor;
 
@@ -374,23 +374,27 @@ namespace PepperDash.Essentials.Core
                     IndexTieLines();
                 }
 
-                var sinks = DeviceManager.AllDevices.OfType<IRoutingInputs>().Where(d => !(d is IRoutingInputsOutputs));
-                var sources = DeviceManager.AllDevices.OfType<IRoutingOutputs>().Where(d => !(d is IRoutingInputsOutputs));
+                var sinks = DeviceManager.AllDevices.OfType<IRoutingInputs>();
+                var sources = DeviceManager.AllDevices.OfType<IRoutingOutputs>();
 
-                foreach (var sink in sinks)
+                foreach (var sink in sinks.Where(d => !(d is IRoutingInputsOutputs)))
                 {
-                    foreach (var source in sources)
+                    foreach (var source in sources.Where(d => !(d is IRoutingInputsOutputs)))
                     {
                         foreach (var inputPort in sink.InputPorts)
                         {
                             foreach (var outputPort in source.OutputPorts)
                             {
-                                var (audioOrSingleRoute, videoRoute) = sink.GetRouteToSource(source, inputPort.Type, inputPort, outputPort);
+                                var (audioOrSingleRoute, videoRoute) = sink.GetRouteToSource(source, outputPort.Type, inputPort, outputPort);
 
                                 if (audioOrSingleRoute == null && videoRoute == null)
                                 {
                                     continue;
                                 }
+
+                                Debug.LogVerbose("AudioOrSingleRoute Found: {audioRoute}", audioOrSingleRoute);
+
+                                Debug.LogVerbose("VideoRoute Found: {videoRoute}", videoRoute);
 
                                 if (audioOrSingleRoute != null)
                                 {
@@ -646,6 +650,8 @@ namespace PepperDash.Essentials.Core
                 // Only the ones that are routing devices
                 var midpointTieLines = destinationTieLines.Where(t => t.SourcePort.ParentDevice is IRoutingInputsOutputs);
 
+                Debug.LogVerbose(destination, "Found {tieLineCount} tie lines to walk for {destinationKey}", midpointTieLines.Count(), destination.Key);
+
                 //Create a list for tracking already checked devices to avoid loops, if it doesn't already exist from previous iteration
                 if (alreadyCheckedDevices == null)
                     alreadyCheckedDevices = new List<IRoutingInputsOutputs>();
@@ -685,7 +691,7 @@ namespace PepperDash.Essentials.Core
 
             if (goodInputPort == null)
             {
-                Debug.LogVerbose(destination, "No route found to {0}", source.Key);
+                Debug.LogVerbose(destination, "No route found to {0} from destination {1} for type {2}", source.Key, destination.Key, signalType);
 
                 // Cache this as an impossible route
                 _impossibleRoutes.TryAdd(routeKey, 0);

--- a/src/PepperDash.Essentials.Core/Routing/RoutingFeedbackManager.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RoutingFeedbackManager.cs
@@ -66,6 +66,9 @@ namespace PepperDash.Essentials.Core.Routing
 
                 foreach (var midpointKey in upstreamMidpoints)
                 {
+                    if (string.IsNullOrEmpty(midpointKey))
+                        continue;
+
                     if (!midpointToSinksMap.ContainsKey(midpointKey))
                         midpointToSinksMap[midpointKey] = new HashSet<string>();
 
@@ -115,7 +118,8 @@ namespace PepperDash.Essentials.Core.Routing
 
             if (tieLine.SourcePort.ParentDevice is IRoutingWithFeedback midpoint)
             {
-                midpoints.Add(midpoint.Key);
+                if (!string.IsNullOrEmpty(midpoint.Key))
+                    midpoints.Add(midpoint.Key);
 
                 // Find upstream TieLines connected to this midpoint's inputs
                 var midpointInputs = (midpoint as IRoutingInputs)?.InputPorts;
@@ -244,6 +248,9 @@ namespace PepperDash.Essentials.Core.Routing
             var upstreamMidpoints = GetUpstreamMidpoints(sink);
             foreach (var midpointKey in upstreamMidpoints)
             {
+                if (string.IsNullOrEmpty(midpointKey))
+                    continue;
+
                 if (!midpointToSinksMap.ContainsKey(midpointKey))
                     midpointToSinksMap[midpointKey] = new HashSet<string>();
 

--- a/src/PepperDash.Essentials.Devices.Common/VideoCodec/MockVC/MockVC.cs
+++ b/src/PepperDash.Essentials.Devices.Common/VideoCodec/MockVC/MockVC.cs
@@ -21,7 +21,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
     /// <summary>
     /// Represents a MockVC
     /// </summary>
-    public class MockVC : VideoCodecBase, IRoutingSource, IHasCallHistory, IHasScheduleAwareness, IHasCallFavorites, IHasDirectory, IHasCodecCameras, IHasCameraAutoMode, IHasCodecRoomPresets
+    public class MockVC : VideoCodecBase, IRoutingSource, IHasCallHistory, IHasScheduleAwareness, IHasCallFavorites, IHasDirectory, IHasCodecCameras, IHasCameraAutoMode, IHasCodecRoomPresets, IRoutingInputs
     {
         /// <summary>
         /// Gets or sets the PropertiesConfig

--- a/src/PepperDash.Essentials.Devices.Common/VideoCodec/VideoCodecBase.cs
+++ b/src/PepperDash.Essentials.Devices.Common/VideoCodec/VideoCodecBase.cs
@@ -26,7 +26,7 @@ namespace PepperDash.Essentials.Devices.Common.VideoCodec
 	/// <summary>
 	/// Base class for video codec devices
 	/// </summary>
-	public abstract class VideoCodecBase : ReconfigurableDevice, IRoutingInputsOutputs,
+	public abstract class VideoCodecBase : ReconfigurableDevice,
 		IUsageTracking, IHasDialer, IHasContentSharing, ICodecAudio, iVideoCodecInfo, IBridgeAdvanced, IHasStandbyMode
 	{
 		private const int XSigEncoding = 28591;


### PR DESCRIPTION
Closes #1423


This pull request introduces several improvements to the routing logic and device type handling in the Essentials Core library. The main focus is on refining how routing sources and sinks are identified, enhancing debug logging for route tracing, and correcting type assignments for mock and base video codec classes.

Key improvements and changes:

### Routing Logic and Device Type Handling

* Refined the selection of routing sources and sinks in `MapDestinationsToSources()` by removing restrictions that excluded devices implementing both `IRoutingInputs` and `IRoutingOutputs`. The filtering is now applied within the loop, making the logic clearer and more flexible.
* Updated the call to `GetRouteToSource` to use the correct signal type (`outputPort.Type` instead of `inputPort.Type`) when mapping routes, ensuring accurate routing behavior.

### Debug Logging Enhancements

* Improved debug logging in several places to provide more detailed information about routing attempts, found routes, and failures. This includes:
  - Logging both `destination.Key` and `source.Key` in route-building messages.
  - Adding verbose logs when routes are found or not found, and when tie lines are being walked, aiding in troubleshooting and traceability. [[1]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL377-R398) [[2]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fR653-R654) [[3]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL688-R694)

### Device Class Type Corrections

* Added `IRoutingInputs` to the `MockVC` class to ensure it is properly recognized as a routing input in the system.
* Removed `IRoutingInputsOutputs` from the `VideoCodecBase` class, clarifying its intended role and preventing incorrect type assignments.