### PR TITLE
Fix cache clearing for impossibleRoutes

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/Extensions.cs
+++ b/src/PepperDash.Essentials.Core/Routing/Extensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -51,13 +50,6 @@ namespace PepperDash.Essentials.Core
         /// Indexed lookup of TieLines by source device key for faster queries.
         /// </summary>
         private static Dictionary<string, List<TieLine>> _tieLinesBySource;
-
-        /// <summary>
-        /// Cache of failed route attempts to avoid re-checking impossible paths.
-        /// Format: "sourceKey|destKey|signalType"
-        /// Uses ConcurrentDictionary as a thread-safe set (byte value is unused).
-        /// </summary>
-        private static readonly ConcurrentDictionary<string, byte> _impossibleRoutes = new ConcurrentDictionary<string, byte>();
 
         /// <summary>
         /// Indexes all TieLines by source and destination device keys for faster lookups.
@@ -119,29 +111,6 @@ namespace PepperDash.Essentials.Core
 
             // Fallback to LINQ if index not available
             return TieLineCollection.Default.Where(t => t.SourcePort.ParentDevice.Key == sourceKey);
-        }
-
-        /// <summary>
-        /// Creates a cache key for route impossibility tracking.
-        /// </summary>
-        /// <param name="sourceKey">Source device key</param>
-        /// <param name="destKey">Destination device key</param>
-        /// <param name="sourcePortKey">Source port key</param>
-        /// <param name="destinationPortKey">Destination port key</param>
-        /// <param name="type">Signal type</param>
-        /// <returns>Cache key string</returns>
-        private static string GetRouteKey(string sourceKey, string destKey, string sourcePortKey, string destinationPortKey, eRoutingSignalType type)
-        {
-            return $"{sourceKey}|{destKey}|{sourcePortKey}|{destinationPortKey}|{type}";
-        }
-
-        /// <summary>
-        /// Clears the impossible routes cache. Should be called if TieLines are added/removed at runtime.
-        /// </summary>
-        public static void ClearImpossibleRoutesCache()
-        {
-            _impossibleRoutes.Clear();
-            Debug.LogInformation("Impossible routes cache cleared");
         }
 
         /// <summary>
@@ -588,14 +557,6 @@ namespace PepperDash.Essentials.Core
         {
             cycle++;
 
-            // Check if this route has already been determined to be impossible
-            var routeKey = GetRouteKey(source.Key, destination.Key, sourcePort?.Key ?? "auto", destinationPort?.Key ?? "auto", signalType);
-            if (_impossibleRoutes.ContainsKey(routeKey))
-            {
-                Debug.LogVerbose("Route {0} is cached as impossible, skipping", routeKey);
-                return false;
-            }
-
             Debug.LogVerbose("GetRouteToSource: {cycle} {sourceKey}:{sourcePortKey}--> {destinationKey}:{destinationPortKey} {type}", null, cycle, source.Key, sourcePort?.Key ?? "auto", destination.Key, destinationPort?.Key ?? "auto", signalType.ToString());
 
             RoutingInputPort goodInputPort = null;
@@ -692,9 +653,6 @@ namespace PepperDash.Essentials.Core
             if (goodInputPort == null)
             {
                 Debug.LogVerbose(destination, "No route found to {0} from destination {1} for type {2}", source.Key, destination.Key, signalType);
-
-                // Cache this as an impossible route
-                _impossibleRoutes.TryAdd(routeKey, 0);
 
                 return false;
             }


### PR DESCRIPTION
This pull request removes the caching mechanism for impossible routing paths in the `Extensions` class, simplifying the routing logic and reducing memory usage. The main changes involve deleting the `ConcurrentDictionary` used for tracking impossible routes, as well as all related helper methods and cache checks.

### Removal of impossible route caching

* The private static field `_impossibleRoutes` and its usage of `ConcurrentDictionary` have been removed from `Extensions.cs`, eliminating the cache that tracked failed route attempts. [[1]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL2) [[2]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL55-L61)
* The helper method `GetRouteKey` for generating cache keys has been deleted, along with the `ClearImpossibleRoutesCache` method that cleared the cache.
* All logic checking the impossible routes cache before attempting a route, as well as logic for adding impossible routes to the cache, has been removed from the routing algorithm. [[1]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL591-L598) [[2]](diffhunk://#diff-e18100a37c5187927d7c469e91e602d2690df176e516af252837e7a381fa6a2fL696-L698)
