### PR TITLE
Feature/add escape handling for devjson

### DIFF
--- a/src/PepperDash.Essentials.Core/Devices/DeviceJsonApi.cs
+++ b/src/PepperDash.Essentials.Core/Devices/DeviceJsonApi.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PepperDash.Essentials.Core
@@ -176,7 +177,20 @@ namespace PepperDash.Essentials.Core
         {
             if (!conversionType.IsEnum)
             {
-                return Convert.ChangeType(value, conversionType, System.Globalization.CultureInfo.InvariantCulture);
+                if (conversionType == typeof(byte[]) && value is string byteString)
+                {
+                    var unescaped = UnescapeString(byteString);
+                    return System.Text.Encoding.GetEncoding(28591).GetBytes(unescaped);
+                }
+
+                var converted = Convert.ChangeType(value, conversionType, System.Globalization.CultureInfo.InvariantCulture);
+
+                if (conversionType == typeof(string) && converted is string s)
+                {
+                    return UnescapeString(s);
+                }
+
+                return converted;
             }
 
             var stringValue = Convert.ToString(value);
@@ -187,6 +201,32 @@ namespace PepperDash.Essentials.Core
                     String.Format("{0} cannot be converted to a string prior to conversion to enum"));
             }
             return Enum.Parse(conversionType, stringValue, true);
+        }
+
+        /// <summary>
+        /// Processes escape sequences in a string, converting sequences like \r, \n, \t, \xHH
+        /// to their corresponding non-printable ASCII characters.
+        /// </summary>
+        private static string UnescapeString(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            return Regex.Replace(input, @"\\(r|n|t|\\|x[0-9A-Fa-f]{2})", match =>
+            {
+                var seq = match.Groups[1].Value;
+                switch (seq)
+                {
+                    case "r": return "\r";
+                    case "n": return "\n";
+                    case "t": return "\t";
+                    case "\\": return "\\";
+                    default:
+                        // \xHH hex escape
+                        var hex = seq.Substring(1);
+                        return ((char)Convert.ToInt32(hex, 16)).ToString();
+                }
+            });
         }
 
         /// <summary>

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
@@ -57,6 +57,36 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                     // Start the WS Server
                     Debug.WebsocketSink.StartServerAndSetPort(port);
                     Debug.SetWebSocketMinimumDebugLevel(Serilog.Events.LogEventLevel.Verbose);
+
+                    // Attempt to forward the port to the CS LAN
+                    try
+                    {
+                        var csAdapterId = CrestronEthernetHelper.GetAdapterdIdForSpecifiedAdapterType(
+                            EthernetAdapterType.EthernetCSAdapter);
+                        var csIp = CrestronEthernetHelper.GetEthernetParameter(
+                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
+
+                        var result = CrestronEthernetHelper.AddPortForwarding(
+                            (ushort)port, (ushort)port, csIp,
+                            CrestronEthernetHelper.ePortMapTransport.TCP);
+
+                        if (result != CrestronEthernetHelper.PortForwardingUserPatRetCodes.NoErr)
+                        {
+                            Debug.LogMessage(LogEventLevel.Warning, "Error adding port forwarding for debug websocket: {0}", result);
+                        }
+                        else
+                        {
+                            Debug.LogMessage(LogEventLevel.Information, "Port {0} forwarded to CS LAN for debug websocket", port);
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        Debug.LogMessage(LogEventLevel.Debug, "This processor does not have a CS LAN adapter; skipping port forwarding");
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogMessage(LogEventLevel.Warning, "Error automatically forwarding debug websocket port to CS LAN: {0}", ex.Message);
+                    }
                 }
 
                 var url = Debug.WebsocketSink.Url;
@@ -90,7 +120,39 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
         /// <param name="context"></param>
         protected override void HandlePost(HttpCwsContext context)
         {
+            var port = Debug.WebsocketSink.Port;
+
             Debug.WebsocketSink.StopServer();
+
+            // Remove the port forwarding entry
+            try
+            {
+                var csAdapterId = CrestronEthernetHelper.GetAdapterdIdForSpecifiedAdapterType(
+                    EthernetAdapterType.EthernetCSAdapter);
+                var csIp = CrestronEthernetHelper.GetEthernetParameter(
+                    CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
+
+                var result = CrestronEthernetHelper.RemovePortForwarding(
+                    (ushort)port, (ushort)port, csIp,
+                    CrestronEthernetHelper.ePortMapTransport.TCP);
+
+                if (result != CrestronEthernetHelper.PortForwardingUserPatRetCodes.NoErr)
+                {
+                    Debug.LogMessage(LogEventLevel.Warning, "Error removing port forwarding for debug websocket: {0}", result);
+                }
+                else
+                {
+                    Debug.LogMessage(LogEventLevel.Information, "Port forwarding for port {0} removed", port);
+                }
+            }
+            catch (ArgumentException)
+            {
+                Debug.LogMessage(LogEventLevel.Debug, "This processor does not have a CS LAN adapter; skipping port forwarding removal");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogMessage(LogEventLevel.Warning, "Error removing debug websocket port forwarding: {0}", ex.Message);
+            }
 
             context.Response.StatusCode = 200;
             context.Response.StatusDescription = "OK";

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
@@ -132,17 +132,24 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                 var csIp = CrestronEthernetHelper.GetEthernetParameter(
                     CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
 
-                var result = CrestronEthernetHelper.RemovePortForwarding(
-                    (ushort)port, (ushort)port, csIp,
-                    CrestronEthernetHelper.ePortMapTransport.TCP);
-
-                if (result != CrestronEthernetHelper.PortForwardingUserPatRetCodes.NoErr)
+                if (port <= 0)
                 {
-                    Debug.LogMessage(LogEventLevel.Warning, "Error removing port forwarding for debug websocket: {0}", result);
+                    Debug.LogMessage(LogEventLevel.Debug, "Debug websocket port is not set; skipping port forwarding removal");
                 }
                 else
                 {
-                    Debug.LogMessage(LogEventLevel.Information, "Port forwarding for port {0} removed", port);
+                    var result = CrestronEthernetHelper.RemovePortForwarding(
+                        (ushort)port, (ushort)port, csIp,
+                        CrestronEthernetHelper.ePortMapTransport.TCP);
+
+                    if (result != CrestronEthernetHelper.PortForwardingUserPatRetCodes.NoErr)
+                    {
+                        Debug.LogMessage(LogEventLevel.Warning, "Error removing port forwarding for debug websocket: {0}", result);
+                    }
+                    else
+                    {
+                        Debug.LogMessage(LogEventLevel.Information, "Port forwarding for port {0} removed", port);
+                    }
                 }
             }
             catch (ArgumentException)


### PR DESCRIPTION
This pull request introduces enhancements to both device API data handling and the debug websocket server. The most significant changes are improved handling of escape sequences for string and byte array conversions in the device JSON API, and the addition of automatic port forwarding management for the debug websocket server to support connectivity on the CS LAN adapter.

**Device JSON API improvements:**

* Added the `UnescapeString` method in `DeviceJsonApi.cs` to process escape sequences (like `\r`, `\n`, `\t`, and `\xHH`) when converting values to `string` or `byte[]`, ensuring that non-printable ASCII characters are handled correctly during type conversion. [[1]](diffhunk://#diff-4ec72b57ae546d500759b73ff6ff7e23ea2fdad4213944c6723a73b053561646L179-R193) [[2]](diffhunk://#diff-4ec72b57ae546d500759b73ff6ff7e23ea2fdad4213944c6723a73b053561646R206-R231)
* Updated `ConvertType` to use `UnescapeString` for `string` and `byte[]` conversions, improving robustness when handling JSON input with escape sequences.

**Debug websocket server enhancements:**

* In `DebugSessionRequestHandler.cs`, added logic to automatically forward the debug websocket port to the CS LAN adapter when starting the server, improving accessibility for debugging sessions. Handles cases where the CS LAN adapter is not present or errors occur during forwarding.
* Added corresponding logic to remove the port forwarding entry when stopping the debug websocket server, ensuring clean-up and avoiding lingering port forwards.