### PR TITLE
Fix/web debug url

### DIFF
--- a/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
+++ b/src/PepperDash.Core/Logging/DebugWebsocketSink.cs
@@ -72,6 +72,20 @@ namespace PepperDash.Core
         /// </summary>
         public bool IsRunning { get => _httpsServer?.IsListening ?? false; }
 
+        /// <summary>
+        /// Gets a value indicating whether there are active WebSocket connections.
+        /// </summary>
+        public bool HasActiveConnections
+        {
+            get
+            {
+                if (_httpsServer == null || !_httpsServer.IsListening) return false;
+                var service = _httpsServer.WebSocketServices[_path];
+                if (service == null) return false;
+                return service.Sessions.Count > 0;
+            }
+        }
+
 
         private readonly ITextFormatter _textFormatter;
 
@@ -216,6 +230,8 @@ namespace PepperDash.Core
         public void StartServerAndSetPort(int port)
         {
             Debug.LogInformation("Starting Websocket Server on port: {0}", port);
+
+            
 
 
             Start(port, CertPath, _certificatePassword);

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
@@ -17,7 +17,10 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
     /// Represents a DebugSessionRequestHandler
     /// </summary>
     public class DebugSessionRequestHandler : WebApiBaseRequestHandler
-    {    
+    {
+        private CTimer _portForwardTimeoutTimer;
+        private readonly object _timerLock = new object();
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -81,6 +84,7 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                         else
                         {
                             Debug.LogMessage(LogEventLevel.Information, "Port {0} forwarded to CS LAN for debug websocket", port);
+                            StartPortForwardTimeout(port, csIp);
                         }
                     }
                 }
@@ -126,6 +130,8 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
         /// <param name="context"></param>
         protected override void HandlePost(HttpCwsContext context)
         {
+            CancelPortForwardTimeout();
+
             var port = Debug.WebsocketSink.Port;
 
             Debug.WebsocketSink.StopServer();
@@ -172,6 +178,56 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
             context.Response.End();
 
             Debug.LogMessage(LogEventLevel.Information, "Websocket Debug Session Stopped");
+        }
+
+        private void StartPortForwardTimeout(int port, string csIp)
+        {
+            lock (_timerLock)
+            {
+                _portForwardTimeoutTimer?.Dispose();
+                _portForwardTimeoutTimer = new CTimer(_ =>
+                {
+                    if (Debug.WebsocketSink.HasActiveConnections)
+                    {
+                        Debug.LogMessage(LogEventLevel.Debug, "Debug websocket has active connections; keeping port forward");
+                        return;
+                    }
+
+                    Debug.LogMessage(LogEventLevel.Information, "No debug websocket connection within 30 seconds; removing port forward for port {0}", port);
+
+                    try
+                    {
+                        var result = CrestronEthernetHelper.RemovePortForwarding(
+                            (ushort)port, (ushort)port, csIp,
+                            CrestronEthernetHelper.ePortMapTransport.TCP);
+
+                        if (result != CrestronEthernetHelper.PortForwardingUserPatRetCodes.NoErr)
+                        {
+                            Debug.LogMessage(LogEventLevel.Warning, "Error removing port forwarding on timeout: {0}", result);
+                        }
+                        else
+                        {
+                            Debug.LogMessage(LogEventLevel.Information, "Port forwarding for port {0} removed due to timeout", port);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogMessage(LogEventLevel.Warning, "Error removing port forwarding on timeout: {0}", ex.Message);
+                    }
+                }, 30000);
+            }
+        }
+
+        /// <summary>
+        /// Cancels the port forward timeout timer if a session is being explicitly stopped.
+        /// </summary>
+        private void CancelPortForwardTimeout()
+        {
+            lock (_timerLock)
+            {
+                _portForwardTimeoutTimer?.Dispose();
+                _portForwardTimeoutTimer = null;
+            }
         }
 
     }

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
@@ -48,6 +48,7 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                     CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0);
 
                 var port = 0;
+                string csIp = null;
 
                 if (!Debug.WebsocketSink.IsRunning)
                 {
@@ -63,7 +64,7 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                     {
                         var csAdapterId = CrestronEthernetHelper.GetAdapterdIdForSpecifiedAdapterType(
                             EthernetAdapterType.EthernetCSAdapter);
-                        var csIp = CrestronEthernetHelper.GetEthernetParameter(
+                        csIp = CrestronEthernetHelper.GetEthernetParameter(
                             CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
 
                         var result = CrestronEthernetHelper.AddPortForwarding(
@@ -93,7 +94,8 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 
                 object data = new
                 {
-                    url = Debug.WebsocketSink.Url
+                    url = Debug.WebsocketSink.Url,
+                    csLanUrl = csIp != null ? url.Replace(ip, csIp) : null
                 };
 
                 Debug.LogMessage(LogEventLevel.Information, "Debug Session URL: {0}", url);

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/DebugSessionRequestHandler.cs
@@ -58,15 +58,18 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                     // Start the WS Server
                     Debug.WebsocketSink.StartServerAndSetPort(port);
                     Debug.SetWebSocketMinimumDebugLevel(Serilog.Events.LogEventLevel.Verbose);
+                }
 
-                    // Attempt to forward the port to the CS LAN
-                    try
+                // Attempt to get the CS LAN IP and forward the port
+                try
+                {
+                    var csAdapterId = CrestronEthernetHelper.GetAdapterdIdForSpecifiedAdapterType(
+                        EthernetAdapterType.EthernetCSAdapter);
+                    csIp = CrestronEthernetHelper.GetEthernetParameter(
+                        CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
+
+                    if (port > 0)
                     {
-                        var csAdapterId = CrestronEthernetHelper.GetAdapterdIdForSpecifiedAdapterType(
-                            EthernetAdapterType.EthernetCSAdapter);
-                        csIp = CrestronEthernetHelper.GetEthernetParameter(
-                            CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, csAdapterId);
-
                         var result = CrestronEthernetHelper.AddPortForwarding(
                             (ushort)port, (ushort)port, csIp,
                             CrestronEthernetHelper.ePortMapTransport.TCP);
@@ -80,25 +83,26 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
                             Debug.LogMessage(LogEventLevel.Information, "Port {0} forwarded to CS LAN for debug websocket", port);
                         }
                     }
-                    catch (ArgumentException)
-                    {
-                        Debug.LogMessage(LogEventLevel.Debug, "This processor does not have a CS LAN adapter; skipping port forwarding");
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.LogMessage(LogEventLevel.Warning, "Error automatically forwarding debug websocket port to CS LAN: {0}", ex.Message);
-                    }
+                }
+                catch (ArgumentException)
+                {
+                    Debug.LogMessage(LogEventLevel.Debug, "This processor does not have a CS LAN adapter; skipping port forwarding");
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogMessage(LogEventLevel.Warning, "Error automatically forwarding debug websocket port to CS LAN: {0}", ex.Message);
                 }
 
                 var url = Debug.WebsocketSink.Url;
 
-                object data = new
+                var data = new
                 {
                     url = Debug.WebsocketSink.Url,
-                    csLanUrl = csIp != null ? url.Replace(ip, csIp) : null
+                    fallbackUrl = csIp != null ? url.Replace(csIp, ip) : null
                 };
 
                 Debug.LogMessage(LogEventLevel.Information, "Debug Session URL: {0}", url);
+                Debug.LogMessage(LogEventLevel.Information, "Fallback Debug Session URL: {0}", data.fallbackUrl);
 
                 // Return the port number with the full url of the WS Server
                 var res = JsonConvert.SerializeObject(data);

--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
@@ -264,6 +264,9 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
                 message.Name = _device.Name;
 
+                message.MessageBasePath = MessagePath;
+
+
                 var token = JToken.FromObject(message);
 
                 PostStatusMessage(token, MessagePath, clientId);


### PR DESCRIPTION
This pull request introduces enhancements to the debug WebSocket session management, particularly around port forwarding and connection handling, as well as a minor fix in the mobile control messenger. The main focus is on improving the reliability and cleanup of port forwarding for debug sessions, ensuring resources are managed efficiently and providing better diagnostics.

**Debug WebSocket Session Management Improvements:**

* Added a `HasActiveConnections` property to `DebugWebsocketSink` to check for active WebSocket connections, which is used to decide whether to remove port forwarding after a timeout.
* Implemented a mechanism in `DebugSessionRequestHandler` to automatically remove port forwarding if no WebSocket connection is established within 30 seconds, including timer management and cleanup on session stop. [[1]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR21-R23) [[2]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR87-R88) [[3]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR133-R134) [[4]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR183-R232)
* Improved logic for determining the control system (CS) LAN IP and handling port forwarding, including fallback URL support if the CS IP is unavailable. [[1]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR54) [[2]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR64-R75) [[3]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cL90-R109)

**Diagnostics and Logging Enhancements:**

* Added detailed logging for debug session URLs, fallback URLs, and the status of port forwarding operations to aid troubleshooting. [[1]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cL90-R109) [[2]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR87-R88) [[3]](diffhunk://#diff-72f35e3378f4572bfdea23755c136abd3c89212b8a200652125bf7b62a391c6cR183-R232)

**Other Fixes:**

* Ensured that the `MessageBasePath` is set on status messages in the mobile control messenger to maintain message consistency.