### PR TITLE
Fix string formatting issues in console responses

### DIFF
--- a/src/PepperDash.Essentials.Core/Secrets/SecretsManager.cs
+++ b/src/PepperDash.Essentials.Core/Secrets/SecretsManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Crestron.SimplSharp;
 using PepperDash.Core;
+using PepperDash.Core.Logging;
 using Serilog.Events;
 
 namespace PepperDash.Essentials.Core
@@ -296,19 +297,14 @@ namespace PepperDash.Essentials.Core
         {
             var secretPresent = provider.TestSecret(key);
 
-            Debug.LogMessage(LogEventLevel.Verbose, provider, "SecretsProvider {0} {1} contain a secret entry for {2}", provider.Key, secretPresent ? "does" : "does not", key);
+            provider.LogVerbose("SecretsProvider {0} {1} contain a secret entry for {2}", provider.Key, secretPresent ? "does" : "does not", key);
 
             if (!secretPresent)
                 return
-                    String.Format(
-                        "Unable to update secret for {0}:{1} - Please use the 'SetSecret' command to modify it");
+                    $"Unable to update secret for {provider.Key}:{key} - Please use the 'SetSecret' command to modify it";
             var response = provider.SetSecret(key, secret)
-                ? String.Format(
-                    "Secret successfully set for {0}:{1}",
-                    provider.Key, key)
-                : String.Format(
-                    "Unable to set secret for {0}:{1}",
-                    provider.Key, key);
+                ? $"Secret successfully set for {provider.Key}:{key}"
+                : $"Unable to set secret for {provider.Key}:{key}";
             return response;
         }
 
@@ -316,19 +312,14 @@ namespace PepperDash.Essentials.Core
         {
             var secretPresent = provider.TestSecret(key);
 
-            Debug.LogMessage(LogEventLevel.Verbose, provider, "SecretsProvider {0} {1} contain a secret entry for {2}", provider.Key, secretPresent ? "does" : "does not", key);
+            provider.LogVerbose("SecretsProvider {0} {1} contain a secret entry for {2}", provider.Key, secretPresent ? "does" : "does not", key);
 
             if (secretPresent)
                 return
-                    String.Format(
-                        "Unable to set secret for {0}:{1} - Please use the 'UpdateSecret' command to modify it");
+                    $"Unable to set secret for {provider.Key}:{key} - Please use the 'UpdateSecret' command to modify it";
             var response = provider.SetSecret(key, secret)
-                ? String.Format(
-                    "Secret successfully set for {0}:{1}",
-                    provider.Key, key)
-                : String.Format(
-                    "Unable to set secret for {0}:{1}",
-                    provider.Key, key);
+                ? $"Secret successfully set for {provider.Key}:{key}"
+                : $"Unable to set secret for {provider.Key}:{key}";
             return response;
 
         }
@@ -377,15 +368,10 @@ namespace PepperDash.Essentials.Core
 
             var key = args[1];
 
-
             provider.SetSecret(key, "");
             response = provider.SetSecret(key, "")
-                ? String.Format(
-                    "Secret successfully deleted for {0}:{1}",
-                    provider.Key, key)
-                : String.Format(
-                    "Unable to delete secret for {0}:{1}",
-                    provider.Key, key);
+                ? $"Secret successfully deleted for {provider.Key}:{key}"
+                : $"Unable to delete secret for {provider.Key}:{key}";
             CrestronConsole.ConsoleCommandResponse(response);
             return;
 


### PR DESCRIPTION
This pull request refactors the `SecretsManager` class to improve logging practices and modernize string formatting. The main changes include replacing the use of `Debug.LogMessage` with the provider's own logging method, and updating string formatting to use interpolated strings for better readability and maintainability.

**Logging improvements:**
* Replaced calls to `Debug.LogMessage` with `provider.LogVerbose` for more consistent and encapsulated logging within the `SecretsManager` class.

**Code modernization and readability:**
* Updated all string formatting in secret management methods (`UpdateSecret`, `SetSecret`, and secret deletion process) to use C# string interpolation instead of `String.Format`. This makes the code easier to read and less error-prone. [[1]](diffhunk://#diff-7c21e91ea36cca19a62e9b6d9b571414c4c8fe793c0024c6f1af65caf2805af9L299-R322) [[2]](diffhunk://#diff-7c21e91ea36cca19a62e9b6d9b571414c4c8fe793c0024c6f1af65caf2805af9L380-R374)

**Dependency management:**
* Added a `using PepperDash.Core.Logging;` directive to the top of the file to support the new logging method.