### PR TITLE
fix(config): version data, packageManifest API, and v1/v2 config detection

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <Version>2.29.0-local</Version>
+    <Version>2.36.6-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Authors>PepperDash Technology</Authors>
     <Company>PepperDash Technology</Company>
     <Product>PepperDash Essentials</Product>
-    <Copyright>Copyright ©  2025</Copyright>
+    <Copyright>Copyright © 2026</Copyright>
     <RepositoryUrl>https://github.com/PepperDash/Essentials</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Crestron; 4series</PackageTags>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,4 +20,7 @@
     <None Include="..\..\LICENSE.md" Pack="true" PackagePath=""/>
     <None Include="..\..\README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyMetadata Include="PackageId" Value="$(PackageId)" />
+  </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.Core/Config/Essentials/ConfigReader.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/ConfigReader.cs
@@ -135,18 +135,22 @@ namespace PepperDash.Essentials.Core.Config
                     {
                         var parsedConfig = JObject.Parse(fs.ReadToEnd());
 
-                        // Check if it's a v2 config (check for "version" node)
-                        // this means it's already merged by the Portal API
-                        // from the v2 config tool
-                        var isV2Config = parsedConfig["versions"] != null;
-                        
-                        if (isV2Config)
+                        // A config is v1 if it has separate "system" and "template" nodes that
+                        // need to be merged. A v2 config is already merged by the Portal API and
+                        // will not have "system"/"template" nodes. This is independent of whether
+                        // a "versions" node is present, which only carries version metadata and
+                        // can appear on either a v1 or v2 config.
+                        var isV1Config = parsedConfig["system"] != null && parsedConfig["template"] != null;
+
+                        if (!isV1Config)
                         {
                             Debug.LogMessage(LogEventLevel.Information, "Config file is a v2 format, no merge necessary.");
                             ConfigObject = parsedConfig.ToObject<EssentialsConfig>();
                             Debug.LogMessage(LogEventLevel.Information, "Successfully Loaded v2 Config");
                             return true;
                         }
+
+                        Debug.LogMessage(LogEventLevel.Information, "Config file is a v1 format, merging system and template.");
 
                         // Extract SystemUrl and TemplateUrl into final config output
                         ConfigObject = PortalConfigReader.MergeConfigs(parsedConfig).ToObject<EssentialsConfig>();
@@ -159,6 +163,13 @@ namespace PepperDash.Essentials.Core.Config
                         if (parsedConfig["template_url"] != null)
                         {
                             ConfigObject.TemplateUrl = parsedConfig["template_url"].Value<string>();
+                        }
+
+                        // MergeConfigs does not carry the "versions" node forward, so it must be
+                        // applied separately to ensure it's preserved in the merged config.
+                        if (parsedConfig["versions"] != null)
+                        {
+                            ConfigObject.Versions = parsedConfig["versions"].ToObject<VersionData>();
                         }
                     }
 

--- a/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
@@ -105,6 +105,7 @@ namespace PepperDash.Essentials.Core.Config
         /// <summary>
         /// Gets or sets the Versions
         /// </summary>
+        [JsonProperty("versions")]
         public VersionData Versions { get; set; }
 
         /// <summary>
@@ -170,14 +171,20 @@ namespace PepperDash.Essentials.Core.Config
         /// <summary>
         /// Gets or sets the PackageId
         /// </summary>
-        [JsonProperty("packageId")]
+        [JsonProperty("packageId", NullValueHandling = NullValueHandling.Ignore)]
         public string PackageId { get; set; }
 
         /// <summary>
         /// Gets or sets the RepoUrl
         /// </summary>
-        [JsonProperty("repoUrl")]
+        [JsonProperty("repoUrl", NullValueHandling = NullValueHandling.Ignore)]
         public string RepoUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the human-readable name
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
     }
 
     /// <summary>

--- a/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
+++ b/src/PepperDash.Essentials.Core/Config/Essentials/EssentialsConfig.cs
@@ -135,11 +135,24 @@ namespace PepperDash.Essentials.Core.Config
         public List<NugetVersion> Packages { get; set; }
 
         /// <summary>
+        /// Gets or sets the touchpanel wrapper app version
+        /// </summary>
+        [JsonProperty("touchpanelWrapperApp")]
+        public NugetVersion TouchpanelWrapperApp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of user interface packages
+        /// </summary>
+        [JsonProperty("userInterfaces")]
+        public List<NugetVersion> UserInterfaces { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="VersionData"/> class.
         /// </summary>
         public VersionData()
         {
             Packages = new List<NugetVersion>();
+            UserInterfaces = new List<NugetVersion>();
         }
     }
 
@@ -159,6 +172,12 @@ namespace PepperDash.Essentials.Core.Config
         /// </summary>
         [JsonProperty("packageId")]
         public string PackageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the RepoUrl
+        /// </summary>
+        [JsonProperty("repoUrl")]
+        public string RepoUrl { get; set; }
     }
 
     /// <summary>

--- a/src/PepperDash.Essentials.Core/Web/EssentialsWebApi.cs
+++ b/src/PepperDash.Essentials.Core/Web/EssentialsWebApi.cs
@@ -95,6 +95,11 @@ namespace PepperDash.Essentials.Core.Web
                     Name = "ReportVersions",
                     RouteHandler = new ReportVersionsRequestHandler()
                 },
+                new HttpCwsRoute("packageManifest")
+                {
+                    Name = "GetPackageManifest",
+                    RouteHandler = new GetPackageManifestRequestHandler()
+                },
                 new HttpCwsRoute("appdebug")
                 {
                     Name = "AppDebug",

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -93,7 +93,15 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 				essentials.Name = name;
 			}
 
-			if (string.IsNullOrEmpty(essentials.PackageId))
+			// Prefer the PackageId embedded via Directory.Build.props' AssemblyMetadata item (the
+			// authoritative source, matching the actual published PackageId) over any config-supplied
+			// or hardcoded value.
+			var reflectedPackageId = GetAssemblyMetadataValue(essentialsAssembly, "PackageId");
+			if (!string.IsNullOrEmpty(reflectedPackageId))
+			{
+				essentials.PackageId = reflectedPackageId;
+			}
+			else if (string.IsNullOrEmpty(essentials.PackageId))
 			{
 				essentials.PackageId = "PepperDash.Essentials";
 			}
@@ -123,6 +131,11 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 				var reflectedRepoUrl = TrimTrailingGit(GetAssemblyMetadataValue(loaded.Assembly, "RepositoryUrl"));
 				var reflectedName = GetAssemblyProduct(loaded.Assembly);
 
+				// Plugins built from a Directory.Build.props that embeds
+				// <AssemblyMetadata Include="PackageId" Value="$(PackageId)" /> carry their PackageId
+				// directly - this is authoritative and should be preferred over the title/name fallback chain.
+				var reflectedPackageId = GetAssemblyMetadataValue(loaded.Assembly, "PackageId");
+
 				var assemblyTitle = GetAssemblyTitle(loaded.Assembly);
 				var assemblyName = loaded.Assembly.GetName().Name;
 				var assemblyNameNoSeriesSuffix = StripTrailingSeriesSuffix(assemblyName);
@@ -130,7 +143,8 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 				var match = configPackages.FirstOrDefault(p =>
 					!matchedConfigPackages.Contains(p) &&
 					!string.IsNullOrEmpty(p.PackageId) &&
-					(string.Equals(p.PackageId, assemblyTitle, StringComparison.OrdinalIgnoreCase) ||
+					(string.Equals(p.PackageId, reflectedPackageId, StringComparison.OrdinalIgnoreCase) ||
+					 string.Equals(p.PackageId, assemblyTitle, StringComparison.OrdinalIgnoreCase) ||
 					 string.Equals(p.PackageId, assemblyName, StringComparison.OrdinalIgnoreCase) ||
 					 string.Equals(p.PackageId, assemblyNameNoSeriesSuffix, StringComparison.OrdinalIgnoreCase)));
 
@@ -140,20 +154,22 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 
 					mergedPackages.Add(new NugetVersion
 					{
-						PackageId = match.PackageId,
-						Version = reflectedVersion,
+						Name = !string.IsNullOrEmpty(match.Name) ? match.Name : reflectedName,
 						RepoUrl = !string.IsNullOrEmpty(match.RepoUrl) ? match.RepoUrl : reflectedRepoUrl,
-						Name = !string.IsNullOrEmpty(match.Name) ? match.Name : reflectedName
+						PackageId = !string.IsNullOrEmpty(reflectedPackageId) ? reflectedPackageId : match.PackageId,
+						Version = reflectedVersion
 					});
 				}
 				else
 				{
-					// Loaded but not present (or not matched) in config - emit without a packageId
+					// Loaded but not present (or not matched) in config - emit the reflected PackageId
+					// when the assembly carries one, otherwise leave it null as before.
 					mergedPackages.Add(new NugetVersion
 					{
-						Version = reflectedVersion,
+						Name = reflectedName,
 						RepoUrl = reflectedRepoUrl,
-						Name = reflectedName
+						PackageId = reflectedPackageId,
+						Version = reflectedVersion,						
 					});
 				}
 			}

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -46,8 +46,9 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 				context.Response.Write(js, false);
 				context.Response.End();
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
+				PepperDash.Core.Debug.LogMessage(ex, "Exception handling GET /packageManifest request");
 				context.Response.StatusCode = 500;
 				context.Response.StatusDescription = "Internal Server Error";
 				context.Response.End();

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -77,9 +77,15 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 
 			essentials.Version = Global.AssemblyVersion;
 
-			// PepperDash_Essentials_Core.dll - same repo/Directory.Build.props as PepperDashEssentials.dll,
-			// and unlike PluginLoader.EssentialsAssembly, this Assembly reference is never null at runtime.
-			var essentialsAssembly = typeof(GetPackageManifestRequestHandler).Assembly;
+			// The main program assembly (AssemblyName/PackageId "PepperDashEssentials") is what's
+			// actually published to NuGet, but this handler lives in PepperDash.Essentials.Core, which
+			// can't reference that project's types directly (Essentials -> Core, not the reverse).
+			// PluginLoader.EssentialsAssembly.Assembly is unreliable (often left null - see
+			// PluginLoader.SetEssentialsAssembly), so look it up directly from the loaded AppDomain,
+			// falling back to this handler's own (Core) assembly if it can't be found.
+			var essentialsAssembly = AppDomain.CurrentDomain.GetAssemblies()
+				.FirstOrDefault(a => string.Equals(a.GetName().Name, "PepperDashEssentials", StringComparison.OrdinalIgnoreCase))
+				?? typeof(GetPackageManifestRequestHandler).Assembly;
 
 			var repoUrl = TrimTrailingGit(GetAssemblyMetadataValue(essentialsAssembly, "RepositoryUrl"));
 			if (!string.IsNullOrEmpty(repoUrl))
@@ -103,7 +109,7 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 			}
 			else if (string.IsNullOrEmpty(essentials.PackageId))
 			{
-				essentials.PackageId = "PepperDash.Essentials";
+				essentials.PackageId = "PepperDashEssentials";
 			}
 
 			result.Essentials = essentials;

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -77,14 +77,15 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 
 			essentials.Version = Global.AssemblyVersion;
 
-			// The main program assembly (AssemblyName/PackageId "PepperDashEssentials") is what's
-			// actually published to NuGet, but this handler lives in PepperDash.Essentials.Core, which
-			// can't reference that project's types directly (Essentials -> Core, not the reverse).
-			// PluginLoader.EssentialsAssembly.Assembly is unreliable (often left null - see
-			// PluginLoader.SetEssentialsAssembly), so look it up directly from the loaded AppDomain,
-			// falling back to this handler's own (Core) assembly if it can't be found.
+			// The main program assembly (PackageId "PepperDashEssentials") is what's actually published
+			// to NuGet, but this handler lives in PepperDash.Essentials.Core, which can't reference that
+			// project's types directly (Essentials -> Core, not the reverse). PluginLoader.EssentialsAssembly.Assembly
+			// is unreliable (often left null - see PluginLoader.SetEssentialsAssembly), so look it up
+			// directly from the loaded AppDomain by its Directory.Build.props-embedded PackageId metadata
+			// (every project's .csproj sets its own PackageId explicitly), falling back to this handler's
+			// own (Core) assembly if it can't be found.
 			var essentialsAssembly = AppDomain.CurrentDomain.GetAssemblies()
-				.FirstOrDefault(a => string.Equals(a.GetName().Name, "PepperDashEssentials", StringComparison.OrdinalIgnoreCase))
+				.FirstOrDefault(a => string.Equals(GetAssemblyMetadataValue(a, "PackageId"), "PepperDashEssentials", StringComparison.OrdinalIgnoreCase))
 				?? typeof(GetPackageManifestRequestHandler).Assembly;
 
 			var repoUrl = TrimTrailingGit(GetAssemblyMetadataValue(essentialsAssembly, "RepositoryUrl"));

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -122,7 +122,11 @@ namespace PepperDash.Essentials.Core.Web.RequestHandlers
 		/// </summary>
 		private static void PopulatePackages(VersionData result)
 		{
-			var configPackages = result.Packages ?? new System.Collections.Generic.List<NugetVersion>();
+			// Filter out null entries defensively - the packages list is deserialized from user-editable
+			// config JSON, so a malformed "packages": [null, ...] shouldn't throw and 500 the endpoint.
+			var configPackages = (result.Packages ?? new System.Collections.Generic.List<NugetVersion>())
+				.Where(p => p != null)
+				.ToList();
 			var matchedConfigPackages = new System.Collections.Generic.HashSet<NugetVersion>();
 			var mergedPackages = new System.Collections.Generic.List<NugetVersion>();
 

--- a/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
+++ b/src/PepperDash.Essentials.Core/Web/RequestHandlers/GetPackageManifestRequestHandler.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Crestron.SimplSharp.WebScripting;
+using Newtonsoft.Json;
+using PepperDash.Core.Web.RequestHandlers;
+using PepperDash.Essentials.Core.Config;
+
+namespace PepperDash.Essentials.Core.Web.RequestHandlers
+{
+	/// <summary>
+	/// Represents a GetPackageManifestRequestHandler
+	/// </summary>
+	public class GetPackageManifestRequestHandler : WebApiBaseRequestHandler
+	{
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <remarks>
+		/// base(true) enables CORS support by default
+		/// </remarks>
+		public GetPackageManifestRequestHandler()
+			: base(true)
+		{
+		}
+
+		/// <summary>
+		/// Handles GET method requests
+		/// </summary>
+		/// <param name="context"></param>
+		protected override void HandleGet(HttpCwsContext context)
+		{
+			try
+			{
+				var result = CloneVersionData(ConfigReader.ConfigObject?.Versions) ?? new VersionData();
+
+				PopulateEssentials(result);
+				PopulatePackages(result);
+
+				var js = JsonConvert.SerializeObject(result, Formatting.Indented);
+
+				context.Response.StatusCode = 200;
+				context.Response.StatusDescription = "OK";
+				context.Response.ContentType = "application/json";
+				context.Response.ContentEncoding = System.Text.Encoding.UTF8;
+				context.Response.Write(js, false);
+				context.Response.End();
+			}
+			catch (Exception)
+			{
+				context.Response.StatusCode = 500;
+				context.Response.StatusDescription = "Internal Server Error";
+				context.Response.End();
+			}
+		}
+
+		/// <summary>
+		/// Deep-copies the config's VersionData so the live config object is never mutated
+		/// </summary>
+		private static VersionData CloneVersionData(VersionData source)
+		{
+			if (source == null)
+			{
+				return null;
+			}
+
+			var json = JsonConvert.SerializeObject(source);
+			return JsonConvert.DeserializeObject<VersionData>(json);
+		}
+
+		/// <summary>
+		/// Enriches (or creates) the essentials entry from the loaded PepperDash.Essentials.Core assembly
+		/// </summary>
+		private static void PopulateEssentials(VersionData result)
+		{
+			var essentials = result.Essentials ?? new NugetVersion();
+
+			essentials.Version = Global.AssemblyVersion;
+
+			// PepperDash_Essentials_Core.dll - same repo/Directory.Build.props as PepperDashEssentials.dll,
+			// and unlike PluginLoader.EssentialsAssembly, this Assembly reference is never null at runtime.
+			var essentialsAssembly = typeof(GetPackageManifestRequestHandler).Assembly;
+
+			var repoUrl = TrimTrailingGit(GetAssemblyMetadataValue(essentialsAssembly, "RepositoryUrl"));
+			if (!string.IsNullOrEmpty(repoUrl))
+			{
+				essentials.RepoUrl = repoUrl;
+			}
+
+			var name = GetAssemblyProduct(essentialsAssembly);
+			if (!string.IsNullOrEmpty(name))
+			{
+				essentials.Name = name;
+			}
+
+			if (string.IsNullOrEmpty(essentials.PackageId))
+			{
+				essentials.PackageId = "PepperDash.Essentials";
+			}
+
+			result.Essentials = essentials;
+		}
+
+		/// <summary>
+		/// Merges reflection data from loaded plugin assemblies with the config's packages list
+		/// </summary>
+		private static void PopulatePackages(VersionData result)
+		{
+			var configPackages = result.Packages ?? new System.Collections.Generic.List<NugetVersion>();
+			var matchedConfigPackages = new System.Collections.Generic.HashSet<NugetVersion>();
+			var mergedPackages = new System.Collections.Generic.List<NugetVersion>();
+
+			foreach (var loaded in PluginLoader.EssentialsPluginAssemblies.Where(a => a.Assembly != null))
+			{
+				var reflectedVersion = loaded.Version;
+				if (string.IsNullOrEmpty(reflectedVersion))
+				{
+					// Never emit an entry with no version - the extension's parser drops entries
+					// whose version isn't a string.
+					continue;
+				}
+
+				var reflectedRepoUrl = TrimTrailingGit(GetAssemblyMetadataValue(loaded.Assembly, "RepositoryUrl"));
+				var reflectedName = GetAssemblyProduct(loaded.Assembly);
+
+				var assemblyTitle = GetAssemblyTitle(loaded.Assembly);
+				var assemblyName = loaded.Assembly.GetName().Name;
+				var assemblyNameNoSeriesSuffix = StripTrailingSeriesSuffix(assemblyName);
+
+				var match = configPackages.FirstOrDefault(p =>
+					!matchedConfigPackages.Contains(p) &&
+					!string.IsNullOrEmpty(p.PackageId) &&
+					(string.Equals(p.PackageId, assemblyTitle, StringComparison.OrdinalIgnoreCase) ||
+					 string.Equals(p.PackageId, assemblyName, StringComparison.OrdinalIgnoreCase) ||
+					 string.Equals(p.PackageId, assemblyNameNoSeriesSuffix, StringComparison.OrdinalIgnoreCase)));
+
+				if (match != null)
+				{
+					matchedConfigPackages.Add(match);
+
+					mergedPackages.Add(new NugetVersion
+					{
+						PackageId = match.PackageId,
+						Version = reflectedVersion,
+						RepoUrl = !string.IsNullOrEmpty(match.RepoUrl) ? match.RepoUrl : reflectedRepoUrl,
+						Name = !string.IsNullOrEmpty(match.Name) ? match.Name : reflectedName
+					});
+				}
+				else
+				{
+					// Loaded but not present (or not matched) in config - emit without a packageId
+					mergedPackages.Add(new NugetVersion
+					{
+						Version = reflectedVersion,
+						RepoUrl = reflectedRepoUrl,
+						Name = reflectedName
+					});
+				}
+			}
+
+			// Configured but not currently loaded - pass through unchanged
+			mergedPackages.AddRange(configPackages.Where(p => !matchedConfigPackages.Contains(p)));
+
+			result.Packages = mergedPackages;
+		}
+
+		private static string GetAssemblyMetadataValue(Assembly assembly, string key)
+		{
+			if (assembly == null)
+			{
+				return null;
+			}
+
+			var match = assembly.GetCustomAttributes(typeof(AssemblyMetadataAttribute), false)
+				.Cast<AssemblyMetadataAttribute>()
+				.FirstOrDefault(a => string.Equals(a.Key, key, StringComparison.OrdinalIgnoreCase));
+
+			return match?.Value;
+		}
+
+		private static string GetAssemblyProduct(Assembly assembly)
+		{
+			if (assembly == null)
+			{
+				return null;
+			}
+
+			var attribute = assembly.GetCustomAttributes(typeof(AssemblyProductAttribute), false)
+				.FirstOrDefault() as AssemblyProductAttribute;
+
+			return attribute?.Product;
+		}
+
+		private static string GetAssemblyTitle(Assembly assembly)
+		{
+			if (assembly == null)
+			{
+				return null;
+			}
+
+			var attribute = assembly.GetCustomAttributes(typeof(AssemblyTitleAttribute), false)
+				.FirstOrDefault() as AssemblyTitleAttribute;
+
+			return attribute?.Title;
+		}
+
+		private static string StripTrailingSeriesSuffix(string assemblyName)
+		{
+			const string suffix = ".4Series";
+
+			if (string.IsNullOrEmpty(assemblyName) || !assemblyName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+			{
+				return assemblyName;
+			}
+
+			return assemblyName.Substring(0, assemblyName.Length - suffix.Length);
+		}
+
+		private static string TrimTrailingGit(string repoUrl)
+		{
+			const string suffix = ".git";
+
+			if (string.IsNullOrEmpty(repoUrl) || !repoUrl.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+			{
+				return repoUrl;
+			}
+
+			return repoUrl.Substring(0, repoUrl.Length - suffix.Length);
+		}
+	}
+}

--- a/src/PepperDash.Essentials.MobileControl/ConnectedClientVersionInfo.cs
+++ b/src/PepperDash.Essentials.MobileControl/ConnectedClientVersionInfo.cs
@@ -43,5 +43,19 @@ namespace PepperDash.Essentials
         /// </summary>
         [JsonProperty("lastSeen")]
         public DateTime LastSeen { get; set; }
+
+        /// <summary>
+        /// Returns a copy of this instance, safe for callers outside the owning lock to hold/mutate
+        /// without affecting the internally tracked instance
+        /// </summary>
+        public ConnectedClientVersionInfo Clone() => new ConnectedClientVersionInfo
+        {
+            ClientId = ClientId,
+            RoomKey = RoomKey,
+            TouchpanelKey = TouchpanelKey,
+            AppVersion = AppVersion,
+            ExpectedAppVersion = ExpectedAppVersion,
+            LastSeen = LastSeen
+        };
     }
 }

--- a/src/PepperDash.Essentials.MobileControl/ConnectedClientVersionInfo.cs
+++ b/src/PepperDash.Essentials.MobileControl/ConnectedClientVersionInfo.cs
@@ -1,0 +1,47 @@
+using System;
+using Newtonsoft.Json;
+
+namespace PepperDash.Essentials
+{
+    /// <summary>
+    /// Represents the version information reported by a connected Mobile Control UI client
+    /// </summary>
+    public class ConnectedClientVersionInfo
+    {
+        /// <summary>
+        /// Gets or sets the client id
+        /// </summary>
+        [JsonProperty("clientId")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the room key the client joined
+        /// </summary>
+        [JsonProperty("roomKey")]
+        public string RoomKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the touchpanel key the client joined as, if any
+        /// </summary>
+        [JsonProperty("touchpanelKey")]
+        public string TouchpanelKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the app version reported by the client (e.g. the React app's build-time APP_VERSION)
+        /// </summary>
+        [JsonProperty("appVersion")]
+        public string AppVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expected app version from the system config's versions.touchpanelWrapperApp, if configured
+        /// </summary>
+        [JsonProperty("expectedAppVersion")]
+        public string ExpectedAppVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UTC time the client last reported this version
+        /// </summary>
+        [JsonProperty("lastSeen")]
+        public DateTime LastSeen { get; set; }
+    }
+}

--- a/src/PepperDash.Essentials.MobileControl/MobileControlSystemController.cs
+++ b/src/PepperDash.Essentials.MobileControl/MobileControlSystemController.cs
@@ -89,7 +89,7 @@ namespace PepperDash.Essentials
                 lock (_connectedClientVersionsLock)
                 {
                     return new ReadOnlyDictionary<string, ConnectedClientVersionInfo>(
-                        new Dictionary<string, ConnectedClientVersionInfo>(_connectedClientVersions)
+                        _connectedClientVersions.ToDictionary(kv => kv.Key, kv => kv.Value.Clone())
                     );
                 }
             }
@@ -1820,7 +1820,7 @@ namespace PepperDash.Essentials
 
                     CrestronConsole.ConsoleCommandResponse(
                         $"  Client: {v.ClientId}  Touchpanel: {v.TouchpanelKey}  Room: {v.RoomKey}\r\n" +
-                        $"    Reported: {v.AppVersion}  Expected: {v.ExpectedAppVersion ?? "(not configured)"}  Match: {(match ? "Yes" : "NO - MISMATCH")}\r\n" +
+                        $"    Reported: {v.AppVersion}  Expected: {(string.IsNullOrEmpty(v.ExpectedAppVersion) ? "(not configured)" : v.ExpectedAppVersion)}  Match: {(match ? "Yes" : "NO - MISMATCH")}\r\n" +
                         $"    Last Seen (UTC): {v.LastSeen:yyyy-MM-dd HH:mm:ss}\r\n"
                     );
                 }

--- a/src/PepperDash.Essentials.MobileControl/MobileControlSystemController.cs
+++ b/src/PepperDash.Essentials.MobileControl/MobileControlSystemController.cs
@@ -69,10 +69,31 @@ namespace PepperDash.Essentials
         private readonly Dictionary<string, IMobileControlMessenger> _defaultMessengers =
             new Dictionary<string, IMobileControlMessenger>();
 
+        private readonly Dictionary<string, ConnectedClientVersionInfo> _connectedClientVersions =
+            new Dictionary<string, ConnectedClientVersionInfo>(StringComparer.InvariantCultureIgnoreCase);
+
+        private readonly object _connectedClientVersionsLock = new object();
+
         /// <summary>
         /// Get the custom messengers with subscriptions
         /// </summary>
         public ReadOnlyDictionary<string, IMobileControlMessengerWithSubscriptions> Messengers => new ReadOnlyDictionary<string, IMobileControlMessengerWithSubscriptions>(_messengers.Values.OfType<IMobileControlMessengerWithSubscriptions>().ToDictionary(k => k.Key, v => v));
+
+        /// <summary>
+        /// Gets the most recently reported UI app version for each connected client, keyed by clientId
+        /// </summary>
+        public ReadOnlyDictionary<string, ConnectedClientVersionInfo> ConnectedClientVersions
+        {
+            get
+            {
+                lock (_connectedClientVersionsLock)
+                {
+                    return new ReadOnlyDictionary<string, ConnectedClientVersionInfo>(
+                        new Dictionary<string, ConnectedClientVersionInfo>(_connectedClientVersions)
+                    );
+                }
+            }
+        }
 
         /// <summary>
         /// Get the default messengers
@@ -1782,6 +1803,28 @@ namespace PepperDash.Essentials
                     "    Not Enabled in Config.\r\n"
                 );
             }
+
+            var connectedClientVersions = ConnectedClientVersions;
+
+            if (connectedClientVersions.Count == 0)
+            {
+                CrestronConsole.ConsoleCommandResponse("\r\nUI Client App Versions: None reported yet\r\n");
+            }
+            else
+            {
+                CrestronConsole.ConsoleCommandResponse("\r\nUI Client App Versions:\r\n");
+                foreach (var kv in connectedClientVersions)
+                {
+                    var v = kv.Value;
+                    var match = string.IsNullOrEmpty(v.ExpectedAppVersion) || string.Equals(v.ExpectedAppVersion, v.AppVersion, StringComparison.OrdinalIgnoreCase);
+
+                    CrestronConsole.ConsoleCommandResponse(
+                        $"  Client: {v.ClientId}  Touchpanel: {v.TouchpanelKey}  Room: {v.RoomKey}\r\n" +
+                        $"    Reported: {v.AppVersion}  Expected: {v.ExpectedAppVersion ?? "(not configured)"}  Match: {(match ? "Yes" : "NO - MISMATCH")}\r\n" +
+                        $"    Last Seen (UTC): {v.LastSeen:yyyy-MM-dd HH:mm:ss}\r\n"
+                    );
+                }
+            }
         }
 
         /// <summary>
@@ -2181,6 +2224,8 @@ namespace PepperDash.Essentials
             var roomKey = content["roomKey"].Value<string>();
             var touchpanelKey = content.SelectToken("touchpanelKey");
 
+            TrackClientAppVersion(clientId, roomKey, touchpanelKey?.Value<string>(), content.SelectToken("appVersion")?.Value<string>());
+
             if (_roomCombiner == null)
             {
                 var message = new MobileControlMessage
@@ -2250,6 +2295,50 @@ namespace PepperDash.Essentials
             SendDeviceInterfaces(clientId);
 
             SendTouchpanelKey(clientId, touchpanelKey);
+        }
+
+        /// <summary>
+        /// Records the app version reported by a connecting UI client (e.g. the mobile control React app's
+        /// build-time APP_VERSION) and compares it against the configured versions.touchpanelWrapperApp version.
+        /// </summary>
+        private void TrackClientAppVersion(string clientId, string roomKey, string touchpanelKey, string appVersion)
+        {
+            if (string.IsNullOrEmpty(appVersion))
+            {
+                return;
+            }
+
+            var expectedVersion = ConfigReader.ConfigObject?.Versions?.TouchpanelWrapperApp?.Version;
+
+            var info = new ConnectedClientVersionInfo
+            {
+                ClientId = clientId,
+                RoomKey = roomKey,
+                TouchpanelKey = touchpanelKey,
+                AppVersion = appVersion,
+                ExpectedAppVersion = expectedVersion,
+                LastSeen = DateTime.UtcNow
+            };
+
+            lock (_connectedClientVersionsLock)
+            {
+                _connectedClientVersions[clientId] = info;
+            }
+
+            if (!string.IsNullOrEmpty(expectedVersion) && !string.Equals(expectedVersion, appVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                this.LogWarning(
+                    "Client {clientId} (touchpanel {touchpanelKey}) reported UI app version {appVersion}, which does not match configured versions.touchpanelWrapperApp version {expectedVersion}",
+                    clientId, touchpanelKey, appVersion, expectedVersion
+                );
+            }
+            else
+            {
+                this.LogVerbose(
+                    "Client {clientId} (touchpanel {touchpanelKey}) reported UI app version {appVersion}",
+                    clientId, touchpanelKey, appVersion
+                );
+            }
         }
 
         private void SendTouchpanelKey(string clientId, JToken touchpanelKeyToken)


### PR DESCRIPTION
## Summary

Adds a new `packageManifest` CWS API endpoint that reports version/package info for Essentials, plugins, and touchpanel UI packages, and fixes a config-merge bug where a v1 config's `versions` node was silently dropped after the system/template merge.

## Changes

- **`GetPackageManifestRequestHandler`** (new): Serves `GET /packageManifest`, returning a deep-cloned, enriched `VersionData` payload (Essentials assembly version/repo/name plus loaded packages). Prefers the `PackageId` embedded via `Directory.Build.props`' `AssemblyMetadata` item over any config-supplied/hardcoded value.
- **`EssentialsWebApi.cs`**: Registers the new `packageManifest` route alongside the existing `ReportVersions` route.
- **`EssentialsConfig.cs`** (`VersionData`/`NugetVersion`):
  - Adds `[JsonProperty("versions")]` on `Versions` so it round-trips correctly.
  - Adds `TouchpanelWrapperApp` and `UserInterfaces` for touchpanel UI package version data.
  - Adds `RepoUrl` and `Name` to `NugetVersion`, both ignored when null.
- **`ConfigReader.cs`**: Fixes v1/v2 config detection. Previously a config was treated as "already merged" (v2) whenever a `versions` node was present, but `versions` can legitimately appear on either format. Now detects v1 by the presence of `system`/`template` nodes (which require merging) instead, and explicitly re-applies the `versions` node after merge since `PortalConfigReader.MergeConfigs` doesn't carry it forward.
- **`Directory.Build.props`**: Bumps local version to `2.36.6-local`, updates copyright year, and adds a `PackageId` `AssemblyMetadata` item so it can be reflected at runtime by the new endpoint.

## Testing

Reviewed diff against `main`; no automated tests added in this branch.

## Notes for Reviewers

- The config-detection fix addresses a real bug: any v1 config that happened to include a `versions` node would have skipped the required system/template merge entirely.


Closes #1440
