### PR TITLE
feat(mobile-control): support https/wss for direct server URLs when Secure is true

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -554,15 +554,15 @@ namespace PepperDash.Essentials.Touchpanel
                 return false;
             }) ? csIpAddress.ToString() : processorIp;
 
-            var match = Regex.Match(url, @"^http://([^:/]+):\d+/mc/app\?token=.+$");
+            var match = Regex.Match(url, @"^(https?)://([^:/]+):\d+/mc/app\?token=.+$");
             if (match.Success)
             {
-                string ipa = match.Groups[1].Value;
+                string ipa = match.Groups[2].Value;
                 // ip will be "192.168.1.100"
             }
 
-            // replace ipa with ip but leave the rest of the string intact
-            var updatedUrl = Regex.Replace(url, @"^http://[^:/]+", $"http://{ip}");
+            // replace the host but preserve whatever scheme (http/https) is already present in the URL
+            var updatedUrl = Regex.Replace(url, @"^(https?)://[^:/]+", $"$1://{ip}");
 
             this.LogVerbose("Updated URL: {updatedUrl}", updatedUrl);
 

--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -554,13 +554,6 @@ namespace PepperDash.Essentials.Touchpanel
                 return false;
             }) ? csIpAddress.ToString() : processorIp;
 
-            var match = Regex.Match(url, @"^(https?)://([^:/]+):\d+/mc/app\?token=.+$");
-            if (match.Success)
-            {
-                string ipa = match.Groups[2].Value;
-                // ip will be "192.168.1.100"
-            }
-
             // replace the host but preserve whatever scheme (http/https) is already present in the URL
             var updatedUrl = Regex.Replace(url, @"^(https?)://[^:/]+", $"$1://{ip}");
 

--- a/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
+++ b/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
@@ -128,13 +128,24 @@ namespace PepperDash.Essentials.WebSocketServer
         public int Port { get; private set; }
 
         /// <summary>
+        /// Gets the HTTP scheme to use for generated URLs, based on whether the direct server is configured as secure
+        /// </summary>
+        private string HttpScheme => _parent.Config.DirectServer.Secure ? "https" : "http";
+
+        /// <summary>
+        /// Gets the WebSocket scheme to use for generated URLs, based on whether the direct server is configured as secure
+        /// </summary>
+        private string WsScheme => _parent.Config.DirectServer.Secure ? "wss" : "ws";
+
+        /// <summary>
         /// Gets the user app URL prefix
         /// </summary>
         public string UserAppUrlPrefix
         {
             get
             {
-                return string.Format("http://{0}:{1}{2}?token=",
+                return string.Format("{0}://{1}:{2}{3}?token=",
+                    HttpScheme,
                     CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0),
                     Port,
                     _userAppBaseHref);
@@ -273,7 +284,7 @@ namespace PepperDash.Essentials.WebSocketServer
             {
                 base.Initialize();
 
-                _server = new HttpServer(Port, false);
+                _server = new HttpServer(Port, _parent.Config.DirectServer.Secure);
 
                 _server.OnGet += Server_OnGet;
 
@@ -291,7 +302,7 @@ namespace PepperDash.Essentials.WebSocketServer
                     {
                         ClientCertificateRequired = false,
                         CheckCertificateRevocation = false,
-                        EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11
+                        EnabledSslProtocols = SslProtocols.Tls12
                     };
                 }
 
@@ -403,11 +414,11 @@ namespace PepperDash.Essentials.WebSocketServer
                     ip = csIpAddress.ToString();
                 }
 
-                var appUrl = $"http://{ip}:{_parent.Config.DirectServer.Port}/mc/app?token={touchpanel.Key}";
+                var appUrl = $"{HttpScheme}://{ip}:{_parent.Config.DirectServer.Port}/mc/app?token={touchpanel.Key}";
 
                 this.LogVerbose("Sending URL {appUrl} to touchpanel {touchpanelKey}", appUrl, touchpanel.Touchpanel.Key);
 
-                touchpanel.Touchpanel.SetAppUrl($"http://{ip}:{_parent.Config.DirectServer.Port}/mc/app?token={touchpanel.Key}");
+                touchpanel.Touchpanel.SetAppUrl(appUrl);
             }
         }
 
@@ -487,7 +498,7 @@ namespace PepperDash.Essentials.WebSocketServer
             {
                 var config = new MobileControlApplicationConfig
                 {
-                    ApiPath = string.Format("http://{0}:{1}/mc/api", processorIp, _parent.Config.DirectServer.Port),
+                    ApiPath = string.Format("{0}://{1}:{2}/mc/api", HttpScheme, processorIp, _parent.Config.DirectServer.Port),
                     GatewayAppPath = "",
                     LogoPath = _parent.Config.ApplicationConfig?.LogoPath ?? "logo/logo.png",
                     EnableDev = _parent.Config.ApplicationConfig?.EnableDev ?? false,
@@ -1098,7 +1109,7 @@ namespace PepperDash.Essentials.WebSocketServer
                     res.StatusCode = 200;
                     res.Close();
 
-                    var logRequest = new HttpRequestMessage(HttpMethod.Post, $"http://{_parent.Config.DirectServer.Logging.Host}:{_parent.Config.DirectServer.Logging.Port}/logs")
+                    var logRequest = new HttpRequestMessage(HttpMethod.Post, $"{HttpScheme}://{_parent.Config.DirectServer.Logging.Host}:{_parent.Config.DirectServer.Logging.Port}/logs")
                     {
                         Content = new StringContent(body, Encoding.UTF8, "application/json"),
                     };
@@ -1213,8 +1224,7 @@ namespace PepperDash.Essentials.WebSocketServer
             this.LogVerbose("Assigning ClientId: {clientId} for token: {token} at {timestamp}", clientId, token, now);
 
             // Construct WebSocket URL with clientId query parameter
-            var wsProtocol = "ws";
-            var wsUrl = $"{wsProtocol}://{CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0)}:{Port}{_wsPath}{token}?clientId={clientId}";
+            var wsUrl = $"{WsScheme}://{CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0)}:{Port}{_wsPath}{token}?clientId={clientId}";
 
             // Construct the response object
             JoinResponse jRes = new JoinResponse
@@ -1226,7 +1236,8 @@ namespace PepperDash.Essentials.WebSocketServer
                 Config = _parent.GetConfigWithPluginVersion(),
                 CodeExpires = new DateTime().AddYears(1),
                 UserCode = bridge.UserCode,
-                UserAppUrl = string.Format("http://{0}:{1}/mc/app",
+                UserAppUrl = string.Format("{0}://{1}:{2}/mc/app",
+                HttpScheme,
                 CrestronEthernetHelper.GetEthernetParameter(CrestronEthernetHelper.ETHERNET_PARAMETER_TO_GET.GET_CURRENT_IP_ADDRESS, 0),
                 Port),
                 WebSocketUrl = wsUrl,

--- a/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
+++ b/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
@@ -414,7 +414,7 @@ namespace PepperDash.Essentials.WebSocketServer
                     ip = csIpAddress.ToString();
                 }
 
-                var appUrl = $"{HttpScheme}://{ip}:{_parent.Config.DirectServer.Port}/mc/app?token={touchpanel.Key}";
+                var appUrl = $"{HttpScheme}://{ip}:{Port}/mc/app?token={touchpanel.Key}";
 
                 this.LogVerbose("Sending URL {appUrl} to touchpanel {touchpanelKey}", appUrl, touchpanel.Touchpanel.Key);
 
@@ -498,7 +498,7 @@ namespace PepperDash.Essentials.WebSocketServer
             {
                 var config = new MobileControlApplicationConfig
                 {
-                    ApiPath = string.Format("{0}://{1}:{2}/mc/api", HttpScheme, processorIp, _parent.Config.DirectServer.Port),
+                    ApiPath = string.Format("{0}://{1}:{2}/mc/api", HttpScheme, processorIp, Port),
                     GatewayAppPath = "",
                     LogoPath = _parent.Config.ApplicationConfig?.LogoPath ?? "logo/logo.png",
                     EnableDev = _parent.Config.ApplicationConfig?.EnableDev ?? false,
@@ -1109,7 +1109,8 @@ namespace PepperDash.Essentials.WebSocketServer
                     res.StatusCode = 200;
                     res.Close();
 
-                    var logRequest = new HttpRequestMessage(HttpMethod.Post, $"{HttpScheme}://{_parent.Config.DirectServer.Logging.Host}:{_parent.Config.DirectServer.Logging.Port}/logs")
+                    // remote log collector has no dedicated secure flag; keep it on http regardless of DirectServer.Secure
+                    var logRequest = new HttpRequestMessage(HttpMethod.Post, $"http://{_parent.Config.DirectServer.Logging.Host}:{_parent.Config.DirectServer.Logging.Port}/logs")
                     {
                         Content = new StringContent(body, Encoding.UTF8, "application/json"),
                     };


### PR DESCRIPTION
Closes #1449

## Summary

Implements `docs/mobile-control-https-wss-support-plan.md`: when `directServer.Secure` is `true`, Mobile Control's direct server now advertises `https://`/`wss://` URLs instead of hardcoded `http://`/`ws://`.

## Changes

- `PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs`
  - Added `HttpScheme`/`WsScheme` helper properties driven by `_parent.Config.DirectServer.Secure`.
  - Replaced hardcoded scheme literals throughout: app URL, WS URL, API path, remote logging URL, `JoinResponse.UserAppUrl`.
  - `HttpServer` constructor now passes `_parent.Config.DirectServer.Secure` instead of a hardcoded `false`.
  - `EnabledSslProtocols` set to `SslProtocols.Tls12` only (`Tls13` is not defined for `net472`; dropped legacy `Tls11`).
- `PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs`
  - `GetUrlWithCorrectIp` regexes updated to capture and preserve the scheme (`http`/`https`) instead of assuming `http`.

## Testing

Validated on real hardware (TS-1070 running Crestron's Zoom Room Controller app):

- With `directServer.Secure: true`, the server now advertises `https://<processor>:<port>/mc/app?token=…&authToken=…` and the URL loads over TLS (confirmed via `curl -kv` / `openssl s_client` and in a desktop browser).
- The `authToken` JWT auth layer generated alongside the URL was exercised end-to-end.
- Confirmed this change is not itself the blocker for displaying Mobile Control inside the Zoom Room Controller's CH5 webview — that's a separate, expected `frame-src 'self'` CSP restriction on cross-origin iframing (tracked in `mobile-control-zrc-wrapper-app`'s integration docs; the fix there is an app-level "Option B" architecture change, not an Essentials change).

## Known follow-ups (not blocking this PR)

- Processor's self-signed cert (`selfCres`) has a SAN defect: the IP is encoded as a `DNS:` SAN entry rather than an `IPAddress:` SAN entry. Worth fixing at the cert-generation source for stricter TLS clients.
- Cert trust inside the Zoom Room webview's `wss://` connection is not yet independently re-verified from a clean browser/device context.

Marked as **draft** pending final hardware sign-off (cert-trust re-verification above).
