### PR TITLE
feat: add TS-1080 and TSW-1080 touchpanel support

### DIFF
--- a/src/PepperDash.Core/PepperDash.Core.csproj
+++ b/src/PepperDash.Core/PepperDash.Core.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
-    <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.Library" Version="2.21.274" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />

--- a/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
+++ b/src/PepperDash.Essentials.Core/PepperDash.Essentials.Core.csproj
@@ -25,7 +25,7 @@
     <DocumentationFile>bin\$(Configuration)\PepperDash_Essentials_Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.274" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Crestron\CrestronGenericBaseDevice.cs.orig" />

--- a/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
+++ b/src/PepperDash.Essentials.Devices.Common/PepperDash.Essentials.Devices.Common.csproj
@@ -29,6 +29,6 @@
     <ProjectReference Include="..\PepperDash.Essentials.Core\PepperDash.Essentials.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.274" />
   </ItemGroup>
 </Project>

--- a/src/PepperDash.Essentials.MobileControl.Messengers/PepperDash.Essentials.MobileControl.Messengers.csproj
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/PepperDash.Essentials.MobileControl.Messengers.csproj
@@ -33,7 +33,7 @@
     <Compile Remove="Messengers\SIMPLVtcMessenger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.274" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PepperDash.Core\PepperDash.Core.csproj" />

--- a/src/PepperDash.Essentials.MobileControl/PepperDash.Essentials.MobileControl.csproj
+++ b/src/PepperDash.Essentials.MobileControl/PepperDash.Essentials.MobileControl.csproj
@@ -38,7 +38,7 @@
     <Compile Remove="RoomBridges\SourceDeviceMapDictionary.cs" />
   </ItemGroup>  
   <ItemGroup>    
-    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.274" />
     <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -740,7 +740,7 @@ namespace PepperDash.Essentials.Touchpanel
         /// </summary>
         public MobileControlTouchpanelControllerFactory()
         {
-            TypeNames = new List<string>() { "mccrestronapp", "mctsw550", "mctsw750", "mctsw1050", "mctsw560", "mctsw760", "mctsw1060", "mctsw570", "mctsw770", "mcts770", "mctsw1070", "mcts1070", "mcxpanel", "mcdge1000" };
+            TypeNames = new List<string>() { "mccrestronapp", "mctsw550", "mctsw750", "mctsw1050", "mctsw560", "mctsw760", "mctsw1060", "mctsw570", "mctsw770", "mcts770", "mctsw1070", "mcts1070", "mctsw1080", "mcts1080", "mcxpanel", "mcdge1000" };
             MinimumEssentialsFrameworkVersion = "2.0.0";
 
             factories = new Dictionary<string, Func<uint, CrestronControlSystem, string, BasicTriListWithSmartObject>>
@@ -765,6 +765,8 @@ namespace PepperDash.Essentials.Touchpanel
                 {"ts770", (id, controlSystem, projectName) => new Ts770(id, controlSystem)},
                 {"tsw1070", (id, controlSystem, projectName) => new Tsw1070(id, controlSystem)},
                 {"ts1070", (id, controlSystem, projectName) => new Ts1070(id, controlSystem)},
+                {"tsw1080", (id, controlSystem, projectName) => new Tsw1080(id, controlSystem)},
+                {"ts1080", (id, controlSystem, projectName) => new Ts1080(id, controlSystem)},
                 {"dge1000", (id, controlSystem, projectName) => new Dge1000(id, controlSystem)}
             };
         }

--- a/src/PepperDash.Essentials/PepperDash.Essentials.csproj
+++ b/src/PepperDash.Essentials/PepperDash.Essentials.csproj
@@ -48,7 +48,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.21.90" />
+    <PackageReference Include="Crestron.SimplSharp.SDK.Program" Version="2.21.274" />
     <PackageReference Include="System.IO.Compression" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds Mobile Control touchpanel support for the TS-1080 and TSW-1080 panels.

- Registers new type names `mctsw1080` and `mcts1080`.
- Maps them to the `Tsw1080` and `Ts1080` hardware classes in the touchpanel controller factory.

## Why the SDK bump is required

The `Tsw1080` and `Ts1080` device classes were introduced in the Crestron SimplSharp SDK at version **2.21.274**. They are **not** present in the previously referenced **2.21.90**. Adding the 1080 panel types therefore requires bumping the SDK package references — the new support cannot compile against the older SDK.

All SDK packages are moved in lockstep across every project so the referenced SDK version stays consistent:

- `Crestron.SimplSharp.SDK.Library` 2.21.90 -> 2.21.274
- `Crestron.SimplSharp.SDK.ProgramLibrary` 2.21.90 -> 2.21.274
- `Crestron.SimplSharp.SDK.Program` 2.21.90 -> 2.21.274

## Version impact

Minor release (new feature, backward compatible). Existing consumers gain the new panel types; no public API is removed or changed.

## Validation

- Full 4-series solution builds cleanly (0 errors).
- Loaded on a 4-series appliance: the program boots and a panel configured as `mctsw1080` is recognized and constructed at runtime with no type-load errors.
