### PR TITLE
feat: add ICommunicationMonitor support to MobileControlTouchpanelController

### DIFF
--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -25,10 +25,15 @@ namespace PepperDash.Essentials.Touchpanel
     /// Mobile Control touchpanel controller that provides app control, Zoom integration, 
     /// and mobile control functionality for Crestron touchpanels.
     /// </summary>
-    public class MobileControlTouchpanelController : TouchpanelBase, IHasFeedback, ITswAppControl, ITswZoomControl, IDeviceInfoProvider, IMobileControlCrestronTouchpanelController, ITheme
+    public class MobileControlTouchpanelController : TouchpanelBase, IHasFeedback, ITswAppControl, ITswZoomControl, IDeviceInfoProvider, IMobileControlCrestronTouchpanelController, ITheme, ICommunicationMonitor
     {
         private readonly MobileControlTouchpanelProperties localConfig;
         private IMobileControlRoomMessenger _bridge;
+
+        /// <summary>
+        /// Gets the CommunicationMonitor tracking the panel's online/offline state
+        /// </summary>
+        public StatusMonitorBase CommunicationMonitor { get; private set; }
 
         private string _appUrl;
 
@@ -127,6 +132,11 @@ namespace PepperDash.Essentials.Touchpanel
         public MobileControlTouchpanelController(string key, string name, BasicTriListWithSmartObject panel, MobileControlTouchpanelProperties config) : base(key, name, panel, config)
         {
             localConfig = config;
+
+            if (panel != null)
+            {
+                CommunicationMonitor = new CrestronGenericBaseCommunicationMonitor(this, panel, 120000, 300000);
+            }
 
             AddPostActivationAction(SubscribeForMobileControlUpdates);
 
@@ -366,6 +376,8 @@ namespace PepperDash.Essentials.Touchpanel
         /// </summary>
         public override bool CustomActivate()
         {
+            CommunicationMonitor?.Start();
+
             var appMessenger = new ITswAppControlMessenger($"appControlMessenger-{Key}", $"/device/{Key}", this);
 
             var zoomMessenger = new ITswZoomControlMessenger($"zoomControlMessenger-{Key}", $"/device/{Key}", this);
@@ -391,6 +403,17 @@ namespace PepperDash.Essentials.Touchpanel
             mc.AddDeviceMessenger(themeMessenger);
 
             return base.CustomActivate();
+        }
+
+        /// <summary>
+        /// Stops the CommunicationMonitor on deactivation.
+        /// </summary>
+        /// <returns>True if deactivation was successful; otherwise, false.</returns>
+        public override bool Deactivate()
+        {
+            CommunicationMonitor?.Stop();
+
+            return base.Deactivate();
         }
 
         /// <summary>

--- a/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
+++ b/src/PepperDash.Essentials.MobileControl/Touchpanel/MobileControlTouchpanelController.cs
@@ -35,6 +35,18 @@ namespace PepperDash.Essentials.Touchpanel
         /// </summary>
         public StatusMonitorBase CommunicationMonitor { get; private set; }
 
+        private sealed class NullCommunicationMonitor : StatusMonitorBase
+        {
+            public NullCommunicationMonitor(IKeyed parent) : base(parent, 120000, 300000)
+            {
+                Status = MonitorStatus.InError;
+                Message = "Panel is not initialized";
+            }
+
+            public override void Start() { }
+            public override void Stop() { }
+        }
+
         private string _appUrl;
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds `ICommunicationMonitor` support to `MobileControlTouchpanelController` so Mobile Control touchpanels (TSW/XPanel/Crestron App instances) can report online/offline health status to the Mobile Control "Tech Controls: Health" page, the same way other `ICommunicationMonitor` devices already do.

Previously, `MobileControlTouchpanelController` did not implement `ICommunicationMonitor`, so `MobileControlSystemController.SetupDefaultDeviceMessengers()` silently skipped creating a health messenger for it -- touchpanels had no way to surface online/offline state to the frontend, regardless of config.

## Changes

- `MobileControlTouchpanelController` now implements `ICommunicationMonitor`.
- New `CommunicationMonitor` property (`StatusMonitorBase`), backed by `CrestronGenericBaseCommunicationMonitor` wrapping the controller's own `BasicTriListWithSmartObject` panel -- the same monitor class already used by `CrestronGenericBaseDevice`, reusing the panel's existing `OnlineStatusChange` event.
- `CustomActivate()` starts the monitor; new `Deactivate()` override stops it.

## Testing

Verified end-to-end on a bench RMC4 processor:
- Deployed a locally-built Essentials package with this change.
- Connected an XPanel instance (IP ID 11) to the touchpanel device.
- Confirmed the corresponding health item on the Tech Controls: Health page went **online** immediately when the XPanel connected, and transitioned to **offline** ~60 seconds after disconnecting it -- matching the expected communication-monitor warning timeout behavior.

## Notes

- No breaking changes; purely additive.
- No config schema changes -- existing touchpanel device configs work unchanged; a device simply needs its key added to the consuming room/frontend's health-device list to be surfaced (unrelated project-side config, not part of this PR).
