### PR TITLE
Feature/screen lift controller updates

### DIFF
--- a/src/PepperDash.Essentials.Core/Routing/RouteDescriptor.cs
+++ b/src/PepperDash.Essentials.Core/Routing/RouteDescriptor.cs
@@ -92,19 +92,48 @@ namespace PepperDash.Essentials.Core
             {
                 Debug.LogVerbose("ExecuteRoutes: {0}", route.ToString());
 
+                var inputSelector = route.InputPort?.Selector ?? route.InputPort?.Key;
+
                 if (route.SwitchingDevice is IRoutingSinkWithSwitching sink)
                 {
-                    sink.ExecuteSwitch(route.InputPort.Selector);
+                    try
+                    {
+                        sink.ExecuteSwitch(inputSelector);
+                    }
+                    catch (Exception)
+                    {
+                        // Some devices expose null/unsupported selectors but can switch by port key.
+                        if (route.InputPort?.Key != null && !Equals(inputSelector, route.InputPort.Key))
+                        {
+                            sink.ExecuteSwitch(route.InputPort.Key);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+
                     continue;
                 }
 
                 if (route.SwitchingDevice is IRouting switchingDevice)
                 {
-                    switchingDevice.ExecuteSwitch(route.InputPort.Selector, route.OutputPort.Selector, SignalType);
+                    // Some sink-style routing devices can produce route descriptors without an explicit output port.
+                    if (route.OutputPort == null)
+                    {
+                        switchingDevice.ExecuteSwitch(inputSelector, null, SignalType);
+                        continue;
+                    }
 
-                    route.OutputPort.InUseTracker.AddUser(Destination, "destination-" + SignalType);
+                    var outputSelector = route.OutputPort.Selector ?? route.OutputPort.Key;
+                    switchingDevice.ExecuteSwitch(inputSelector, outputSelector, SignalType);
 
-                    Debug.LogVerbose("Output port {0} routing. Count={1}", route.OutputPort.Key, route.OutputPort.InUseTracker.InUseCountFeedback.UShortValue);
+                    route.OutputPort.InUseTracker?.AddUser(Destination, "destination-" + SignalType);
+
+                    if (route.OutputPort.InUseTracker != null)
+                    {
+                        Debug.LogVerbose("Output port {0} routing. Count={1}", route.OutputPort.Key, route.OutputPort.InUseTracker.InUseCountFeedback.UShortValue);
+                    }
                 }
             }
         }
@@ -125,7 +154,7 @@ namespace PepperDash.Essentials.Core
                     {
                         try
                         {
-                            switchingDevice.ExecuteSwitch(null, route.OutputPort.Selector, SignalType);
+                            switchingDevice.ExecuteSwitch(null, route.OutputPort?.Selector, SignalType);
                         }
                         catch (Exception e)
                         {


### PR DESCRIPTION
This pull request improves the robustness and flexibility of routing execution in the `RouteDescriptor` class. The main changes introduce better handling of input and output selectors, add error handling for device-specific quirks, and ensure safer usage tracking. These updates help prevent exceptions and support devices with incomplete or non-standard selector information.

**Routing execution improvements:**

* Updated `ExecuteRoutes()` to use either the `Selector` or `Key` from input/output ports, depending on availability, improving compatibility with devices that may not provide a selector.
* Added error handling around `sink.ExecuteSwitch` to fall back to using the port key if the selector is null or unsupported, preventing failures with certain devices.
* Enhanced handling for routes without an explicit output port by allowing `null` as an output selector when calling `switchingDevice.ExecuteSwitch`.
* Made usage tracking (`InUseTracker.AddUser`) safer by making it null-safe, avoiding potential null reference exceptions.

**Release route improvements:**

* Updated `ReleaseRoutes()` to use a null-conditional operator when accessing the output port selector, preventing exceptions if the output port is missing.