### PR TITLE
fix: null-safe CodecInfo access in AudioCodecBaseMessenger

### DIFF
--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/AudioCodecBaseMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/AudioCodecBaseMessenger.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using PepperDash.Essentials.Devices.Common.AudioCodec;
+using PepperDash.Essentials.Devices.Common.Codec;
+
+namespace PepperDash.Essentials.AppServer.Messengers
+{
+    /// <summary>
+    /// Provides a messaging bridge for an AudioCodecBase device
+    /// </summary>
+    public class AudioCodecBaseMessenger : MessengerBase
+    {
+        /// <summary>
+        /// Device being bridged
+        /// </summary>
+        public AudioCodecBase Codec { get; private set; }
+
+        /// <summary>
+        /// Constuctor
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="codec"></param>
+        /// <param name="messagePath"></param>
+        public AudioCodecBaseMessenger(string key, AudioCodecBase codec, string messagePath)
+            : base(key, messagePath, codec)
+        {
+            Codec = codec ?? throw new ArgumentNullException("codec");
+            codec.CallStatusChange += Codec_CallStatusChange;
+        }
+
+        /// <inheritdoc />
+        protected override void RegisterActions()
+
+        {
+            base.RegisterActions();
+
+            AddAction("/fullStatus", (id, content) => SendAtcFullMessageObject(id));
+
+            AddAction("/audioDialerStatus", (id, content) => SendAtcFullMessageObject(id));
+
+            AddAction("/dial", (id, content) =>
+            {
+                var msg = content.ToObject<MobileControlSimpleContent<string>>();
+
+                Codec.Dial(msg.Value);
+            });
+
+            AddAction("/endCallById", (id, content) =>
+            {
+                var msg = content.ToObject<MobileControlSimpleContent<string>>();
+
+                var call = GetCallWithId(msg.Value);
+                if (call != null)
+                    Codec.EndCall(call);
+            });
+
+            AddAction("/endAllCalls", (id, content) => Codec.EndAllCalls());
+            AddAction("/dtmf", (id, content) =>
+            {
+                var msg = content.ToObject<MobileControlSimpleContent<string>>();
+
+                Codec.SendDtmf(msg.Value);
+            });
+
+            AddAction("/rejectById", (id, content) =>
+            {
+                var msg = content.ToObject<MobileControlSimpleContent<string>>();
+
+                var call = GetCallWithId(msg.Value);
+
+                if (call != null)
+                    Codec.RejectCall(call);
+            });
+
+            AddAction("/acceptById", (id, content) =>
+            {
+                var msg = content.ToObject<MobileControlSimpleContent<string>>();
+                var call = GetCallWithId(msg.Value);
+                if (call != null)
+                    Codec.AcceptCall(call);
+            });
+        }
+
+        /// <summary>
+        /// Helper to grab a call with string ID
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private CodecActiveCallItem GetCallWithId(string id)
+        {
+            return Codec.ActiveCalls.FirstOrDefault(c => c.Id == id);
+        }
+
+        private void Codec_CallStatusChange(object sender, CodecCallStatusItemChangeEventArgs e)
+        {
+            SendAtcFullMessageObject();
+        }
+
+        /// <summary>
+        /// Helper method to build call status for vtc
+        /// </summary>
+        /// <returns></returns>
+        private void SendAtcFullMessageObject(string id = null)
+        {
+            var info = Codec.CodecInfo;
+
+            PostStatusMessage(JToken.FromObject(new
+            {
+                isInCall = Codec.IsInCall,
+                calls = Codec.ActiveCalls,
+                info = new
+                {
+                    phoneNumber = info?.PhoneNumber
+                }
+            }), id
+            );
+        }
+    }
+}


### PR DESCRIPTION
Codec.CodecInfo is null during DSP startup/reconnect. Guard with null- conditional to prevent NullReferenceException from propagating up through the CallStatusChange event chain.