### PR TITLE
fix(mobile-control): update version and improve response caching for …

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.36.6-local</Version>
+    <Version>2.42.1-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Authors>PepperDash Technology</Authors>
     <Company>PepperDash Technology</Company>

--- a/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
+++ b/src/PepperDash.Essentials.MobileControl/WebSocketServer/MobileControlWebsocketServer.cs
@@ -1162,6 +1162,11 @@ namespace PepperDash.Essentials.WebSocketServer
             var qp = req.QueryString;
             var token = qp["token"];
 
+            // Each join mints a single-use clientId; the panel webview must never replay a cached
+            // response, or it reconnects forever with an already-consumed id (1008 loop).
+            res.Headers.Add("Cache-Control", "no-store");
+            res.Headers.Add("Pragma", "no-cache");
+
             this.LogVerbose("Join Room Request with token: {token}", token);
 
             byte[] body;
@@ -1263,6 +1268,8 @@ namespace PepperDash.Essentials.WebSocketServer
         {
             res.StatusCode = 200;
             res.ContentType = "application/json";
+            res.Headers.Add("Cache-Control", "no-store");
+            res.Headers.Add("Pragma", "no-cache");
             var version = new Version() { ServerVersion = _parent.GetConfigWithPluginVersion().RuntimeInfo.PluginVersion };
             var message = JsonConvert.SerializeObject(version);
             this.LogVerbose("{message}", message);


### PR DESCRIPTION
## Summary

Fixes a reconnect loop in the Mobile Control direct server caused by HTTP
response caching on the `/ui/joinroom` (and `/ui/version`) endpoints.

## Problem

The `HandleJoinRequest` handler mints a single-use `clientId` on every call
and expects the client to use it exactly once to complete the WebSocket
handshake. Some client webviews (e.g. embedded Chromium/CEF-based UIs)
HTTP-cache the join response by default, since no cache-control headers were
set on it. When the webview replays a cached response instead of issuing a
fresh request, it receives an already-consumed `clientId`, and the
subsequent WebSocket join is rejected as unregistered/expired. The client
then retries on a fixed interval, replays the same stale response again,
and loops indefinitely instead of recovering.

## Fix

Set `Cache-Control: no-store` and `Pragma: no-cache` on the join and
version endpoint responses so clients always receive a fresh `clientId`
and are never able to silently replay a stale, already-consumed one.

## Changes

- `MobileControlWebsocketServer.cs`
  - `HandleJoinRequest`: added `Cache-Control: no-store` / `Pragma:
    no-cache` headers to the response.
  - Version endpoint handler: added the same headers for consistency.

## Testing

- Rebuilt the solution locally (0 errors) and verified the response headers
  are present on both endpoints.
- Deployed to a production processor and confirmed a client using a caching
  webview no longer reconnects in a loop after receiving a join response.

## Risk / Impact

Low risk — purely additive response headers on two endpoints; no change to
request/response payloads, authentication, or existing client behavior for
well-behaved (non-caching) clients.