### PR TITLE
feat(messenger): implement client-specific event messaging for tech p…

### DIFF
--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/ITechPasswordMessenger.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/ITechPasswordMessenger.cs
@@ -11,6 +11,15 @@ namespace PepperDash.Essentials.AppServer.Messengers
     {
         private readonly ITechPassword _room;
 
+        // Captures the id of the client whose /validateTechPassword request is in flight, so the
+        // TechPasswordValidateResult handler below can reply to only that client instead of
+        // broadcasting to every connected panel. Relies on ValidateTechPassword firing the event
+        // synchronously (true for all known ITechPassword implementations); if a future
+        // implementation validates asynchronously, _pendingClientId will already be null when the
+        // handler runs and this degrades to the previous broadcast behavior.
+        private readonly object _pendingLock = new object();
+        private string _pendingClientId;
+
         public ITechPasswordMessenger(string key, string messagePath, ITechPassword room)
             : base(key, messagePath, room as IKeyName)
         {
@@ -28,7 +37,12 @@ namespace PepperDash.Essentials.AppServer.Messengers
             {
                 var password = content.Value<string>("password");
 
-                _room.ValidateTechPassword(password);
+                lock (_pendingLock)
+                {
+                    _pendingClientId = id;
+                    _room.ValidateTechPassword(password);
+                    _pendingClientId = null;
+                }
             });
 
             AddAction("/setTechPassword", (id, content) =>
@@ -45,12 +59,18 @@ namespace PepperDash.Essentials.AppServer.Messengers
 
             _room.TechPasswordValidateResult += (sender, args) =>
             {
+                string clientId;
+                lock (_pendingLock)
+                {
+                    clientId = _pendingClientId;
+                }
+
                 var evt = new ITechPasswordEventMessage
                 {
                     IsValid = args.IsValid
                 };
 
-                PostEventMessage(evt, "passwordValidationResult");
+                PostEventMessage(evt, "passwordValidationResult", clientId);
             };
         }
 

--- a/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
+++ b/src/PepperDash.Essentials.MobileControl.Messengers/Messengers/MessengerBase.cs
@@ -405,5 +405,28 @@ namespace PepperDash.Essentials.AppServer.Messengers
             });
         }
 
+        /// <summary>
+        /// Helper for posting an event message to a single client. A null/empty clientId falls back
+        /// to the existing broadcast behavior of the other PostEventMessage overloads.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="eventType"></param>
+        /// <param name="clientId">Client id that will direct the message back to only that client</param>
+        protected void PostEventMessage(DeviceEventMessageBase message, string eventType, string clientId)
+        {
+            message.Key = _device.Key;
+
+            message.Name = _device.Name;
+
+            message.EventType = eventType;
+
+            AppServerController?.SendMessageObject(new MobileControlMessage
+            {
+                Type = $"/event{MessagePath}/{eventType}",
+                ClientId = clientId,
+                Content = JToken.FromObject(message),
+            });
+        }
+
     }
 }


### PR DESCRIPTION
## Summary

Fixes a security issue where the tech-password (tech settings PIN) validation result was broadcast to **all** connected Mobile Control clients instead of only the client that submitted the password. In practice, one panel entering the correct tech password would also unlock the tech settings screen on every other connected panel.

## Root cause

`ITechPasswordMessenger` replies to a `/validateTechPassword` request via `PostEventMessage(event, eventType)`, and every existing `PostEventMessage` overload in `MessengerBase` omits `ClientId` on the outgoing `MobileControlMessage`. With no `ClientId`, the Mobile Control server delivers the message to all subscribed clients, not just the requester.

The validation result itself arrives through the `ITechPassword.TechPasswordValidateResult` event, which is decoupled from the originating request and carries no client identifier — so there was no existing way to correlate the result back to the client that asked for it.

## Fix

Two small, additive, backward-compatible changes — no public interface changes:

1. **`MessengerBase`** — added a new `PostEventMessage(DeviceEventMessageBase message, string eventType, string clientId)` overload that sets `ClientId` on the outgoing message so it is routed to a single client. A null/empty `clientId` is not passed by any new caller in this change, so existing broadcast call sites are unaffected.

2. **`ITechPasswordMessenger`** — captures the requesting client's id in a field guarded by a lock immediately before calling `ITechPassword.ValidateTechPassword(password)`, then reads it back inside the `TechPasswordValidateResult` handler to post the result to that client only, via the new overload.

This relies on `ValidateTechPassword` invoking `TechPasswordValidateResult` **synchronously**, which is true for all current `ITechPassword` implementations reviewed. If a future implementation validates asynchronously, the captured client id will already be cleared by the time the event fires, and behavior gracefully falls back to the previous broadcast — no regression, just no isolation for that specific implementation.

## Compatibility

- `ITechPassword` interface: **unchanged**
- `TechPasswordEventArgs`: **unchanged**
- No changes required in any room/device implementing `ITechPassword`
- No frontend/client changes required — the event type and payload shape are identical; only the delivery targeting changed

## Testing

- Solution builds clean (`dotnet build -c Release`, 0 errors)
- Manual verification with two simultaneous Mobile Control client connections: entering the correct tech password on one client unlocks only that client's tech settings screen; the second client remains on the PIN gate. Incorrect-password behavior on each client is unaffected.

## Alternatives considered

- Threading a client id through the `ITechPassword` interface and `TechPasswordEventArgs` directly — more robust for hypothetical async implementations, but a breaking interface change affecting every implementor. Deferred unless an async implementation is actually needed.
- A pending-request correlation queue — avoids relying on synchronous firing, but adds complexity (timeout/eviction handling) with no current implementation that needs it.