### PR TITLE
fix(core-ssh): stop reconnect loop during stopprog

### DIFF
--- a/src/PepperDash.Core/Comm/GenericSshClient.cs
+++ b/src/PepperDash.Core/Comm/GenericSshClient.cs
@@ -151,6 +151,8 @@ namespace PepperDash.Core
         // Thread-safety lock for state changes
         private readonly object _stateLock = new object();
 
+        private volatile bool _isProgramStopping;
+
         private bool disconnectLogged = false;
 
         /// <summary>
@@ -207,11 +209,9 @@ namespace PepperDash.Core
         {
             if (programEventType == eProgramStatusEventType.Stopping)
             {
-                if (client != null)
-                {
-                    this.LogDebug("Program stopping. Closing connection");
-                    Disconnect();
-                }
+                _isProgramStopping = true;
+                this.LogDebug("Program stopping. Closing connection");
+                Disconnect();
             }
         }
 
@@ -229,6 +229,13 @@ namespace PepperDash.Core
             }
 
             ConnectEnabled = true;
+
+            if (_isProgramStopping)
+            {
+                this.LogDebug("Skipping connect because program is stopping");
+                ConnectEnabled = false;
+                return;
+            }
 
             try
             {
@@ -308,7 +315,7 @@ namespace PepperDash.Core
 
                         disconnectLogged = true;
                         KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                        if (AutoReconnect)
+                        if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                         {
                             this.LogDebug("Checking autoreconnect: {autoReconnect}, {autoReconnectInterval}ms", AutoReconnect, AutoReconnectIntervalMs);
                             StartReconnectTimer();
@@ -320,7 +327,7 @@ namespace PepperDash.Core
 
                         disconnectLogged = true;
                         KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                        if (AutoReconnect)
+                        if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                         {
                             this.LogDebug("Checking autoreconnect: {0}, {1}ms", AutoReconnect, AutoReconnectIntervalMs);
                             StartReconnectTimer();
@@ -332,7 +339,7 @@ namespace PepperDash.Core
                         this.LogVerbose(e, "Exception details: ");
                         disconnectLogged = true;
                         KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                        if (AutoReconnect)
+                        if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                         {
                             this.LogDebug("Checking autoreconnect: {0}, {1}ms", AutoReconnect, AutoReconnectIntervalMs);
                             StartReconnectTimer();
@@ -467,7 +474,7 @@ namespace PepperDash.Core
                 {
                     connectLock.Release();
                 }
-                if (AutoReconnect && ConnectEnabled)
+                if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                 {
                     this.LogDebug("Checking autoreconnect: {0}, {1}ms", AutoReconnect, AutoReconnectIntervalMs);
                     StartReconnectTimer();
@@ -510,7 +517,10 @@ namespace PepperDash.Core
                 this.LogError("ObjectDisposedException sending '{message}'. Restarting connection...", text.Trim());
 
                 KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                StartReconnectTimer();
+                if (ConnectEnabled && !_isProgramStopping)
+                {
+                    StartReconnectTimer();
+                }
             }
             catch (Exception ex)
             {
@@ -543,7 +553,10 @@ namespace PepperDash.Core
                 this.LogException(ex, "ObjectDisposedException sending {message}", ComTextHelper.GetEscapedText(bytes));
 
                 KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                StartReconnectTimer();
+                if (ConnectEnabled && !_isProgramStopping)
+                {
+                    StartReconnectTimer();
+                }
             }
             catch (Exception ex)
             {

--- a/src/PepperDash.Core/Comm/GenericSshClient.cs
+++ b/src/PepperDash.Core/Comm/GenericSshClient.cs
@@ -228,14 +228,13 @@ namespace PepperDash.Core
                 return;
             }
 
-            ConnectEnabled = true;
-
             if (_isProgramStopping)
             {
                 this.LogDebug("Skipping connect because program is stopping");
-                ConnectEnabled = false;
                 return;
             }
+
+            ConnectEnabled = true;
 
             try
             {
@@ -517,7 +516,7 @@ namespace PepperDash.Core
                 this.LogError("ObjectDisposedException sending '{message}'. Restarting connection...", text.Trim());
 
                 KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                if (ConnectEnabled && !_isProgramStopping)
+                if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                 {
                     StartReconnectTimer();
                 }
@@ -553,7 +552,7 @@ namespace PepperDash.Core
                 this.LogException(ex, "ObjectDisposedException sending {message}", ComTextHelper.GetEscapedText(bytes));
 
                 KillClient(SocketStatus.SOCKET_STATUS_CONNECT_FAILED);
-                if (ConnectEnabled && !_isProgramStopping)
+                if (AutoReconnect && ConnectEnabled && !_isProgramStopping)
                 {
                     StartReconnectTimer();
                 }


### PR DESCRIPTION
This PR improves stopprog shutdown behavior by preventing SSH auto-reconnect activity from continuing during program shutdown.