### PR TITLE
fix(logging): cap rolling debug log file size to prevent disk exhaustion

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.36.6-local</Version>
+    <Version>2.39.0-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Authors>PepperDash Technology</Authors>
     <Company>PepperDash Technology</Company>

--- a/src/PepperDash.Core/Logging/Debug.cs
+++ b/src/PepperDash.Core/Logging/Debug.cs
@@ -26,6 +26,27 @@ namespace PepperDash.Core
         private static readonly string WebSocketLevelStoreKey = "WebsocketDebugLevel";
         private static readonly string ErrorLogLevelStoreKey = "ErrorLogDebugLevel";
         private static readonly string FileLevelStoreKey = "FileDebugLevel";
+        private static readonly string FileSizeLimitStoreKey = "FileLogSizeLimitBytes";
+        private static readonly string FileRetainedCountStoreKey = "FileLogRetainedCount";
+
+        // Conservative defaults so the daily rolling log set cannot exhaust
+        // constrained storage (e.g. RMC4 with \user on a small removable drive).
+        private const long DefaultApplianceFileSizeLimitBytes = 4L * 1024 * 1024;
+        private const long DefaultServerFileSizeLimitBytes = 16L * 1024 * 1024;
+        private const int DefaultApplianceRetainedFileCount = 7;
+        private const int DefaultServerRetainedFileCount = 14;
+
+        /// <summary>
+        /// Per-file size (bytes) that triggers a roll of the debug log file. Read at
+        /// startup from CrestronDataStore; override with the applogfilecap console command.
+        /// </summary>
+        public static long LogFileSizeLimitBytes { get; private set; }
+
+        /// <summary>
+        /// Number of rolled debug log files retained on disk. Combined with
+        /// LogFileSizeLimitBytes this bounds total debug-log disk usage.
+        /// </summary>
+        public static int LogRetainedFileCountLimit { get; private set; }
 
         private static readonly Dictionary<uint, LogEventLevel> _logLevels = new Dictionary<uint, LogEventLevel>()
         {
@@ -157,6 +178,12 @@ namespace PepperDash.Core
                 ? "{@t:fff}ms [{@l:u4}]{#if Key is not null}[{Key}]{#end} {@m}{#if @x is not null}\r\n{@x}{#end}"
                 : "[{@t:yyyy-MM-dd HH:mm:ss.fff}][{@l:u4}][{App}]{#if Key is not null}[{Key}]{#end} {@m}{#if @x is not null}\r\n{@x}{#end}";
 
+            var isAppliance = CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance;
+            LogFileSizeLimitBytes = GetStoredIntValue(FileSizeLimitStoreKey,
+                (int)(isAppliance ? DefaultApplianceFileSizeLimitBytes : DefaultServerFileSizeLimitBytes));
+            LogRetainedFileCountLimit = GetStoredIntValue(FileRetainedCountStoreKey,
+                isAppliance ? DefaultApplianceRetainedFileCount : DefaultServerRetainedFileCount);
+
             _defaultLoggerConfiguration = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .Enrich.FromLogContext()
@@ -166,8 +193,10 @@ namespace PepperDash.Core
                 .WriteTo.Sink(new DebugErrorLogSink(new ExpressionTemplate(errorLogTemplate)), levelSwitch: _errorLogLevelSwitch)
                 .WriteTo.File(new RenderedCompactJsonFormatter(), logFilePath,
                     rollingInterval: RollingInterval.Day,
+                    fileSizeLimitBytes: LogFileSizeLimitBytes,
+                    rollOnFileSizeLimit: true,
                     restrictedToMinimumLevel: LogEventLevel.Debug,
-                    retainedFileCountLimit: CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance ? 7 : 14,
+                    retainedFileCountLimit: LogRetainedFileCountLimit,
                     levelSwitch: _fileLogLevelSwitch
                 );
 
@@ -223,6 +252,9 @@ namespace PepperDash.Core
                     ConsoleAccessLevelEnum.AccessOperator);
                 CrestronConsole.AddNewConsoleCommand(SetDebugFilterFromConsole, "appdebugfilter",
                     "appdebugfilter [params]", ConsoleAccessLevelEnum.AccessOperator);
+                CrestronConsole.AddNewConsoleCommand(SetLogFileCapFromConsole, "applogfilecap",
+                    "applogfilecap:P [sizeBytes] [retainedCount]: Caps rolling debug log size/count (next restart)",
+                    ConsoleAccessLevelEnum.AccessOperator);
             }
 
             CrestronEnvironment.ProgramStatusEventHandler += CrestronEnvironment_ProgramStatusEventHandler;
@@ -295,6 +327,75 @@ namespace PepperDash.Core
                 CrestronConsole.PrintLine($"Exception retrieving log level for {levelStoreKey}: {ex.Message}");
                 return LogEventLevel.Information;
             }
+        }
+
+        private static int GetStoredIntValue(string storeKey, int defaultValue)
+        {
+            try
+            {
+                var result = CrestronDataStoreStatic.GetLocalIntValue(storeKey, out int value);
+
+                if (result != CrestronDataStore.CDS_ERROR.CDS_SUCCESS)
+                {
+                    CrestronDataStoreStatic.SetLocalIntValue(storeKey, defaultValue);
+                    return defaultValue;
+                }
+
+                return value <= 0 ? defaultValue : value;
+            }
+            catch (Exception ex)
+            {
+                CrestronConsole.PrintLine($"Exception retrieving stored value for {storeKey}: {ex.Message}");
+                return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Console handler to cap the rolling debug log file size and retained count.
+        /// Values persist in CrestronDataStore and take effect on the next program restart.
+        /// </summary>
+        public static void SetLogFileCapFromConsole(string command)
+        {
+            var trimmed = command?.Trim() ?? string.Empty;
+
+            if (trimmed == "?" || string.IsNullOrEmpty(trimmed))
+            {
+                CrestronConsole.ConsoleCommandResponse(
+                    "Caps the rolling debug log file (takes effect on next program restart):\r\n" +
+                    "Usage: applogfilecap:P [sizeBytes] [retainedCount]\r\n" +
+                    "  sizeBytes: per-file size that triggers a roll (min 65536)\r\n" +
+                    "  retainedCount: number of rolled files to keep (min 1)\r\n" +
+                    $"Current: sizeBytes = {LogFileSizeLimitBytes}, retainedCount = {LogRetainedFileCountLimit}\r\n" +
+                    $"Approx on-disk ceiling = {LogFileSizeLimitBytes * LogRetainedFileCountLimit} bytes\r\n");
+                return;
+            }
+
+            var tokens = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (!long.TryParse(tokens[0], out var sizeBytes) || sizeBytes < 65536)
+            {
+                CrestronConsole.ConsoleCommandResponse("Invalid sizeBytes. Must be an integer >= 65536.\r\n");
+                return;
+            }
+
+            sizeBytes = Math.Min(sizeBytes, int.MaxValue);
+
+            var retained = LogRetainedFileCountLimit;
+            if (tokens.Length > 1 && (!int.TryParse(tokens[1], out retained) || retained < 1))
+            {
+                CrestronConsole.ConsoleCommandResponse("Invalid retainedCount. Must be an integer >= 1.\r\n");
+                return;
+            }
+
+            var sizeErr = CrestronDataStoreStatic.SetLocalIntValue(FileSizeLimitStoreKey, (int)sizeBytes);
+            var countErr = CrestronDataStoreStatic.SetLocalIntValue(FileRetainedCountStoreKey, retained);
+
+            LogFileSizeLimitBytes = sizeBytes;
+            LogRetainedFileCountLimit = retained;
+
+            CrestronConsole.ConsoleCommandResponse(
+                $"File log cap stored: sizeBytes = {sizeBytes}, retainedCount = {retained} (store result: {sizeErr}/{countErr}).\r\n" +
+                "Takes effect on next program restart.\r\n");
         }
 
         private static void GetVersion()

--- a/src/PepperDash.Core/Logging/Debug.cs
+++ b/src/PepperDash.Core/Logging/Debug.cs
@@ -257,7 +257,7 @@ namespace PepperDash.Core
                 CrestronConsole.AddNewConsoleCommand(SetDebugFilterFromConsole, "appdebugfilter",
                     "appdebugfilter [params]", ConsoleAccessLevelEnum.AccessOperator);
                 CrestronConsole.AddNewConsoleCommand(SetLogFileCapFromConsole, "applogfilecap",
-                    "applogfilecap:P [sizeBytes] [retainedCount]: Caps rolling debug log size/count (next restart)",
+                    "applogfilecap:P [sizeBytes] [retainedCount]: Cap rolling log size/count",
                     ConsoleAccessLevelEnum.AccessOperator);
             }
 

--- a/src/PepperDash.Core/Logging/Debug.cs
+++ b/src/PepperDash.Core/Logging/Debug.cs
@@ -36,6 +36,10 @@ namespace PepperDash.Core
         private const int DefaultApplianceRetainedFileCount = 7;
         private const int DefaultServerRetainedFileCount = 14;
 
+        // Enforced floors so a stale/corrupt stored value can't cause pathological rolling.
+        private const int MinFileSizeLimitBytes = 65536;
+        private const int MinRetainedFileCount = 1;
+
         /// <summary>
         /// Per-file size (bytes) that triggers a roll of the debug log file. Read at
         /// startup from CrestronDataStore; override with the applogfilecap console command.
@@ -179,10 +183,10 @@ namespace PepperDash.Core
                 : "[{@t:yyyy-MM-dd HH:mm:ss.fff}][{@l:u4}][{App}]{#if Key is not null}[{Key}]{#end} {@m}{#if @x is not null}\r\n{@x}{#end}";
 
             var isAppliance = CrestronEnvironment.DevicePlatform == eDevicePlatform.Appliance;
-            LogFileSizeLimitBytes = GetStoredIntValue(FileSizeLimitStoreKey,
-                (int)(isAppliance ? DefaultApplianceFileSizeLimitBytes : DefaultServerFileSizeLimitBytes));
-            LogRetainedFileCountLimit = GetStoredIntValue(FileRetainedCountStoreKey,
-                isAppliance ? DefaultApplianceRetainedFileCount : DefaultServerRetainedFileCount);
+            LogFileSizeLimitBytes = Math.Max(MinFileSizeLimitBytes, GetStoredIntValue(FileSizeLimitStoreKey,
+                (int)(isAppliance ? DefaultApplianceFileSizeLimitBytes : DefaultServerFileSizeLimitBytes)));
+            LogRetainedFileCountLimit = Math.Max(MinRetainedFileCount, GetStoredIntValue(FileRetainedCountStoreKey,
+                isAppliance ? DefaultApplianceRetainedFileCount : DefaultServerRetainedFileCount));
 
             _defaultLoggerConfiguration = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
@@ -372,7 +376,13 @@ namespace PepperDash.Core
 
             var tokens = trimmed.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
 
-            if (!long.TryParse(tokens[0], out var sizeBytes) || sizeBytes < 65536)
+            if (tokens.Length > 2)
+            {
+                CrestronConsole.ConsoleCommandResponse("Too many arguments. Usage: applogfilecap [sizeBytes] [retainedCount].\r\n");
+                return;
+            }
+
+            if (!long.TryParse(tokens[0], out var sizeBytes) || sizeBytes < MinFileSizeLimitBytes)
             {
                 CrestronConsole.ConsoleCommandResponse("Invalid sizeBytes. Must be an integer >= 65536.\r\n");
                 return;
@@ -381,7 +391,7 @@ namespace PepperDash.Core
             sizeBytes = Math.Min(sizeBytes, int.MaxValue);
 
             var retained = LogRetainedFileCountLimit;
-            if (tokens.Length > 1 && (!int.TryParse(tokens[1], out retained) || retained < 1))
+            if (tokens.Length > 1 && (!int.TryParse(tokens[1], out retained) || retained < MinRetainedFileCount))
             {
                 CrestronConsole.ConsoleCommandResponse("Invalid retainedCount. Must be an integer >= 1.\r\n");
                 return;


### PR DESCRIPTION
Fixes #1472

## Problem

On constrained storage (e.g. an RMC4 where Crestron relocates `\user` onto a small removable USB drive), the Serilog rolling debug log file could grow without bound. The `.WriteTo.File(...)` sink used `rollingInterval: Day` + `retainedFileCountLimit` but had **no** `fileSizeLimitBytes`, so a single day's `global-log.log` could fill the drive and take the processor down.

## Fix

- Add `fileSizeLimitBytes` + `rollOnFileSizeLimit: true` to the file sink so each rolled file is bounded and rolls on size as well as by day.
- Make both the size cap and the retained-file count **configurable and persisted** in `CrestronDataStore`, with conservative platform defaults:
  - Appliance: 4 MB × 7 files
  - Server: 16 MB × 14 files
- Add the `applogfilecap` console command to view/set the caps at runtime (takes effect on next program restart, since the Serilog file-size limit is fixed at sink construction).

## Compatibility

Backward compatible — defaults preserve the existing daily-rolling behavior while adding an upper bound. No API breakage.

## Note on base version

Authored and **build-verified against tag `v2.39.0`** (0 errors) because Crestron SDK builds after v2.39.0 currently have unrelated issues in our environment. The change itself is version-agnostic (Serilog.Sinks.File 5.0.0 supports these parameters on both lines). It may need a rebase/manual apply onto `main`; happy to adjust the base branch if the maintainers prefer a maintenance line.
